### PR TITLE
gltrace: Add support for GL 4.4 routines.

### DIFF
--- a/specs/glapi.py
+++ b/specs/glapi.py
@@ -1444,6 +1444,23 @@ glapi.addFunctions([
     GlFunction(Void, "glTextureStorage2DMultisampleEXT", [(GLtexture, "texture"), (GLenum, "target"), (GLsizei, "samples"), (GLenum, "internalformat"), (GLsizei, "width"), (GLsizei, "height"), (GLboolean, "fixedsamplelocations")]),
     GlFunction(Void, "glTextureStorage3DMultisampleEXT", [(GLtexture, "texture"), (GLenum, "target"), (GLsizei, "samples"), (GLenum, "internalformat"), (GLsizei, "width"), (GLsizei, "height"), (GLsizei, "depth"), (GLboolean, "fixedsamplelocations")]),
 
+    # GL_ARB_multi_bind
+    GlFunction(Void, "glBindBuffersBase", [(GLenum, "target"), (GLuint, "first"), (GLsizei, "count"), (Array(Const(GLuint), "count"), "buffers")]),
+    GlFunction(Void, "glBindBuffersRange", [(GLenum, "target"), (GLuint, "first"), (GLsizei, "count"), (Array(Const(GLuint), "count"), "buffers"), (Array(Const(GLintptr), "count"), "offsets"), (Array(Const(GLsizeiptr), "count"), "sizes")]),
+
+    GlFunction(Void, "glBindImageTextures", [ (GLuint, "first"), (GLsizei, "count"), (Array(Const(GLuint), "count"), "textures")]),
+    GlFunction(Void, "glBindSamplers", [ (GLuint, "first"), (GLsizei, "count"), (Array(Const(GLuint), "count"), "samplers")]),
+    GlFunction(Void, "glBindTextures", [ (GLuint, "first"), (GLsizei, "count"), (Array(Const(GLuint), "count"), "textures")]),
+    GlFunction(Void, "glBindVertexBuffers", [ (GLuint, "first"), (GLsizei, "count"), (Array(Const(GLuint), "count"), "buffers"), (Array(Const(GLintptr), "count"), "offsets"), (Array(Const(GLsizei), "count"), "strides")]),
+
+    # GL_ARB_buffer_storage
+    GlFunction(Void, "glBufferStorage", [ (GLenum, "target"), (GLsizeiptr, "size"), (Blob(Const(GLvoid), "size"), "data"), (GLbitfield_storage, "flags")]),
+    GlFunction(Void, "glNamedBufferStorageEXT", [ (GLuint, "buffer"), (GLsizeiptr, "size"), (Blob(Const(GLvoid), "size"), "data"), (GLbitfield_storage, "flags")]),
+
+    # GL_ARB_clear_texture
+    GlFunction(Void, "glClearTexImage", [ (GLuint, "texture"), (GLint, "level"), (GLenum, "format"), (GLenum, "type"), (Blob(Const(GLvoid), "_glClearBufferData_size(format, type)"), "data")]),
+    GlFunction(Void, "glClearTexSubImage", [ (GLuint, "texture"), (GLint, "level"), (GLint, "xoffset"), (GLint, "yoffset"), (GLint, "zoffset"), (GLsizei, "width"), (GLsizei, "height"), (GLsizei, "depth"), (GLenum, "format"), (GLenum, "type"), (Blob(Const(GLvoid), "_glClearBufferData_size(format, type)"), "data")]),
+
     # GL_EXT_blend_color
     GlFunction(Void, "glBlendColorEXT", [(GLfloat, "red"), (GLfloat, "green"), (GLfloat, "blue"), (GLfloat, "alpha")]),
 

--- a/specs/glparams.py
+++ b/specs/glparams.py
@@ -1730,7 +1730,6 @@ parameters = [
     # XXX: GL_DOT3_RGBA_EXT == GL_PROGRAM_BINARY_LENGTH, but you can't glGet GL_DOT3_RGBA_EXT
     ("glGetProgram",	I,	1,	"GL_PROGRAM_BINARY_LENGTH"),	# 0x8741,
     ("",	X,	1,	"GL_MIRROR_CLAMP_ATI"),	# 0x8742
-    ("",	X,	1,	"GL_MIRROR_CLAMP_TO_EDGE_ATI"),	# 0x8743
     ("",	X,	1,	"GL_MODULATE_ADD_ATI"),	# 0x8744
     ("",	X,	1,	"GL_MODULATE_SIGNED_ADD_ATI"),	# 0x8745
     ("",	X,	1,	"GL_MODULATE_SUBTRACT_ATI"),	# 0x8746
@@ -3182,9 +3181,6 @@ parameters = [
     ("",	X,	1,	"GL_VERTEX_ARRAY_OBJECT_EXT"),	# 0x9154
     ("",	X,	1,	"GL_SAMPLER_OBJECT_AMD"),	# 0x9155
     ("",	X,	1,	"GL_EXTERNAL_VIRTUAL_MEMORY_BUFFER_AMD"),	# 0x9160
-    ("",	X,	1,	"GL_QUERY_BUFFER_AMD"),	# 0x9192
-    ("",	X,	1,	"GL_QUERY_BUFFER_BINDING_AMD"),	# 0x9193
-    ("",	X,	1,	"GL_QUERY_RESULT_NO_WAIT_AMD"),	# 0x9194
     ("glGetTexLevelParameter",	I,	1,	"GL_TEXTURE_BUFFER_OFFSET"),	# 0x919D
     ("glGetTexLevelParameter",	I,	1,	"GL_TEXTURE_BUFFER_SIZE"),	# 0x919E
     ("glGet",	I,	1,	"GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT"),	# 0x919F
@@ -3333,6 +3329,16 @@ parameters = [
     ("",	X,	1,	"GL_CIRCULAR_CW_ARC_TO_NV"),	# 0xFA
     ("",	X,	1,	"GL_CIRCULAR_TANGENT_ARC_TO_NV"),	# 0xFC
     ("",	X,	1,	"GL_ARC_TO_NV"),	# 0xFE
+    ("",	X,	1,	"GL_BUFFER_IMMUTABLE_STORAGE"),		# 0x821F
+    ("",	X,	1,	"GL_BUFFER_STORAGE_FLAGS"),		# 0x821F
+    ("",	X,	1,	"GL_CLEAR_TEXTURE"),			# 0x9365
+    ("",	X,	1,	"GL_LOCATION_COMPONENT"),		# 0x934A
+    ("",	X,	1,	"GL_TRANSFORM_FEEDBACK_BUFFER_INDEX"),	# 0x934B
+    ("",	X,	1,	"GL_TRANSFORM_FEEDBACK_BUFFER_STRIDE"),	# 0x934C
+    ("",	X,	1,	"GL_QUERY_RESULT_NO_WAIT"),		# 0x9194
+    ("",	X,	1,	"GL_QUERY_BUFFER"),			# 0x9192
+    ("",	X,	1,	"GL_QUERY_BUFFER_BINDING"),		# 0x9193
+    ("",	X,	1,	"GL_MIRROR_CLAMP_TO_EDGE"),		# 0x8743
     #("",	X,	1,	"GL_TIMEOUT_IGNORED"),	# 0xFFFFFFFFFFFFFFFFull
     ("",	X,	1,	"GL_INVALID_INDEX"),	# 0xFFFFFFFFu
 ]

--- a/specs/gltypes.py
+++ b/specs/gltypes.py
@@ -210,6 +210,17 @@ GLbitfield_access = Flags(GLbitfield, [
     "GL_MAP_INVALIDATE_BUFFER_BIT",   # 0x0008
     "GL_MAP_FLUSH_EXPLICIT_BIT",      # 0x0010
     "GL_MAP_UNSYNCHRONIZED_BIT",      # 0x0020
+    "GL_MAP_PERSISTENT_BIT",          # 0x0040
+    "GL_MAP_COHERENT_BIT",            # 0x0080
+])
+
+GLbitfield_storage = Flags(GLbitfield, [
+    "GL_MAP_READ_BIT",                # 0x0001 (existing)
+    "GL_MAP_WRITE_BIT",               # 0x0002 (existing)
+    "GL_MAP_PERSISTENT_BIT",          # 0x0040
+    "GL_MAP_COHERENT_BIT",            # 0x0080
+    "GL_DYNAMIC_STORAGE_BIT",         # 0x0100
+    "GL_CLIENT_STORAGE_BIT",          # 0x0200
 ])
 
 GLbitfield_sync_flush = Flags(GLbitfield, [
@@ -231,6 +242,8 @@ GLbitfield_barrier = Flags(GLbitfield, [
     "GL_FRAMEBUFFER_BARRIER_BIT",               # 0x00000400
     "GL_TRANSFORM_FEEDBACK_BARRIER_BIT",        # 0x00000800
     "GL_ATOMIC_COUNTER_BARRIER_BIT",            # 0x00001000
+    "GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT",      # 0x00004000
+    "GL_QUERY_BUFFER_BARRIER_BIT",              # 0x00008000
 ])
 
 # GL_ARB_vertex_array_bgra

--- a/thirdparty/khronos/GL/glext.h
+++ b/thirdparty/khronos/GL/glext.h
@@ -1448,6 +1448,32 @@ extern "C" {
 /* reuse GL_MAX_VERTEX_ATTRIB_BINDINGS */
 #endif
 
+#ifndef GL_VERSION_4_4
+#define GL_NUM_SHADING_LANGUAGE_VERSIONS     0x82E9
+#define GL_BUFFER_IMMUTABLE_STORAGE          0x821F
+#define GL_BUFFER_STORAGE_FLAGS              0x8220
+#define GL_CLEAR_TEXTURE                     0x9365
+#define GL_LOCATION_COMPONENT                0x934A
+#define GL_TRANSFORM_FEEDBACK_BUFFER_INDEX   0x934B
+#define GL_TRANSFORM_FEEDBACK_BUFFER_STRIDE  0x934C
+#define GL_QUERY_RESULT_NO_WAIT              0x9194
+#define GL_QUERY_BUFFER                      0x9192
+#define GL_QUERY_BUFFER_BINDING              0x9193
+/* Reuse tokens from ARB_map_buffer_range */
+/* reuse GL_MAP_READ_BIT */
+/* reuse GL_MAP_WRITE_BIT */
+#define GL_MAP_PERSISTENT_BIT                0x0040
+#define GL_MAP_COHERENT_BIT                  0x0080
+#define GL_DYNAMIC_STORAGE_BIT               0x0100
+#define GL_CLIENT_STORAGE_BIT                0x0200
+#define GL_MIRROR_CLAMP_TO_EDGE              0x8743
+#define GL_FRAMEBUFFER_BARRIER_BIT           0x00000400
+#define GL_TRANSFORM_FEEDBACK_BARRIER_BIT    0x00000800
+#define GL_ATOMIC_COUNTER_BARRIER_BIT        0x00001000
+#define GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT  0x00004000
+#define GL_QUERY_BUFFER_BARRIER_BIT          0x00008000
+#endif
+
 #ifndef GL_ARB_multitexture
 #define GL_TEXTURE0_ARB                   0x84C0
 #define GL_TEXTURE1_ARB                   0x84C1


### PR DESCRIPTION
Trace support for:
- GL_ARB_multi_bind
- GL_ARB_clear_texture
- GL_ARB_buffer_storage
