### PR TITLE
Support for Mac OS X 10.5 Leopard

### DIFF
--- a/dispatch/glimports.hpp
+++ b/dispatch/glimports.hpp
@@ -89,8 +89,22 @@ typedef struct _WGLSWAP
 #elif defined(__APPLE__)
 
 #include <OpenGL/OpenGL.h>
+
+#include <AvailabilityMacros.h>
+
+#ifndef MAC_OS_X_VERSION_10_6
+#define MAC_OS_X_VERSION_10_6 1060
+#endif
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_6
 #include <OpenGL/CGLIOSurface.h>
 #include <OpenGL/CGLDevice.h>
+#else
+#define kCGLPFAAcceleratedCompute 97
+#define kCGLRPAcceleratedCompute 130
+typedef void *CGLShareGroupObj;
+typedef struct __IOSurface *IOSurfaceRef;
+#endif
 
 #ifndef CGL_VERSION_1_3
 #define kCGLPFAOpenGLProfile 99


### PR DESCRIPTION
CGLShareGroupObj and IOSurfaceRef were added in 10.6 Snow Leopard SDK
Add workarounds to glimports.hpp to support building for pre-10.6.

---

Regal currently supports 10.5 onwards, and I personally like to use the old gcc compiler toolchain that is faster than clang.  This modest patch is necessary for apitrace to build with the 10.5 SDK. (ppc/i686/x86_64)
- Nigel
