### PR TITLE
glsl edit: grep multiline error/warning messages

### DIFF
--- a/gui/retracer.cpp
+++ b/gui/retracer.cpp
@@ -406,6 +406,14 @@ void Retracer::run()
             error.type = regexp.cap(2);
             error.message = regexp.cap(3);
             errors.append(error);
+        } else if (!errors.isEmpty()) {
+            // Probably a multiligne message
+            ApiTraceError &previous = errors.last();
+            if (line.endsWith("\n")) {
+                line.chop(1);
+            }
+            previous.message.append('\n');
+            previous.message.append(line);
         }
     }
 


### PR DESCRIPTION
Useful for GL shader errors which spawn multiple lines error message like that:
    >> 2135: warning: Vertex shader failed to compile with the following errors:
    >> ERROR: 1:1: error(#132) Syntax error: 'sdfsafasf' parse error
    >> ERROR: error(#273) 1 compilation errors.  No code generated
