### PR TITLE
qapitrace: Highlight color too dark to read row text

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -670,6 +670,17 @@ void MainWindow::fillStateForFrame()
     m_ui.stateDock->show();
 }
 
+bool MainWindow::setHighlightColor(QWidget *widget, QColor hiliteColor)
+{
+    bool bIsValid = hiliteColor.isValid();
+    if (bIsValid) {
+        QPalette palette = widget->palette();
+        palette.setColor(QPalette::Highlight, hiliteColor);
+        widget->setPalette(palette);
+    }
+    return bIsValid;
+}
+
 void MainWindow::showSettings()
 {
     SettingsDialog dialog;
@@ -773,6 +784,7 @@ void MainWindow::initObjects()
     m_ui.callView->header()->swapSections(0, 1);
     m_ui.callView->setColumnWidth(1, 42);
     m_ui.callView->setContextMenuPolicy(Qt::CustomContextMenu);
+    setHighlightColor(m_ui.callView, QColor(sDefaultHighlightColor));
 
     m_progressBar = new QProgressBar();
     m_progressBar->setRange(0, 100);

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -33,6 +33,8 @@ class TrimProcess;
 class ProfileDialog;
 class VertexDataInterpreter;
 
+static const QString sDefaultHighlightColor("lightsteelblue");
+
 namespace trace { struct Profile; }
 
 class MainWindow : public QMainWindow
@@ -105,6 +107,7 @@ private:
     void replayTrace(bool dumpState, bool dumpThumbnails);
     void trimEvent();
     void fillStateForFrame();
+    bool setHighlightColor(QWidget*, QColor hicolor=Qt::gray);
 
     /* there's a difference between selected frame/call and
      * current call/frame. the former implies actual selection


### PR DESCRIPTION
PROBLEM
On my debian system, the default highlight color is dark blue against
black text and is virtually unreadable (see attached)
![qapitrace-highlight-too-dark](https://f.cloud.github.com/assets/6090880/2527898/f08474e0-b509-11e3-8ff2-b35a7cd3543a.png)

% uname -a
Linux gok 3.13-1-amd64 #1 SMP Debian 3.13.5-1 (2014-03-04) x86_64 GNU/Linux

SOLUTION
On initialization, set treeview highlight color to a lighter shade.
![qapitrace-modified-highlight-color](https://f.cloud.github.com/assets/6090880/2527927/37314882-b50a-11e3-8935-f82695690244.png)

COMMENTS
This could be extended as a command-line option or added to the Options
dialog window to allow the user to select highlight a color. A gradient
colored highlight gives a nice look also (image attached).
![qapitrace-highlight-2014-03-14](https://f.cloud.github.com/assets/6090880/2426309/86c359bc-abc3-11e3-9602-433f4a7042fa.png)

CAVEAT
The highlight color may be ignored on debian systems that haven't been
recently updated. I do a weekly software update on my system and a few
weeks ago when I tried changing the hightlight color it was ignored. Now
it works so it may be ignored on systems that havent' been updated
recently.
The reason may be because Qt/GTK don't (didn't) use Xrdb as explained
here
http://stackoverflow.com/questions/16254895/x11-how-to-get-system-colors#tab-top

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
