### PR TITLE
glimports: Check for iOS and skip OpenGL and CGL as appropriate.

### DIFF
--- a/dispatch/glimports.hpp
+++ b/dispatch/glimports.hpp
@@ -88,6 +88,10 @@ typedef struct _WGLSWAP
 
 #elif defined(__APPLE__)
 
+#include <TargetConditionals.h>
+
+#if TARGET_OS_IPHONE
+#elif TARGET_OS_MAC
 #include <OpenGL/OpenGL.h>
 
 #include <AvailabilityMacros.h>
@@ -124,6 +128,7 @@ CGLError CGLGetSurface(CGLContextObj ctx, CGSConnectionID* cid, CGSWindowID* wid
 CGLError CGLUpdateContext(CGLContextObj ctx);
 
 }
+#endif
 
 #else
 


### PR DESCRIPTION
The Regal build for iOS supporting apitrace needs this
change to avoid a compilation error.
