### PR TITLE
common: Conditionally compile-out os::log with -DTRACE_OS_LOG=0

### DIFF
--- a/common/os.hpp
+++ b/common/os.hpp
@@ -47,6 +47,12 @@
 #endif
 #endif /* !_WIN32 */
 
+/* Implement os::log by default, opt-out with -DTRACE_OS_LOG=0 */
+
+#ifndef TRACE_OS_LOG
+#define TRACE_OS_LOG 1
+#endif
+
 namespace os {
 
 void log(const char *format, ...)

--- a/common/os_posix.cpp
+++ b/common/os_posix.cpp
@@ -175,6 +175,7 @@ int execute(char * const * args)
 
 static volatile bool logging = false;
 
+#if TRACE_OS_LOG
 void
 log(const char *format, ...)
 {
@@ -199,6 +200,7 @@ log(const char *format, ...)
     va_end(ap);
     logging = false;
 }
+#endif
 
 #if defined(__APPLE__)
 long long timeFrequency = 0LL;

--- a/common/os_win32.cpp
+++ b/common/os_win32.cpp
@@ -206,6 +206,7 @@ int execute(char * const * args)
     return (int)exitCode;
 }
 
+#if TRACE_OS_LOG
 void
 log(const char *format, ...)
 {
@@ -231,6 +232,7 @@ log(const char *format, ...)
     }
 #endif
 }
+#endif
 
 long long timeFrequency = 0LL;
 


### PR DESCRIPTION
For the purpose of integrating apitrace into Regal, unify the logging by
leaving out the defaut os::log method, optionally.

This change ought to have no side-effects for regular apitrace builds.
- Nigel
