### PR TITLE
backtrace: Opt-out of backtrace support with -DTRACE_BACKTRACE=0

### DIFF
--- a/common/trace_backtrace.cpp
+++ b/common/trace_backtrace.cpp
@@ -33,7 +33,7 @@
 
 #include "trace_backtrace.hpp"
 
-#if defined(ANDROID) || defined(__ELF__)
+#if TRACE_BACKTRACE
 
 #include <set>
 #include "os.hpp"
@@ -387,4 +387,4 @@ std::vector<RawStackFrame> get_backtrace() {
 
 } /* namespace trace */
 
-#endif /* ANDROID or LINUX */
+#endif /* TRACE_BACKTRACE */

--- a/common/trace_backtrace.hpp
+++ b/common/trace_backtrace.hpp
@@ -27,19 +27,28 @@
 #ifndef _TRACE_BACKTRACE_HPP_
 #define _TRACE_BACKTRACE_HPP_
 
+/* Enable backtrace depending on the platform, opt-out with -DTRACE_BACKTRACE=0 */
+
+#ifndef TRACE_BACKTRACE
+# if defined(ANDROID) || defined(__ELF__)
+#  define TRACE_BACKTRACE 1
+# else
+#  define TRACE_BACKTRACE 0
+# endif
+#endif
+
 #include <vector>
 
 #include "trace_model.hpp"
 
 namespace trace {
 
-
-#if defined(ANDROID) || defined(__ELF__)
+#if TRACE_BACKTRACE
 
 std::vector<RawStackFrame> get_backtrace();
 bool backtrace_is_needed(const char* fname);
 
-#else
+#else /* TRACE_BACKTRACE==0 */
 
 static inline std::vector<RawStackFrame> get_backtrace() {
     return std::vector<RawStackFrame>();
@@ -49,7 +58,7 @@ static inline bool backtrace_is_needed(const char*) {
     return false;
 }
 
-#endif
+#endif /* TRACE_BACKTRACE */
 
 } /* namespace trace */
 


### PR DESCRIPTION
For apitrace integrated into Regal we want to opt-out of backtrace support, for now.
One reason is that it's fairly platform-specific.  Another concern is potential
build issue across various Linux flavors.  This change ought to make no difference
with TRACE_BACKTRACE undefined at build-time.
