### PR TITLE
Fix Android target build on Apple hosts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required (VERSION 2.8)
 
 # Use clang on MacOSX. gcc doesn't support __thread key, and Apple has
 # abandoned it for clang.  This must be done before the project is defined.
-if (APPLE)
+# But DONT force clang if we are cross-compiling to Android.
+if (APPLE AND NOT ANDROID_NDK)
     set (CMAKE_C_COMPILER "clang")
     set (CMAKE_CXX_COMPILER "clang++")
 endif ()


### PR DESCRIPTION
Currently CMakeLists.txt forces CMAKE_C_COMPILER to clang whenever
compiling on an APPLE host.  Unfortunately, this prevents the
android.toolchain.cmake script from selecting the correct cross
compiler. See [line 1136](https://github.com/apitrace/apitrace/blob/master/cmake/toolchain/android.toolchain.cmake#L1136).

To avoid this problem, only force clang if ANDROID_NDK is not set.  This
is one of the variables used by Android.mk.
