### PR TITLE
egltrace/android: Write trace to specified file (global variable)

### DIFF
--- a/common/trace_writer_local.cpp
+++ b/common/trace_writer_local.cpp
@@ -60,6 +60,7 @@ static void exceptionCallback(void)
     localWriter.flush();
 }
 
+const char *localWriterFileName = NULL;
 
 LocalWriter::LocalWriter() :
     acquired(0)
@@ -79,12 +80,18 @@ LocalWriter::~LocalWriter()
 
 void
 LocalWriter::open(void) {
-    os::String szFileName;
 
-    const char *lpFileName;
+    const char *lpFileName = NULL;
 
-    lpFileName = getenv("TRACE_FILE");
-    if (!lpFileName) {
+    if (!lpFileName || !*lpFileName) {
+        lpFileName = getenv("TRACE_FILE");
+    }
+
+    if (!lpFileName || !*lpFileName) {
+        lpFileName = localWriterFileName;
+    }
+
+    if (!lpFileName || !*lpFileName) {
         static unsigned dwCounter = 0;
 
         os::String process = os::getProcessName();
@@ -102,6 +109,7 @@ LocalWriter::open(void) {
 
         for (;;) {
             FILE *file;
+            os::String szFileName;
 
             if (dwCounter)
                 szFileName = os::String::format("%s.%u.trace", prefix.str(), dwCounter);

--- a/common/trace_writer_local.hpp
+++ b/common/trace_writer_local.hpp
@@ -112,6 +112,14 @@ namespace trace {
     };
 
     /**
+     * The TRACE_FILE environment variable or the global variable
+     * trace::localWriterFileName can be used to trace to a specific
+     * file.
+     */
+
+    extern const char *localWriterFileName;
+
+    /**
      * Singleton.
      */
     extern LocalWriter localWriter;


### PR DESCRIPTION
In addition to the TRACE_FILE environment variable, provide a trace::localWriterFileName
global variable that can be used to specify the trace output file.  This is beneficial
in the use-case of using apitrace as a user-space library and tracing on non-rooted
Android devices, or even iOS.
