### PR TITLE
qapitrace: minor optimization to findCallIndex()

### DIFF
--- a/gui/traceloader.cpp
+++ b/gui/traceloader.cpp
@@ -520,6 +520,7 @@ void TraceLoader::findCallIndex(int index)
     for (itr = calls.constBegin(); itr != calls.constEnd(); ++itr) {
         if ((*itr)->index() == index) {
             call = *itr;
+            break;
         }
     }
     if (call) {


### PR DESCRIPTION
Function continues searching after target call index is found

Noticed that TraceLoader::findCallIndex(int index) continues looking
through the entire list of calls after target call index is found

Fix:
Add a 'break;' after call is found.

Testing:
No real difference in time. Rough test /w 180MB file:

$ ll warzone2100.trace
-rw-r--r-- 1 lllove lllove 180664407 Feb 14 09:58 warzone2100.trace

Selecting the first call (7797067) of 10362 calls in frame 1767

Without change:
$ time qapitrace warzone2100.trace 7797067
real    0m13.495s
user    0m12.592s
sys 0m0.072s

With change:
$ time ../../src/qapitrace warzone2100.trace 7797067
real    0m13.275s
user    0m12.476s
sys 0m0.092s

(time based on my reaction time to kill qapitrace when frame 1767
 is expanded to call# 7797067)

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
