### PR TITLE
qapitrace: Don't crash when dragging outside image in viewer

### DIFF
--- a/gui/imageviewer.cpp
+++ b/gui/imageviewer.cpp
@@ -126,6 +126,10 @@ QString createPixelLabel(image::Image *img, int x, int y)
     unsigned char *pixelLocation = 0;
     T *pixel;
 
+    if (x < 0 || y < 0 || x >= img->width || y >= img->height) {
+        return QString::fromLatin1("(Out of bounds)");
+    }
+
     pixelLocation = img->pixels + img->stride() * y;
     pixelLocation += x * img->bytesPerPixel;
     pixel = ((T*)pixelLocation);


### PR DESCRIPTION
When the mouse is down, movement events continue to be delivered
to the PixelWidget even when outside the widget.

In these cases, we reference memory outside the image buffer. This
usually worked out OK, as the nearby addresses were usually mapped.
However, the x value gets converted to unsigned before being added, so
very small negative x values end up offsetting the pixel pointer by many
gigabytes, which is almost certainly not accessible, and explodes.

Instead, if the position is outside the image, safely return a fixed
(out of bounds) message.

Fixes #269.

Signed-off-by: Chris Forbes chrisf@ijw.co.nz
