### PR TITLE
add simple support to export buffers to disk.

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -71,6 +71,7 @@ private slots:
     void showSurfacesMenu(const QPoint &pos);
     void showSelectedSurface();
     void saveSelectedSurface();
+    void exportBufferData();
     void slotGoTo();
     void slotJumpTo(int callNum);
     void createdTrace(const QString &path);

--- a/gui/ui/mainwindow.ui
+++ b/gui/ui/mainwindow.ui
@@ -398,6 +398,26 @@
         </widget>
        </item>
        <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="bufferExportButton">
+         <property name="text">
+          <string>Export</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
This adds a new "export" button to the vertex data interpreter widget.  This button simply exports to a file named tracefilename_call_#_buffer.raw

( implements feature #266 )
