### PR TITLE
common: Add platform #ifdefs for non-cmake build convenience.

### DIFF
--- a/common/os_posix.cpp
+++ b/common/os_posix.cpp
@@ -23,6 +23,7 @@
  *
  **************************************************************************/
 
+#ifndef _WIN32
 
 #include <assert.h>
 #include <string.h>
@@ -331,3 +332,4 @@ resetExceptionCallback(void)
 
 } /* namespace os */
 
+#endif // !defined(_WIN32)

--- a/common/os_win32.cpp
+++ b/common/os_win32.cpp
@@ -23,6 +23,8 @@
  *
  **************************************************************************/
 
+#ifdef _WIN32
+
 #include <windows.h>
 
 #include <assert.h>
@@ -172,7 +174,7 @@ int execute(char * const * args)
         sep = ' ';
     }
 
-    STARTUPINFO startupInfo;
+    STARTUPINFOA startupInfo;
     memset(&startupInfo, 0, sizeof(startupInfo));
     startupInfo.cb = sizeof(startupInfo);
 
@@ -338,3 +340,5 @@ resetExceptionCallback(void)
 
 
 } /* namespace os */
+
+#endif  // defined(_WIN32)

--- a/helpers/eglsize.cpp
+++ b/helpers/eglsize.cpp
@@ -29,6 +29,8 @@
  * Auxiliary functions to compute the size of array/blob arguments.
  */
 
+#ifndef _WIN32
+
 #include <string.h>
 
 #include "os_thread.hpp"
@@ -214,4 +216,5 @@ _EGLImageKHR_free_image_info(struct image_info *info)
     delete info;
 }
 
+#endif // !defined(_WIN32)
 

--- a/helpers/eglsize.hpp
+++ b/helpers/eglsize.hpp
@@ -32,6 +32,7 @@
 #ifndef _EGLSIZE_HPP_
 #define _EGLSIZE_HPP_
 
+#ifndef _WIN32
 
 #include "glimports.hpp"
 
@@ -53,5 +54,6 @@ _EGLImageKHR_get_image_info(GLenum target, EGLImageKHR image);
 void
 _EGLImageKHR_free_image_info(struct image_info *info);
 
+#endif // !defined(_WIN32)
 
 #endif


### PR DESCRIPTION
The cmake CMakeLists.txt file has logic for including or excluding certain
compilation units based on the platform: Windows, Linux or Mac OS X.
Other build systems are not as clever, it is convenient to also wrap
platform-specifics with #ifdef _WIN32 ... #endif to keep things simple on
the build side.

The STARTUPINFOA change is necessary for building apitrace
in unicode mode, on Windows.
