### PR TITLE
glretrace: Destroy Context only once via glXDestroyContext

### DIFF
--- a/retrace/glretrace_glx.cpp
+++ b/retrace/glretrace_glx.cpp
@@ -150,13 +150,15 @@ static void retrace_glXMakeCurrent(trace::Call &call) {
 
 
 static void retrace_glXDestroyContext(trace::Call &call) {
-    Context *context = getContext(call.arg(1).toUIntPtr());
-
-    if (!context) {
+    ContextMap::iterator it;
+    it = context_map.find(call.arg(1).toUIntPtr());
+    if (it == context_map.end()) {
         return;
     }
 
-    delete context;
+    delete it->second;
+    
+    context_map.erase(it);
 }
 
 static void retrace_glXCopySubBufferMESA(trace::Call &call) {


### PR DESCRIPTION
Handling adapted from retrace_wglDeleteContext

Observed crash on Linux/X11 (valgrind log)

==20050== Invalid read of size 8
==20050==    at 0x42D65A: glretrace::Context::~Context() (glretrace_ws.cpp:122)
==20050==    by 0x5E4CCB: retrace_glXDestroyContext(trace::Call&) (glretrace_glx.cpp:159)
==20050==    by 0x429D1C: retrace::Retracer::retrace(trace::Call&) (retrace.cpp:119)
==20050==    by 0x41F83B: retrace::retraceCall(trace::Call_) (retrace_main.cpp:173)
==20050==    by 0x4216FB: retrace::RelayRunner::runLeg(trace::Call_) (retrace_main.cpp:324)
==20050==    by 0x4215ED: retrace::RelayRunner::runRace() (retrace_main.cpp:295)
==20050==    by 0x41FB8B: retrace::RelayRace::run() (retrace_main.cpp:462)
==20050==    by 0x41FD5A: retrace::mainLoop() (retrace_main.cpp:522)
==20050==    by 0x4204B2: main (retrace_main.cpp:781)
==20050==  Address 0xa9567e0 is 0 bytes inside a block of size 24 free'd
==20050==    at 0x4C2BADC: operator delete(void_) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==20050==    by 0x5E4CD3: retrace_glXDestroyContext(trace::Call&) (glretrace_glx.cpp:159)
==20050==    by 0x429D1C: retrace::Retracer::retrace(trace::Call&) (retrace.cpp:119)
==20050==    by 0x41F83B: retrace::retraceCall(trace::Call_) (retrace_main.cpp:173)
==20050==    by 0x4216FB: retrace::RelayRunner::runLeg(trace::Call*) (retrace_main.cpp:324)
==20050==    by 0x4215ED: retrace::RelayRunner::runRace() (retrace_main.cpp:295)
==20050==    by 0x41FB8B: retrace::RelayRace::run() (retrace_main.cpp:462)
==20050==    by 0x41FD5A: retrace::mainLoop() (retrace_main.cpp:522)
==20050==    by 0x4204B2: main (retrace_main.cpp:781)
