### PR TITLE
glhelpers: fix glprofile.cpp compilation on VS2012

### DIFF
--- a/helpers/glprofile.hpp
+++ b/helpers/glprofile.hpp
@@ -35,7 +35,7 @@
 
 #include <ostream>
 #include <set>
-
+#include <string>
 
 namespace glprofile {
 


### PR DESCRIPTION
std::string was forward declarated only, so I have
include <string>

Without the fix, you got template compilation error at least for x64 plateform.