### PR TITLE
glretrace: GLX and WGL support for ES2/EGL traces.

### DIFF
--- a/retrace/glws_glx.cpp
+++ b/retrace/glws_glx.cpp
@@ -267,7 +267,8 @@ cleanup(void) {
 Visual *
 createVisual(bool doubleBuffer, Profile profile) {
     if (profile != PROFILE_COMPAT &&
-        profile != PROFILE_CORE) {
+        profile != PROFILE_CORE &&
+        profile != PROFILE_ES2) {
         return NULL;
     }
 
@@ -341,6 +342,9 @@ createContext(const Visual *_visual, Context *shareContext, Profile profile, boo
 
         switch (profile) {
         case PROFILE_COMPAT:
+            break;
+        case PROFILE_ES2:
+            attribs.add(GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_ES2_PROFILE_BIT_EXT);
             break;
         case PROFILE_CORE:
             // XXX: This will invariable return a 3.2 context, when supported.

--- a/retrace/glws_wgl.cpp
+++ b/retrace/glws_wgl.cpp
@@ -304,7 +304,8 @@ cleanup(void) {
 Visual *
 createVisual(bool doubleBuffer, Profile profile) {
     if (profile != PROFILE_COMPAT &&
-        profile != PROFILE_CORE) {
+        profile != PROFILE_CORE &&
+        profile != PROFILE_ES2) {
         return NULL;
     }
 
@@ -325,12 +326,20 @@ Context *
 createContext(const Visual *visual, Context *shareContext, Profile profile, bool debug)
 {
     if (profile != PROFILE_COMPAT &&
-        profile != PROFILE_CORE) {
+        profile != PROFILE_CORE &&
+        profile != PROFILE_ES2) {
         return NULL;
     }
 
-    if (profile == PROFILE_CORE) {
+    switch (profile)
+    {
+      case PROFILE_CORE:
         std::cerr << "warning: ignoring OpenGL core profile request\n";
+        break;
+
+      case PROFILE_ES2:
+        std::cerr << "warning: ignoring OpenGL ES 2.0 profile request\n";
+        break;
     }
 
     return new WglContext(visual, profile, static_cast<WglContext *>(shareContext));


### PR DESCRIPTION
I was able to glretrace Gears for Android on x86 Linux with
NVIDIA (non-DRI supporting) driver by enabling
GLX_CONTEXT_ES2_PROFILE_BIT_EXT for the
glXCreateContextAttribsARB path.

Unfortunately eglretrace via Mesa es2/egl doesn't seem
to be compatible the NVIDIA desktop driver.
