### PR TITLE
Integrate into FirefoxOS

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,79 @@
+#
+# This file helps integrate apitrace into FirefoxOS - when apitrace
+# sources are put in B2GROOT/external/apitrace (including this Android.mk
+# file), then the B2G build system will pick apitrace automatically and
+# compile and install it into the system images seamlessly.
+#
+# This may work in other than FirefoxOS environments, but has not been tested.
+#
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := egltrace
+LOCAL_MODULE_TAGS := debug eng
+
+include $(BUILD_SHARED_LIBRARY)
+
+# Below we hook the process of configuring and compiling apitrace,
+# described in INSTALL.markdown (but we use the FirefoxOS's NDK). We override
+# the $(linked_module): targed, which is already defined by
+# $(BUILD_SHARED_LIBRARY) - by default it would want to compile the
+# library out of some source files.
+# We also override the target $(LOCAL_INSTALLED_MODULE): which installs
+# the shared library because we want it installed in
+# /lib/apitrace/wrappers/egltrace.so instead of /lib/egltrace.so because
+# /bin/apitrace searches for the library in that directory.
+# The rules will end up with /lib/apitrace/wrappers/egltrace.so and
+# /bin/apitrace inside system.img.
+MY_APITRACE_ROOT := $(TOPDIR)external/apitrace
+MY_APITRACE_BUILD_ROOT_HOST := out/host/apitrace
+MY_APITRACE_BUILD_ROOT_TARGET := out/target/apitrace
+
+apitrace_private_target:
+	$(hide) # apitrace: run cmake for the host if it has not been run
+	$(hide) if [ ! -e $(MY_APITRACE_BUILD_ROOT_HOST)/Makefile ] ; then \
+		cd $(MY_APITRACE_ROOT) && \
+		cmake -H. -B../../$(MY_APITRACE_BUILD_ROOT_HOST) ; \
+	fi
+	$(hide) # apitrace: compile for the host
+	$(hide) make -C $(MY_APITRACE_BUILD_ROOT_HOST)
+	$(hide) # apitrace: run cmake for android if it has not been run
+	$(hide) if [ ! -e $(MY_APITRACE_BUILD_ROOT_TARGET)/Makefile ] ; then \
+		cd $(MY_APITRACE_ROOT) && \
+		cmake \
+		-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/android.toolchain.cmake \
+		-DANDROID_NDK=../../prebuilt/ndk/android-ndk-r8 \
+		-DANDROID_NDK_LAYOUT=LINARO \
+		-DANDROID_API_LEVEL=9 \
+		-DANDROID_NO_UNDEFINED=OFF \
+		-DLIBRARY_OUTPUT_PATH_ROOT=../../$(MY_APITRACE_BUILD_ROOT_TARGET) \
+		-H. -B../../$(MY_APITRACE_BUILD_ROOT_TARGET) ; \
+	fi
+	$(hide) # apitrace: compile for android
+	$(hide) make -C $(MY_APITRACE_BUILD_ROOT_TARGET)
+
+$(linked_module): apitrace_private_target
+	$(hide) # apitrace: copy egltrace lib to where the build system expects it
+	$(hide) mkdir -p $(dir $@)
+	$(hide) cp $(MY_APITRACE_BUILD_ROOT_TARGET)/libs/*/egltrace$(TARGET_SHLIB_SUFFIX) $@
+
+$(LOCAL_INSTALLED_MODULE): $(LOCAL_BUILT_MODULE) | $(ACP)
+	@echo "Install (overridden): $@"
+	@mkdir -p $(dir $@)/apitrace/wrappers
+	$(hide) $(ACP) -fp $< $(dir $@)/apitrace/wrappers/egltrace$(TARGET_SHLIB_SUFFIX)
+
+#
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := apitrace
+LOCAL_MODULE_TAGS := debug eng
+
+include $(BUILD_EXECUTABLE)
+
+$(linked_module): apitrace_private_target
+	$(hide) # apitrace: copy apitrace executable to where the build system expects it
+	$(hide) mkdir -p $(dir $@)
+	$(hide) cp $(MY_APITRACE_BUILD_ROOT_TARGET)/apitrace$(TARGET_EXECUTABLE_SUFFIX) $@

--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -73,6 +73,15 @@ Build as:
 You can also choose a particular ABI by passing `ANDROID_ABI` variable to
 cmake, e.g., `-DANDROID_ABI=x86`.
 
+FirefoxOS
+---------
+
+Put Apitrace source tree into B2GROOT/external/apitrace/ and the Android.mk
+file (B2GROOT/external/apitrace/Android.mk) will do the needful to compile
+and install apitrace appropriately into the system image as part of FirefoxOS
+build process. It expects a linaro-type of Android NDK to be present in
+../../prebuilt/ndk/android-ndk-r8 (ie B2GROOT/prebuilt/ndk/android-ndk-r8).
+
 
 Windows
 -------


### PR DESCRIPTION
Add Android.mk to integrate into FirefoxOS

This Android.mk is part of "Bug 831147 - Integrate apitrace into build"
https://bugzilla.mozilla.org/831147
With this addition, when apitrace sources are cloned into
B2GROOT/external/apitrace, then the FirefoxOS build system picks
up automatically apitrace, compiles and install is to the right place.
