### PR TITLE
Remove unused includes from trace_file.cpp

### DIFF
--- a/common/trace_file.cpp
+++ b/common/trace_file.cpp
@@ -27,14 +27,6 @@
 #include "trace_file.hpp"
 
 #include <assert.h>
-#include <string.h>
-
-#include <zlib.h>
-#include <gzguts.h>
-
-#include "os.hpp"
-
-#include <iostream>
 
 using namespace trace;
 


### PR DESCRIPTION
The code in trace_file.cpp was refactored out to trace_file_zlib.cpp. Remove these unused includes so it could be build without zlib.
