### PR TITLE
qapitrace: add Apply button to settings form

### DIFF
--- a/gui/settingsdialog.cpp
+++ b/gui/settingsdialog.cpp
@@ -1,6 +1,8 @@
 #include "settingsdialog.h"
 
 #include <QMessageBox>
+#include <QPushButton>
+#include <QDebug>
 
 SettingsDialog::SettingsDialog(QWidget *parent)
     : QDialog(parent),
@@ -29,6 +31,11 @@ SettingsDialog::SettingsDialog(QWidget *parent)
 
     showFilterCB->setCurrentIndex(0);
     showFilterEdit->setText(m_showFilters.constBegin().value().pattern());
+
+    // Connect Apply button from ButtonBox
+    QPushButton* applyButton = buttonBox->button(QDialogButtonBox::Apply);
+    Q_ASSERT (applyButton != NULL);
+    connect(applyButton, SIGNAL(clicked()), this, SLOT(apply()));
 }
 
 void SettingsDialog::filtersFromModel(const ApiTraceFilter *model)
@@ -98,6 +105,12 @@ void SettingsDialog::filtersToModel(ApiTraceFilter *model)
 
 void SettingsDialog::accept()
 {
+    settingsUpdate();
+    QDialog::accept();
+}
+
+void SettingsDialog::settingsUpdate()
+{
     if (showFilterBox->isChecked()) {
         QRegExp regexp(showFilterEdit->text());
         if (!regexp.isValid()) {
@@ -121,7 +134,11 @@ void SettingsDialog::accept()
         }
     }
     filtersToModel(m_filter);
-    QDialog::accept();
+}
+
+void SettingsDialog::apply()
+{
+    settingsUpdate();
 }
 
 void SettingsDialog::changeRegexp(const QString &name)

--- a/gui/settingsdialog.h
+++ b/gui/settingsdialog.h
@@ -14,11 +14,13 @@ class SettingsDialog : public QDialog, public Ui_Settings
 public:
     SettingsDialog(QWidget *parent = 0);
     void accept();
+    void settingsUpdate();
 
     void setFilterModel(ApiTraceFilter *filter);
 private slots:
     void changeRegexp(const QString &name);
     void regexpChanged(const QString &pattern);
+    void apply();
 
 private:
     void filtersFromModel(const ApiTraceFilter *model);

--- a/gui/ui/settings.ui
+++ b/gui/ui/settings.ui
@@ -123,7 +123,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
It's less annoying to have an apply button for seeing the affect
of the the different filters in the settings form rather than
bringing up the form over and over again.

TESTING
I tested this in a branch where I'm doing some other qapitrace
development and everything worked as expected. But after moving
the (Apply-button-specific) changes to a separate branch to push,
I noticed the filter for
"Only show the following events"
for
"glDraw|glVertex|glBegin|glEnd"

wasn't working correctly (not showing all the selected events)
I tested against the current upstream master and it doesn't work
in the same way. I tried to go back to see if it ever worked
correctly but ran into other problems.

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
