### PR TITLE
do not compile gui when other required packages are not there

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ endif ()
 # By bundling the QJSON source, we make it much more easier to build the GUI on
 # Windows and MacOSX.  But we only use the bundled sources when ENABLE_GUI is
 # AUTO.
-if (QT4_FOUND AND NOT QJSON_FOUND AND (ENABLE_GUI STREQUAL "AUTO"))
+if (Qt4_FOUND AND NOT QJSON_FOUND AND (ENABLE_GUI STREQUAL "AUTO"))
     add_subdirectory (thirdparty/qjson EXCLUDE_FROM_ALL)
     set (QJSON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty)
     set (QJSON_LIBRARY_DIRS)
@@ -639,7 +639,7 @@ install (
 ##############################################################################
 # GUI
 
-if (ENABLE_GUI AND QT4_FOUND AND QJSON_FOUND)
+if (ENABLE_GUI AND Qt4_FOUND AND QJSON_FOUND)
     add_subdirectory(gui)
 endif ()
 


### PR DESCRIPTION
Fix the typo so that correct variable is checked.

e.g. when qjson is installed but qt webkit is not installed, gui should not be installed, without this fix, it adds gui/ directory anyway. This would result later compilation errors for missing header files such as following:

In file included from /home/q/apitrace/gui/mainwindow.h:4:0,
                 from /home/q/apitrace/gui/mainwindow.cpp:1:
/home/q/apitrace/build/gui/ui_mainwindow.h:37:29: fatal error: QtWebKit/QWebView: No such file or directory
compilation terminated.

Please review.
Thanks!
