### PR TITLE
qapitrace: ignore more supporting files generated by qtcreator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.ilk
 *.json
 *.lib
+*.moc*
 *.o
 *.obj
 *.pdb


### PR DESCRIPTION
Missed this extension the previous commit:
"qapitrace: ignore supporting files generated by qtcreator"

Note: *.moc_parameters files are generated by cmake.  Without
them, the following make error occurs:

moc: Cannot open options file specified with @
...
make[2]: **\* [gui/apitrace.moc] Error 1

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
