### PR TITLE
Trace corruption on linux + AMD

### DIFF
--- a/retrace/glstate_images.cpp
+++ b/retrace/glstate_images.cpp
@@ -515,8 +515,8 @@ dumpTextures(JSONWriter &json, Context &context)
 
 static bool
 getDrawableBounds(GLint *width, GLint *height) {
-#if defined(__linux__)
-    if (dlsym(RTLD_DEFAULT, "eglGetCurrentContext")) {
+#if defined(__linux__) && 0
+    if (dlsym(RTLD_DEFAULT, "eglGetCurrentContext")) { // unavailable function on AMD
         EGLContext currentContext = eglGetCurrentContext();
         if (currentContext == EGL_NO_CONTEXT) {
             return false;


### PR DESCRIPTION
This commit fixes trace corruptions on linux systems running with AMD GPUs, because the eglGetCurrentContext function is unavailable.
I've only modified glstate_images.cpp which is causing the issue: I've simply undefed the **linux** macro for the getDrawableBounds function, hence the HAVE_X11 code is executed instead, which works for me
