### PR TITLE
qapitrace: merge duplicate logic in TraceLoader

### DIFF
--- a/gui/traceloader.h
+++ b/gui/traceloader.h
@@ -9,6 +9,7 @@
 #include <QObject>
 #include <QList>
 #include <QMap>
+#include <QStack>
 
 class TraceLoader : public QObject
 {
@@ -23,6 +24,30 @@ public:
 
     ApiTraceEnumSignature *enumSignature(unsigned id);
     void addEnumSignature(unsigned id, ApiTraceEnumSignature *signature);
+
+private:
+    class FrameContents
+    {
+    public:
+        FrameContents(int numOfCalls=0);
+
+        bool load(TraceLoader *loader, ApiTraceFrame* frame,
+                  QHash<QString, QUrl> helpHash, trace::Parser &parser);
+        void reset();
+        int  topLevelCount()      const;
+        int  allCallsCount()      const;
+        QVector<ApiTraceCall*> topLevelCalls() const;
+        QVector<ApiTraceCall*> allCalls()      const;
+        quint64 binaryDataSize()  const;
+        bool isEmpty();
+
+    private:
+        QStack <ApiTraceCall*> m_groups;
+        QVector<ApiTraceCall*> m_topLevelItems;
+        QVector<ApiTraceCall*> m_allCalls;
+        quint64 m_binaryDataSize;
+        int     m_parsedCalls;
+    };
 
 public slots:
     void loadTrace(const QString &filename);


### PR DESCRIPTION
Note: This patch can supercede pull requests #228 and #240

Problem:
Two member functions of TraceLoader (parseTrace and fetchFrameContents)
are using duplicate functionality to retrieve a Frame's Call contents.
Both functions had defects in their logic. Any changes in regard to that
logic has to be made in both functions.

Examples:
Recently a patch for fetchFrameContents (pull request #228) was also
found to be needed for parseTrace.

Another recent patch (pull request #240) was because a slight logic
difference between the two causes parseTrace to fail in loading traces
with groups

Solution:
This patch combines the logic into a separate object that both member
functions can access to retrieve the data.

Implementation details:
The main difference between the two in combining the functionality is
that the Calls list is pre-allocated in the case of fetchFrameContents
but not so for the parseTrace case. (fetchFrameContents is allocated
because the frames have been pre-scanned and it's known how many calls
the frame contains whereas parseTrace loads the entire trace on
initialization with each Frame's Calls added on the fly.)

That distinction in the new object is handled by the constructor default
input argument "numOfCalls" and used as a flag for those variances.

Testing:
Tested with both trace files from issue #218 and with both parseTrace
and scanTrace (tied to fetchFrameContents); debug_khr (mutli-level
groups); and non-group trace, glxgears

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
