### PR TITLE
Android: Opt-out of Android isTracingEnabled logic with -DTRACE_ENABLED_...

### DIFF
--- a/wrappers/trace.cpp
+++ b/wrappers/trace.cpp
@@ -43,6 +43,7 @@
 
 namespace trace {
 
+#if TRACE_ENABLED_CHECK
 
 #ifdef ANDROID
 
@@ -109,6 +110,7 @@ isTracingEnabled(void)
 
 #endif /* ANDROID */
 
+#endif /* TRACE_ENABLED_CHECK */
 
 } /* namespace trace */
 

--- a/wrappers/trace.hpp
+++ b/wrappers/trace.hpp
@@ -32,22 +32,31 @@
 #ifndef _TRACE_HPP_
 #define _TRACE_HPP_
 
+/* Unless specified at build-time with -DTRACE_ENABLED_CHECK=0, auto-detect */
+
+#ifndef TRACE_ENABLED_CHECK
+# ifdef ANDROID
+#  define TRACE_ENABLED_CHECK 1
+# else
+#  define TRACE_ENABLED_CHECK 0
+# endif
+#endif
 
 namespace trace {
 
 
-#ifdef ANDROID
+#if TRACE_ENABLED_CHECK
 
 bool isTracingEnabled(void);
 
-#else /* !ANDROID */
+#else /* !TRACE_ENABLED_CHECK */
 
 static inline bool
 isTracingEnabled(void) {
     return true;
 }
 
-#endif /* !ANDROID */
+#endif /* !TRACE_ENABLED_CHECK */
 
 
 } /* namespace trace */


### PR DESCRIPTION
...CHECK=0

In the Regal use-case we want to enable and disable apitrace without setting system properties.
