### PR TITLE
apitrace: Parse comma-separated list in commandline

### DIFF
--- a/common/trace_callset.cpp
+++ b/common/trace_callset.cpp
@@ -27,10 +27,9 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#include <limits>
 #include <fstream>
 #include <iostream>
-#include <string>
+#include <sstream>
 
 #include <trace_callset.hpp>
 
@@ -233,12 +232,22 @@ CallSet::merge(const char *string)
         firstmerge = false;
     }
 
-    if (*string == '@') {
-        FileCallSetParser parser(*this, &string[1]);
-        parser.parse();
-    } else {
-        StringCallSetParser parser(*this, string);
-        parser.parse();
+    /*
+     * Parse a comma-separated list of files or ranges
+     */
+    std::stringstream calls_arg(string);
+    std::string token;
+    const char *str;
+
+    while (std::getline(calls_arg, token, ',')) {
+        str = token.c_str();
+        if (str[0] == '@') {
+            FileCallSetParser parser(*this, &str[1]);
+            parser.parse();
+        } else {
+            StringCallSetParser parser(*this, str);
+            parser.parse();
+        }
     }
 }
 


### PR DESCRIPTION
<b>Description</b>
In the command line argument list for --calls (and --frames), allow a
single comma-separated mixed list of files and/or ranges instead of
multiple option calls for each one.

E.g., instead of

    apitrace trim --calls=@foo.calls --calls=0-20 --calls=100-150 \
                  --calls=@goo.calls --calls=...

allow

    apitrace trim --calls=@foo.calls,0-20,100-150,@goo.calls,..

which is merged into one callset list of their union.

<b>Details</b>
CallSet class member function CallSet::merge() parses for comma-delimited
tokens in the input option string and adds them to the CallSet list

<b>Testing</b>
Tests have been added to the apitrace-tests repository.

Testing in apitrace-tests done on both
Linux: 3.14-1-amd64 #1 SMP Debian 3.14.4-1 (2014-05-13) x86_64 GNU/Linux
Windows 7: MINGW32_NT-6.1 1.0.12(0.46/3/2) 2012-07-05 14:56 i686 unknown

100% passing.

Signed-off-by: Lawrence L Love <lawrencex.l.love@intel.com>