### PR TITLE
qapitrace: arrow-key selected Call is obstructed

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -127,6 +127,7 @@ void MainWindow::callItemSelected(const QModelIndex &index)
             .arg(call->index()));
         m_ui.detailsWebView->setHtml(call->toHtml());
         m_ui.detailsDock->show();
+        m_ui.callView->scrollTo(index);
         if (call->hasBinaryData()) {
             QByteArray data =
                 call->arguments()[call->binaryDataIndex()].toByteArray();


### PR DESCRIPTION
If the Frame at the bottom of the current view is expanded and
the down arrow-key is used to select the first Call in the Frame
then the Details View window that pops up obstructs the Call.

NOTE: If the first Call is instead selected with a mouse-click
      then the Call appropriately scrolls into view

Not a big deal but disconcerting.

DIRECTIONS
1) Select and expand the Frame at the bottom of the current view
2) Use the down arrow-key to move to the first Call in the Frame

FIX
In selection callback for Call (MainWindow::callItemSelected) add
    m_ui.callView->scrollTo(index)
after the Details View window is shown

TESTING
Manual testing.

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
