### PR TITLE
Fixed compile errors for "error C2039: 'max' : is not a member of 'std'"...

### DIFF
--- a/image/image_pnm.cpp
+++ b/image/image_pnm.cpp
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <algorithm>
 
 #include <fstream>
 

--- a/retrace/glretrace_ws.cpp
+++ b/retrace/glretrace_ws.cpp
@@ -30,6 +30,7 @@
 
 
 #include <string.h>
+#include <algorithm>
 
 #include <map>
 

--- a/retrace/scoped_allocator.hpp
+++ b/retrace/scoped_allocator.hpp
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
-
+#include <algorithm>
 
 /**
  * Similar to alloca(), but implemented with malloc.


### PR DESCRIPTION
... with Visual Studio 2013 (and perhaps others) by adding include for algorithm.
