### PR TITLE
Bypass glDetachShader and glDeleteShader when dumping state

### DIFF
--- a/retrace/glretrace.py
+++ b/retrace/glretrace.py
@@ -318,7 +318,7 @@ class GlRetracer(Retracer):
             print r'    } else {'
             Retracer.invokeFunction(self, function)
             print r'    }'
-        elif function.name in ('glDeleteShader', 'glDetachShader'): 
+        elif function.name in ('glDeleteShader', 'glDetachShader'):
             print r'    if (!retrace::dumpingState) {'
             Retracer.invokeFunction(self, function)
             print r'    }'

--- a/retrace/glretrace.py
+++ b/retrace/glretrace.py
@@ -318,6 +318,10 @@ class GlRetracer(Retracer):
             print r'    } else {'
             Retracer.invokeFunction(self, function)
             print r'    }'
+        elif function.name in ('glDeleteShader', 'glDetachShader'): 
+            print r'    if (!retrace::dumpingState) {'
+            Retracer.invokeFunction(self, function)
+            print r'    }'
         else:
             Retracer.invokeFunction(self, function)
 


### PR DESCRIPTION
Follow issue 78:

Due to a driver bug, I recreate glCreateShaderProgramv in my application but I keep the part that delete/detach the shader part. Unfortunately apitrace isn't able anymore to retrieve shader code source

I think, it would be better to bypass glDetachShader and glDeleteShader too in dumping state.