### PR TITLE
qapitrace: ignore supporting files generated by qtcreator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,10 @@
 _CPack_Packages
 CMakeCache.txt
 CMakeFiles
+CMakeLists.txt.user
 Makefile
 apitrace
+apitrace.cbp
 build
 dxsdk
 eglretrace

--- a/thirdparty/libbacktrace/.gitignore
+++ b/thirdparty/libbacktrace/.gitignore
@@ -1,2 +1,3 @@
 backtrace-supported.h
 config.h
+libbacktrace.cbp

--- a/thirdparty/qjson/.gitignore
+++ b/thirdparty/qjson/.gitignore
@@ -1,1 +1,1 @@
-moc_*.cxx
+moc_*.cxx*


### PR DESCRIPTION
When using qtcreator for build/debug, qtcreator creates miscellaneous
helper files that don't need to be seen by git.

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
