### PR TITLE
Use ndk-android-r7 for FirefoxOS builds.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -44,7 +44,7 @@ apitrace_private_target:
 		cd $(MY_APITRACE_ROOT) && \
 		cmake \
 		-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/android.toolchain.cmake \
-		-DANDROID_NDK=../../prebuilt/ndk/android-ndk-r8 \
+		-DANDROID_NDK=../../prebuilt/ndk/android-ndk-r7 \
 		-DANDROID_NDK_LAYOUT=LINARO \
 		-DANDROID_API_LEVEL=9 \
 		-DANDROID_NO_UNDEFINED=OFF \

--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -80,7 +80,7 @@ Put Apitrace source tree into `B2GROOT/external/apitrace/` and the `Android.mk`
 file (`B2GROOT/external/apitrace/Android.mk`) will do the needful to compile
 and install apitrace appropriately into the system image as part of FirefoxOS
 build process. It expects a linaro-type of Android NDK to be present in
-`../../prebuilt/ndk/android-ndk-r8` (ie `B2GROOT/prebuilt/ndk/android-ndk-r8`).
+`../../prebuilt/ndk/android-ndk-r7` (ie `B2GROOT/prebuilt/ndk/android-ndk-r7`).
 
 
 Windows


### PR DESCRIPTION
Commit 7445733 added support for FirefoxOS, but appears to have been using
a newer version of the NDK than we typically build with.  The codeaurora.org
prebuilts repo we are tracking has not pulled in r8 yet and only provides r7.

For the time being it would be helpful to drop back to r7.  Admittedly, we
should probably have a better mechanism for selecting the latest version
available.
