### PR TITLE
Fix compile error "isatty was not declared"; missing unistd.h include

### DIFF
--- a/cli/cli_dump.cpp
+++ b/cli/cli_dump.cpp
@@ -28,6 +28,9 @@
 #include <string.h>
 #include <limits.h> // for CHAR_MAX
 #include <getopt.h>
+#ifndef _WIN32
+#include <unistd.h> // for isatty()
+#endif
 
 #include "cli.hpp"
 #include "cli_pager.hpp"


### PR DESCRIPTION
When I built apitrace on Fedora 16, using the usual:

```
cmake -H. -Bbuild
make -C build
```

...then I got this compile error:

```
apitrace/cli/cli_dump.cpp: In function ‘int command(int, char**)’:
apitrace/cli/cli_dump.cpp:176:25: error: ‘isatty’ was not declared in this scope
```
