### PR TITLE
Resolve some MS compiler warnings (in picky mode)

### DIFF
--- a/common/os_win32.cpp
+++ b/common/os_win32.cpp
@@ -42,7 +42,7 @@ String
 getProcessName(void)
 {
     String path;
-    size_t size = MAX_PATH;
+    DWORD size = MAX_PATH;
     char *buf = path.buf(size);
 
     DWORD nWritten = GetModuleFileNameA(NULL, buf, size);
@@ -57,7 +57,7 @@ String
 getCurrentDir(void)
 {
     String path;
-    size_t size = MAX_PATH;
+    DWORD size = MAX_PATH;
     char *buf = path.buf(size);
     
     DWORD ret = GetCurrentDirectoryA(size, buf);
@@ -72,7 +72,7 @@ getCurrentDir(void)
 bool
 createDirectory(const String &path)
 {
-    return CreateDirectoryA(path, NULL);
+    return CreateDirectoryA(path, NULL) ? true : false;
 }
 
 bool
@@ -85,13 +85,13 @@ String::exists(void) const
 bool
 copyFile(const String &srcFileName, const String &dstFileName, bool override)
 {
-    return CopyFileA(srcFileName, dstFileName, !override);
+    return CopyFileA(srcFileName, dstFileName, override ? 0 : 1) ? true : false;
 }
 
 bool
 removeFile(const String &srcFilename)
 {
-    return DeleteFileA(srcFilename);
+    return DeleteFileA(srcFilename) ? true : false;
 }
 
 /**

--- a/common/trace_file_snappy.cpp
+++ b/common/trace_file_snappy.cpp
@@ -397,7 +397,7 @@ bool SnappyFile::rawSkip(size_t length)
 
 int SnappyFile::rawPercentRead()
 {
-    return 100 * (double(m_stream.tellg()) / double(m_endPos));
+    return int(100 * (double(m_stream.tellg()) / double(m_endPos)));
 }
 
 

--- a/common/trace_loader.cpp
+++ b/common/trace_loader.cpp
@@ -95,7 +95,7 @@ bool Loader::isCallAFrameMarker(const trace::Call *call) const
 
     switch (m_frameMarker) {
     case FrameMarker_SwapBuffers:
-        return call->flags & trace::CALL_FLAG_END_FRAME;
+        return call->flags & trace::CALL_FLAG_END_FRAME ? true : false;
         break;
     case FrameMarker_Flush:
         return name == "glFlush";

--- a/common/trace_profiler.cpp
+++ b/common/trace_profiler.cpp
@@ -228,7 +228,7 @@ void Profiler::parseLine(const char* in, Profile* profile)
             program.pixelTotal += call.pixels;
             program.vsizeTotal += call.vsizeDuration;
             program.rssTotal += call.rssDuration;
-            program.calls.push_back(profile->calls.size() - 1);
+            program.calls.push_back((unsigned int)(profile->calls.size() - 1));
         }
     } else if (type.compare("frame_end") == 0) {
         Profile::Frame frame;
@@ -252,7 +252,7 @@ void Profiler::parseLine(const char* in, Profile* profile)
         frame.cpuDuration = lastCpuTime - frame.cpuStart;
         frame.vsizeDuration = lastVsizeUsage - frame.vsizeStart;
         frame.rssDuration = lastRssUsage - frame.rssStart;
-        frame.calls.end = profile->calls.size() - 1;
+        frame.calls.end = (unsigned int)(profile->calls.size() - 1);
 
         profile->frames.push_back(frame);
     }


### PR DESCRIPTION
Example compiler messages with /W4 flag: VC8, VC9, VC10, VC11 (VS 2005, 2008, 2010, 2012)

warning C4267: 'argument' : conversion from 'size_t' to 'DWORD', possible loss of data
warning C4800: 'BOOL' : forcing value to bool 'true' or 'false' (performance warning)
warning C4244: 'return' : conversion from 'double' to 'int', possible loss of data
