### PR TITLE
Fix defineShadowBufferHelper for buffer objects

### DIFF
--- a/wrappers/gltrace.py
+++ b/wrappers/gltrace.py
@@ -357,7 +357,7 @@ class GlTracer(Tracer):
         print '    }'
         print
         print '    GLint buffer_binding = 0;'
-        print '    _glGetIntegerv(target, &buffer_binding);'
+        print '    _glGetIntegerv(GL_ELEMENT_ARRAY_BUFFER_BINDING, &buffer_binding);'
         print '    if (buffer_binding > 0) {'
         print '        gltrace::Buffer & buf = ctx->buffers[buffer_binding];'
         print '        buf.getSubData(offset, size, data);'


### PR DESCRIPTION
Traces for glDrawElements with a buffer object for indices were getting the wrong index range because the glGetIntegerv query used the wrong pname.

Use GL_ELEMENT_ARRAY_BUFFER_BINDING instead of GL_ELEMENT_ARRAY_BUFFER
to inquire the current buffer object in _shadow_glGetBufferSubData.
