### PR TITLE
Enable all debug output in glretrace

### DIFF
--- a/retrace/glretrace_main.cpp
+++ b/retrace/glretrace_main.cpp
@@ -312,6 +312,7 @@ initContext() {
     /* Setup debug message call back */
     if (retrace::debug && supportsDebugOutput) {
         glretrace::Context *currentContext = glretrace::getCurrentContext();
+        glDebugMessageControlARB(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, 0, GL_TRUE);
         glDebugMessageCallbackARB(&debugOutputCallback, currentContext);
 
         if (DEBUG_OUTPUT_SYNCHRONOUS) {


### PR DESCRIPTION
On (at least) nVidia systems, not all debug output is enabled by default. If we wish to have the driver tell us where it is placing buffer objects, for example, we have to enable all the debug channels by passing GL_DONT_CARE to everything in glDebugMessageControlARB(...).

The extra messages I get with this enabled, while not technically errors, can be useful diagnosing some types of performance issue. For example:
"Low severity API unknown issue 131185, Buffer detailed info: Buffer object 1 (bound to GL_PIXEL_UNPACK_BUFFER_ARB, usage hint is GL_DYNAMIC_DRAW) has been mapped in DMA CACHED memory."

Thoughts?

— David
