### PR TITLE
Build fixes for VS2013

### DIFF
--- a/common/formatter.hpp
+++ b/common/formatter.hpp
@@ -153,9 +153,9 @@ public:
     WindowsAttribute(WORD _wAttributes) : wAttributes(_wAttributes) {}
     void apply(std::ostream& os) const {
         DWORD nStdHandleOutput;
-        if (os == std::cout) {
+        if (&os == &std::cout) {
             nStdHandleOutput = STD_OUTPUT_HANDLE;
-        } else if (os == std::cerr) {
+        } else if (&os == &std::cerr) {
             nStdHandleOutput = STD_ERROR_HANDLE;
         } else {
             return;

--- a/common/trace_file_snappy.cpp
+++ b/common/trace_file_snappy.cpp
@@ -54,6 +54,7 @@
 #include <snappy.h>
 
 #include <iostream>
+#include <algorithm>
 
 #include <assert.h>
 #include <string.h>


### PR DESCRIPTION
These are some minor changes reportedly necessary for
building apitrace with VS2013.  Upstreaming these from Regal.

See also:
https://github.com/p3/regal/pull/97
