### PR TITLE
cmake 2.8.7 pthread workaround for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required (VERSION 2.8)
 
+include(CheckIncludeFiles)
 
 # Use clang on MacOSX. gcc doesn't support __thread key, and Apple has
 # abandoned it for clang.  This must be done before the project is defined.
@@ -61,7 +62,9 @@ else ()
 endif ()
 
 find_host_package (PythonInterp REQUIRED)
-find_package (Threads)
+if (NOT ANDROID)
+    find_package (Threads)
+endif ()
 
 if (ENABLE_GUI)
     if (NOT (ENABLE_GUI STREQUAL "AUTO"))


### PR DESCRIPTION
Partial merge of glretracer for Android patch set by
Juha-Pekka Heikkila (juha-pekka.heikkila@linux.intel.com)

Aside from the Waffle-based glretracer support in Juha-Pekka's patch set, I wasn't about to build apitrace for Android without these minor cmake changes.

The failure I observed was:

...
-- Check if compiler accepts -pthread
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   THREADS_PTHREAD_ARG (advanced)
For details see /home/nstewart/dev/apitrace/build/TryRunResults.cmake
-- Check if compiler accepts -pthread - no
...
