### PR TITLE
qapitrace: issue #218 crashes on glPopDebugGroup

### DIFF
--- a/gui/traceloader.cpp
+++ b/gui/traceloader.cpp
@@ -449,15 +449,16 @@ TraceLoader::fetchFrameContents(ApiTraceFrame *currentFrame)
                 allCalls[parsedCalls++] = apiCall;
                 if (groups.count() == 0) {
                     topLevelItems.append(apiCall);
-                }
-                if (!groups.isEmpty()) {
+                } else {
                     groups.top()->addChild(apiCall);
                 }
                 if (call->flags & trace::CALL_FLAG_MARKER_PUSH) {
                     groups.push(apiCall);
                 } else if (call->flags & trace::CALL_FLAG_MARKER_POP) {
-                    groups.top()->finishedAddingChildren();
-                    groups.pop();
+                    if (groups.count()) {
+                        groups.top()->finishedAddingChildren();
+                        groups.pop();
+                    }
                 }
                 if (apiCall->hasBinaryData()) {
                     QByteArray data =


### PR DESCRIPTION
This commit fixes #218 

Problem:
dereferencing a NULL pointer.

Reason:
As mentioned in the issue description, a glPushDebugGroup and
glPopDebugGroup pair were in two different frames. The
TraceLoader:fetchFrameContents() function assumes they're in the
same frame and starts a new "groups" stack for each frame fetch.
On encountering a CALL_FLAG_MARKER_POP call, does

```
groups.top()->finishedAddingChildren();
```

when in fact groups is empty and is dereferencing a NULL pointer.

In the other sample trace (sample-effects.trace) all glPush/Pop pairs
were in the same frame but one frame had an extra glPopDebugGroup
causing the same error.

Fix:
Add a groups.count() check before dereferencing groups.top()

Caveats:
Any unpaired glPopDebugGroup calls will be listed as regular gl calls.
Any unpaired glPushDebugGroup calls will end with the frame end.

Tested both sample crash traces; they no longer crash.
(apitrace-tests doesn't apply for testing this fix)

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
