### PR TITLE
glretrace: For GLX multi-sampling back off the requested # of samples, u...

### DIFF
--- a/retrace/glretrace_ws.cpp
+++ b/retrace/glretrace_ws.cpp
@@ -51,10 +51,21 @@ inline glws::Visual *
 getVisual(glws::Profile profile) {
     std::map<glws::Profile, glws::Visual *>::iterator it = visuals.find(profile);
     if (it == visuals.end()) {
-        glws::Visual *visual = glws::createVisual(retrace::doubleBuffer, retrace::samples, profile);
+        glws::Visual *visual = NULL;
+        unsigned samples = retrace::samples;
+        /* The requested number of samples might not be available, try fewer until we succeed */
+        while (!visual && samples>0) {
+            visual = glws::createVisual(retrace::doubleBuffer, samples, profile);
+            if (!visual) {
+                samples--;
+            }
+        }
         if (!visual) {
             std::cerr << "error: failed to create OpenGL visual\n";
             exit(1);
+        }
+        if (samples!=retrace::samples) {
+            std::cerr << "warning: Using " << samples << " samples instead of the requested " << retrace::samples << "\n";
         }
         visuals[profile] = visual;
         return visual;

--- a/retrace/glws_glx.cpp
+++ b/retrace/glws_glx.cpp
@@ -295,7 +295,8 @@ createVisual(bool doubleBuffer, unsigned samples, Profile profile) {
         int num_configs = 0;
         GLXFBConfig * fbconfigs;
         fbconfigs = glXChooseFBConfig(display, screen, attribs, &num_configs);
-        assert(num_configs && fbconfigs);
+        if (!num_configs || !fbconfigs)
+            return NULL;
         visual->fbconfig = fbconfigs[0];
         assert(visual->fbconfig);
         visual->visinfo = glXGetVisualFromFBConfig(display, visual->fbconfig);


### PR DESCRIPTION
...ntil success.

This change resolves a crash when the command-line specified number of samples
is higher than the GL implementation supports.
