### PR TITLE
Add option to retrace with core profile in GUI

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -199,6 +199,9 @@ void MainWindow::replayStart()
     dlgUi.singlethreadCB->setChecked(
         m_retracer->isSinglethread());
 
+    dlgUi.coreProfileCB->setChecked(
+        m_retracer->isCoreProfile());
+
     if (dlg.exec() == QDialog::Accepted) {
         m_retracer->setDoubleBuffered(
             dlgUi.doubleBufferingCB->isChecked());
@@ -208,6 +211,9 @@ void MainWindow::replayStart()
 
         m_retracer->setSinglethread(
             dlgUi.singlethreadCB->isChecked());
+
+        m_retracer->setCoreProfile(
+            dlgUi.coreProfileCB->isChecked());
 
         m_retracer->setProfiling(false, false, false);
 
@@ -479,7 +485,7 @@ variantListToItems(const QVector<QVariant> &lst,
         QString key = QString::number(i);
         QVariant var = lst[i];
         QVariant defaultVar;
-        
+
         if (i < defaultLst.count()) {
             defaultVar = defaultLst[i];
         }

--- a/gui/retracer.cpp
+++ b/gui/retracer.cpp
@@ -195,6 +195,16 @@ void Retracer::setSinglethread(bool singlethread)
     m_singlethread = singlethread;
 }
 
+bool Retracer::isCoreProfile() const
+{
+    return m_useCoreProfile;
+}
+
+void Retracer::setCoreProfile(bool coreprofile)
+{
+    m_useCoreProfile = coreprofile;
+}
+
 bool Retracer::isProfilingGpu() const
 {
     return m_profileGpu;
@@ -294,6 +304,10 @@ void Retracer::run()
 
     if (m_singlethread) {
         arguments << QLatin1String("--singlethread");
+    }
+
+    if (m_useCoreProfile) {
+        arguments << QLatin1String("--core");
     }
 
     if (m_captureState) {

--- a/gui/retracer.h
+++ b/gui/retracer.h
@@ -34,6 +34,9 @@ public:
     bool isSinglethread() const;
     void setSinglethread(bool singlethread);
 
+    bool isCoreProfile() const;
+    void setCoreProfile(bool coreprofile);
+
     bool isProfilingGpu() const;
     bool isProfilingCpu() const;
     bool isProfilingPixels() const;
@@ -67,6 +70,7 @@ private:
     bool m_benchmarking;
     bool m_doubleBuffered;
     bool m_singlethread;
+    bool m_useCoreProfile;
     bool m_captureState;
     bool m_captureThumbnails;
     qlonglong m_captureCall;

--- a/gui/ui/retracerdialog.ui
+++ b/gui/ui/retracerdialog.ui
@@ -61,6 +61,43 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <item>
+      <spacer name="horizontalSpacer_8">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="coreProfileCB">
+       <property name="text">
+        <string>Use core profile</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_7">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>48</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <spacer name="horizontalSpacer_2">


### PR DESCRIPTION
This was preventing using qapitrace to debug issues using Mesa. The
application being debugged used GL 3.3, but since a core profile wasn't
requested, the max Mesa would give was 3.0.
