### PR TITLE
ARB timer and occlusion query fixes for some drivers

### DIFF
--- a/retrace/glretrace_main.cpp
+++ b/retrace/glretrace_main.cpp
@@ -174,11 +174,10 @@ completeCallQuery(CallQuery& query) {
         }
 
         if (retrace::profilingPixelsDrawn) {
-            if( supportsTimestamp )
-            {
+            if (supportsTimestamp) {
                 glGetQueryObjecti64v(query.ids[OCCLUSION], GL_QUERY_RESULT, &pixels);
             } else {
-                if( supportsElapsed ) {
+                if (supportsElapsed) {
                     glGetQueryObjecti64vEXT(query.ids[OCCLUSION], GL_QUERY_RESULT, &pixels);
                 } else {
                     uint32_t pixels32;


### PR DESCRIPTION
Some GPU drivers, for example Intel HD3000 on Windows, do not support GL_EXT_timer_query but do support the ARB version, and so cannot use the EXT query functions. However the ARB ones are valid in this situation. This patch resolves this issue supporting paths for both EXT and ARB variants.

This also uses the ARB query for the occlusion query, with support for the 64bit queries where available.
