### PR TITLE
Resolve C4267 MS compiler warnings

### DIFF
--- a/common/trace_file_zlib.cpp
+++ b/common/trace_file_zlib.cpp
@@ -105,12 +105,12 @@ bool ZLibFile::rawOpen(const std::string &filename, File::Mode mode)
 
 bool ZLibFile::rawWrite(const void *buffer, size_t length)
 {
-    return gzwrite(m_gzFile, buffer, length) != -1;
+    return gzwrite(m_gzFile, buffer, unsigned(length)) != -1;
 }
 
 size_t ZLibFile::rawRead(void *buffer, size_t length)
 {
-    int ret = gzread(m_gzFile, buffer, length);
+    int ret = gzread(m_gzFile, buffer, unsigned(length));
     return ret < 0 ? 0 : ret;
 }
 
@@ -150,7 +150,7 @@ bool ZLibFile::rawSkip(size_t)
 int ZLibFile::rawPercentRead()
 {
     gz_state *state = (gz_state *)m_gzFile;
-    return 100 * (lseek(state->fd, 0, SEEK_CUR) / m_endOffset);
+    return int(100 * (lseek(state->fd, 0, SEEK_CUR) / m_endOffset));
 }
 
 

--- a/common/trace_loader.cpp
+++ b/common/trace_loader.cpp
@@ -25,7 +25,7 @@ void Loader::setFrameMarker(Loader::FrameMarker marker)
 
 unsigned Loader::numberOfFrames() const
 {
-    return m_frameBookmarks.size();
+    return unsigned(m_frameBookmarks.size());
 }
 
 unsigned Loader::numberOfCallsInFrame(unsigned frameIdx) const

--- a/common/trace_profiler.cpp
+++ b/common/trace_profiler.cpp
@@ -232,7 +232,7 @@ void Profiler::parseLine(const char* in, Profile* profile)
         }
     } else if (type.compare("frame_end") == 0) {
         Profile::Frame frame;
-        frame.no = profile->frames.size();
+        frame.no = unsigned(profile->frames.size());
 
         if (frame.no == 0) {
             frame.gpuStart = 0;


### PR DESCRIPTION
The C4267 isn't globally disabled by the apitrace CMakeLists.txt,
using explicit c-casting here to appease the MS compiler.

warning C4267: 'argument' : conversion from 'size_t' to 'unsigned int', possible loss of data
