### PR TITLE
qapitrace: fix a string search FIXME request

### DIFF
--- a/gui/traceloader.cpp
+++ b/gui/traceloader.cpp
@@ -406,14 +406,11 @@ bool TraceLoader::callContains(trace::Call *call,
                                const QString &str,
                                Qt::CaseSensitivity sensitivity)
 {
-    /*
-     * FIXME: do string comparison directly on trace::Call
-     */
-    ApiTraceCall *apiCall = apiCallFromTraceCall(call, m_helpHash,
-                                                 0, 0, this);
-    bool result = apiCall->contains(str, sensitivity);
-    delete apiCall;
-    return result;
+    if (sensitivity == Qt::CaseSensitive) {
+        return (bool) strstr (call->name(), str.toAscii().data());
+    } else {
+        return (bool) strcasestr (call->name(), str.toAscii().data());
+    }
 }
 
 QVector<ApiTraceCall*>


### PR DESCRIPTION
Issue:
TraceLoader::callContains() had the comment

```
FIXME: do string comparison directly on trace::Call
```

The existing code was doing a new/delete of an ApiTraceCall object
in order to use its interface for a string search.

Resolution:
Assuming what was meant by a direct comparison is using C's
strstr/strcasestr functions, that is what's implemented in
this patch.

An alternative would be to use a QString object's API

```
return (QString(call->name()).contains(str, sensitivity));
```

but no timing was done on that.

Testing:
This code is only hit when searching in unloaded frames. Frame 0 is
pre-loaded so this code isn't exercised until the string is searched
in another frame.

Testing was done with case-sensitive and case-insensitive searches.
Compared against existing previous code for same results.

Timing:
Did two searches each of old and new code using "gettimeofday" timing
in TraceLoader::search with the following results searching for a
nonsense string (to search entire trace), case-insensitive:

<pre>
warzone2100 180MB (180664407)     old         new
                                  ------      -------
Total time in seconds:            89.047      16.3269
                                  88.9844     16.3358
</pre>


Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
