### PR TITLE
Apitrace replay: Fix "apitrace replay" regression when used with fips

### DIFF
--- a/dispatch/CMakeLists.txt
+++ b/dispatch/CMakeLists.txt
@@ -27,17 +27,26 @@ add_custom_command (
 # multiple times simulatenously, when the targets that depend on it are built
 # in parallel.
 add_custom_target (glproc DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/glproc.hpp)
-
+add_custom_target (glproc_retrace DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/glproc.hpp)
 
 add_library (glproc_gl STATIC EXCLUDE_FROM_ALL
     glproc_gl.cpp
 )
+add_library (glproc_gl_retrace STATIC EXCLUDE_FROM_ALL
+    glproc_gl.cpp
+)
 
 add_dependencies (glproc_gl glproc)
+add_dependencies (glproc_gl_retrace glproc_retrace)
 
 set_target_properties (glproc_gl PROPERTIES
     # Ensure it can be statically linked in shared libraries
     COMPILE_FLAGS "${CMAKE_SHARED_LIBRARY_CXX_FLAGS}"
+)
+set_target_properties (glproc_gl_retrace PROPERTIES
+    # Ensure it can be statically linked in shared libraries
+    COMPILE_FLAGS "${CMAKE_SHARED_LIBRARY_CXX_FLAGS}"
+    COMPILE_DEFINITIONS RETRACE_ALLOW_DLSYM_INTERCEPT
 )
 
 if (ENABLE_EGL)

--- a/dispatch/glproc_gl.cpp
+++ b/dispatch/glproc_gl.cpp
@@ -144,7 +144,7 @@ _getPrivateProcAddress(const char *procName)
 
 #else
 
-
+#ifndef RETRACE_ALLOW_DLSYM_INTERCEPT
 static inline void
 logSymbol(const char *name, void *ptr) {
     if (0) {
@@ -206,11 +206,11 @@ _dlsym(void *handle, const char *symbol)
     result = dlsym_ptr(handle, symbol);
 #else
     result = dlsym(handle, symbol);
-#endif
+#endif //#ifdef __GLIBC__
 
     return result;
 }
-
+#endif //#ifndef RETRACE_ALLOW_DLSYM_INTERCEPT
 
 /*
  * Lookup a libGL symbol
@@ -255,11 +255,15 @@ void * _libgl_sym(const char *symbol)
         }
     }
 
-    result = _dlsym(_libGlHandle, symbol);
+#ifndef RETRACE_ALLOW_DLSYM_INTERCEPT
+        result = _dlsym(_libGlHandle, symbol);
 
-    logSymbol(symbol, result);
+        logSymbol(symbol, result);
 
-    return result;
+        return result;
+#else
+        return dlsym(_libGlHandle, symbol);
+#endif //#ifndef RETRACE_ALLOW_DLSYM_INTERCEPT
 }
 
 

--- a/retrace/CMakeLists.txt
+++ b/retrace/CMakeLists.txt
@@ -74,12 +74,12 @@ if (WIN32 OR APPLE OR X11_FOUND)
         ${glws_os}
     )
 
-    add_dependencies (glretrace glproc)
+    add_dependencies (glretrace glproc_retrace)
 
     target_link_libraries (glretrace
         retrace_common
         glretrace_common
-        glproc_gl
+        glproc_gl_retrace
     )
 
     if (WIN32)


### PR DESCRIPTION
It was noticed that "fips apitrace replay <tracefile>" was no longer
printing out data.

Carl Worth tracked down the cause to SHA1# patch:
7700f74 2013-06-15 Prevent infinite recursion with Steam's overlay.

which introduces a new method of retrieving "dlsym" in file
glproc_gl.cpp to prevent interception by the Steam overlay and
consequent SIGSEGV (or infinite recursion). However this prevents fips
from injecting it's own libraries.

This patch creates an additional library that is used by glretrace to
link against using the old method instead of the new one.

The approach was to maintain both methods of retrieving dlsym by
modifying glproc_gl.cpp with #ifdef. An additional static lib is
built using a -D<macro> to compile for the old method. The retrace
CMakeLists.txt was modified to link against this added library.

For testing, followed instructions from
https://github.com/apitrace/apitrace/wiki/Steam#linux

Confirmed that removing SHA 7700f74 patch causes SIGSEGV when running
apitrace with Steam.

Confirmed that with this patch:
- "apitrace trace steam ..." uses the newer method of accessing dlsym
- "apitrace replay ..."      uses the old method of accessing dlsym
- "fips apitrace replay ..." outputs data.

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
