### PR TITLE
gui: let the edit mode work.

### DIFF
--- a/gui/argumentseditor.cpp
+++ b/gui/argumentseditor.cpp
@@ -51,87 +51,45 @@ isVariantStringArray(const QVariant &var)
     return true;
 }
 
-ArgumentsItemEditorFactory::ArgumentsItemEditorFactory()
-    : QItemEditorFactory()
-{
-}
 
-QWidget * ArgumentsItemEditorFactory::createEditor(QMetaType::Type type,
-                                                   QWidget *parent) const
-{
-    switch (type) {
-    case QVariant::Bool: {
-        BooleanComboBox *cb = new BooleanComboBox(parent);
-        cb->setFrame(false);
-        return cb;
-    }
-    case QVariant::UInt: {
-        QSpinBox *sb = new QSpinBox(parent);
-        sb->setFrame(false);
-        sb->setMaximum(INT_MAX);
-        return sb; }
-    case QVariant::Int: {
-        QSpinBox *sb = new QSpinBox(parent);
-        sb->setFrame(false);
-        sb->setMinimum(INT_MIN);
-        sb->setMaximum(INT_MAX);
-        return sb;
-    }
-    case QVariant::ULongLong: {
-        QSpinBox *sb = new QSpinBox(parent);
-        sb->setFrame(false);
-        sb->setMaximum(INT_MAX);
-        return sb; }
-    case QVariant::LongLong: {
-        QSpinBox *sb = new QSpinBox(parent);
-        sb->setFrame(false);
-        sb->setMinimum(INT_MIN);
-        sb->setMaximum(INT_MAX);
-        return sb;
-    }
-    case QVariant::Pixmap:
-        return new QLabel(parent);
-    case QMetaType::Float: {
-        QDoubleSpinBox *sb = new QDoubleSpinBox(parent);
-        sb->setFrame(false);
-        sb->setMinimum(-FLT_MAX);
-        sb->setMaximum(FLT_MAX);
-        sb->setDecimals(8);
-        return sb;
-    }
-    case QVariant::Double: {
-        QDoubleSpinBox *sb = new QDoubleSpinBox(parent);
-        sb->setFrame(false);
-        sb->setMinimum(-DBL_MAX);
-        sb->setMaximum(DBL_MAX);
-        sb->setDecimals(8);
-        return sb;
-    }
-    default:
-        break;
-    }
-    return 0;
-}
 
-QByteArray
-ArgumentsItemEditorFactory::valuePropertyName(QMetaType::Type type) const
+void setArgumentsItemEditorFactory ()
 {
-    switch (type) {
-    case QVariant::Bool:
-        return "currentIndex";
-    case QVariant::UInt:
-    case QVariant::Int:
-    case QVariant::LongLong:
-    case QVariant::ULongLong:
-    case QMetaType::Float:
-    case QVariant::Double:
-        return "value";
-#if 0
-    case QVariant::String:
-#endif
-    default:
-        return "text";
-    }
+    QItemEditorCreatorBase *booleanComboBoxEditorCreator =
+    new QStandardItemEditorCreator<BooleanComboBoxEditorCreator>();
+    QItemEditorCreatorBase *uIntEditorCreator =
+    new QStandardItemEditorCreator<UIntEditorCreator>();
+    QItemEditorCreatorBase *intEditorCreator =
+    new QStandardItemEditorCreator<IntEditorCreator>();
+    QItemEditorCreatorBase *uLongLongEditorCreator =
+    new QStandardItemEditorCreator<ULongLongEditorCreator>();
+    QItemEditorCreatorBase *longLongEditorCreator =
+    new QStandardItemEditorCreator<LongLongEditorCreator>();
+    QItemEditorCreatorBase *pixmapEditorCreator =
+    new QStandardItemEditorCreator<PixmapEditorCreator>();
+    QItemEditorCreatorBase *floatEditorCreator =
+    new QStandardItemEditorCreator<FloatEditorCreator>();
+    QItemEditorCreatorBase *doubleEditorCreator =
+    new QStandardItemEditorCreator<DoubleEditorCreator>();
+    QItemEditorCreatorBase *invalidEditorCreator =
+    new QStandardItemEditorCreator<InvalidEditorCreator>();
+
+    QItemEditorFactory *factory =
+        new QItemEditorFactory();
+
+    QVariant::Type typeFloat = static_cast<QVariant::Type> (qMetaTypeId<float>());
+
+    factory->registerEditor(QVariant::Bool, booleanComboBoxEditorCreator);
+    factory->registerEditor(QVariant::UInt, uIntEditorCreator);
+    factory->registerEditor(QVariant::Int, intEditorCreator);
+    factory->registerEditor(QVariant::ULongLong, uLongLongEditorCreator);
+    factory->registerEditor(QVariant::LongLong, longLongEditorCreator);
+    factory->registerEditor(QVariant::Pixmap, pixmapEditorCreator);
+    factory->registerEditor(typeFloat, floatEditorCreator);
+    factory->registerEditor(QVariant::Double, doubleEditorCreator);
+    factory->registerEditor(QVariant::Invalid, invalidEditorCreator);
+
+    QItemEditorFactory::setDefaultFactory(factory);
 }
 
 BooleanComboBox::BooleanComboBox(QWidget *parent)
@@ -186,11 +144,10 @@ void ArgumentsEditor::init()
     connect(m_ui.revertButton, SIGNAL(clicked()),
             SLOT(revert()));
 
-    m_ui.argsTree->setModel(m_model);
-    QItemEditorFactory *factory =
-        new ArgumentsItemEditorFactory();
+    setArgumentsItemEditorFactory ();
 
-    QItemEditorFactory::setDefaultFactory(factory);
+    m_ui.argsTree->setModel(m_model);
+
 }
 
 void ArgumentsEditor::setupCall()
@@ -239,7 +196,7 @@ void ArgumentsEditor::setupCall()
 
                     QStandardItem *col = new QStandardItem();
                     col->setFlags(col->flags() | Qt::ItemIsEditable);
-                    col->setData(vals[i], Qt::DisplayRole);
+                    col->setData(vals[i], Qt::EditRole);
                     row.append(idx);
                     row.append(col);
                     nameItem->appendRow(row);
@@ -307,7 +264,7 @@ void ArgumentsEditor::setupCall()
                 item->setFlags(item->flags() ^ Qt::ItemIsEditable);
                 item->setToolTip(tr("Argument is read-only"));
             }
-            item->setData(val, Qt::DisplayRole);
+            item->setData(val, Qt::EditRole);
             topRow.append(item);
         }
         rootItem->appendRow(topRow);

--- a/gui/argumentseditor.h
+++ b/gui/argumentseditor.h
@@ -8,6 +8,11 @@
 #include <QDialog>
 #include <QItemEditorFactory>
 #include <QStandardItemModel>
+#include <QSpinBox>
+
+#include <limits.h>
+#include <float.h>
+
 
 class ApiTraceCall;
 
@@ -21,12 +26,114 @@ public:
     bool value() const;
 };
 
-class ArgumentsItemEditorFactory : public QItemEditorFactory
+
+class BooleanComboBoxEditorCreator : public BooleanComboBox
 {
+    Q_OBJECT
+    Q_PROPERTY(bool value READ value WRITE setValue USER true)
 public:
-    ArgumentsItemEditorFactory();
-    QWidget *createEditor(QMetaType::Type type, QWidget *parent) const;
-    QByteArray valuePropertyName(QMetaType::Type) const;
+    BooleanComboBoxEditorCreator(QWidget *widget = 0) : BooleanComboBox(widget)
+    {
+	this->setFrame(false);
+    };
+};
+
+class UIntEditorCreator : public QSpinBox
+{
+    Q_OBJECT
+    Q_PROPERTY(int value READ value WRITE setValue USER true)
+public:
+    UIntEditorCreator(QWidget *widget = 0) : QSpinBox(widget)
+    {
+	this->setFrame(false);
+        this->setMaximum(INT_MAX);
+    };
+};
+
+class IntEditorCreator : public QSpinBox
+{
+    Q_OBJECT
+    Q_PROPERTY(int value READ value WRITE setValue USER true)
+public:
+    IntEditorCreator(QWidget *widget = 0) : QSpinBox(widget)
+    {
+	this->setFrame(false);
+        this->setMinimum(INT_MIN);
+        this->setMaximum(INT_MAX);
+    };
+};
+
+class ULongLongEditorCreator : public QSpinBox
+{
+    Q_OBJECT
+    Q_PROPERTY(int value READ value WRITE setValue USER true)
+public:
+    ULongLongEditorCreator(QWidget *widget = 0) : QSpinBox(widget)
+    {
+	this->setFrame(false);
+        this->setMaximum(INT_MAX);
+    };
+};
+
+class LongLongEditorCreator : public QSpinBox
+{
+    Q_OBJECT
+    Q_PROPERTY(int value READ value WRITE setValue USER true)
+public:
+    LongLongEditorCreator(QWidget *widget = 0) : QSpinBox(widget)
+    {
+	this->setFrame(false);
+        this->setMinimum(INT_MIN);
+        this->setMaximum(INT_MAX);
+    };
+};
+
+class PixmapEditorCreator : public QLabel
+{
+    Q_OBJECT
+    Q_PROPERTY(QString text READ text WRITE setText USER true)
+public:
+    PixmapEditorCreator(QWidget *widget = 0) : QLabel (widget)
+    {
+    };
+};
+
+class FloatEditorCreator : public QDoubleSpinBox
+{
+    Q_OBJECT
+    Q_PROPERTY(double value READ value WRITE setValue USER true)
+public:
+    FloatEditorCreator(QWidget *widget = 0) : QDoubleSpinBox(widget)
+    {
+	this->setFrame(false);
+        this->setMinimum(-FLT_MAX);
+        this->setMaximum(FLT_MAX);
+        this->setDecimals(8);
+    };
+};
+
+class DoubleEditorCreator : public QDoubleSpinBox
+{
+    Q_OBJECT
+    Q_PROPERTY(double value READ value WRITE setValue USER true)
+public:
+    DoubleEditorCreator(QWidget *widget = 0) : QDoubleSpinBox(widget)
+    {
+	this->setFrame(false);
+        this->setMinimum(-DBL_MAX);
+        this->setMaximum(DBL_MAX);
+        this->setDecimals(8);
+    };
+};
+
+class InvalidEditorCreator : public QLabel
+{
+    Q_OBJECT
+    Q_PROPERTY(QString text READ text WRITE setText USER true)
+public:
+    InvalidEditorCreator(QWidget *widget = 0) :  QLabel(widget)
+    {
+    };
 };
 
 class ArgumentsEditor : public QDialog


### PR DESCRIPTION
It was not allowing edition at least locally (Qt 4.7).
It turns out that the editor use the value to get the type . If positive
 the unsigned type is choosen :/
One cannot enter negative values anymore.

Could we discuss the best way to let the editor know the type expected for an argument ?
I wonder if instead of an array of the arguments values  or array of pair of <type, argument value> is too intrusive
( it looks from a first sight that it is in the common code that this "cast" to fromValue starts).
Otherwise I might be able to grab the types from the spec via the api.
