### PR TITLE
specs: Ensure IDirectDrawSurface2 and IDirectDrawSurface3 are wrapped

### DIFF
--- a/specs/ddraw.py
+++ b/specs/ddraw.py
@@ -1467,7 +1467,7 @@ IDirectDrawSurface2.methods += [
     StdMethod(DDRESULT, "UpdateOverlay", [(LPRECT, "lpSrcRect"), (LPDIRECTDRAWSURFACE2, "lpDDDestSurface"), (LPRECT, "lpDestRect"), (DirectDrawSurfaceOverlayFlags, "dwFlags"), (LPDDOVERLAYFX, "lpDDOverlayFx")]),
     StdMethod(DDRESULT, "UpdateOverlayDisplay", [(DWORD, "dwFlags")]),
     StdMethod(DDRESULT, "UpdateOverlayZOrder", [(DirectDrawUpdateOverlayZOrderFlags, "dwFlags"), (LPDIRECTDRAWSURFACE2, "lpDDSReference")]),
-    StdMethod(DDRESULT, "GetDDInterface", [Out(LPUNKNOWN, "lplpDD")]),
+    StdMethod(DDRESULT, "GetDDInterface", [Out(Pointer(LPVOID), "lplpDD")]),
     StdMethod(DDRESULT, "PageLock", [(DWORD, "dwFlags")]),
     StdMethod(DDRESULT, "PageUnlock", [(DWORD, "dwFlags")]),
 ]
@@ -1506,7 +1506,7 @@ IDirectDrawSurface3.methods += [
     StdMethod(DDRESULT, "UpdateOverlay", [(LPRECT, "lpSrcRect"), (LPDIRECTDRAWSURFACE3, "lpDDDestSurface"), (LPRECT, "lpDestRect"), (DirectDrawSurfaceOverlayFlags, "dwFlags"), (LPDDOVERLAYFX, "lpDDOverlayFx")]),
     StdMethod(DDRESULT, "UpdateOverlayDisplay", [(DWORD, "dwFlags")]),
     StdMethod(DDRESULT, "UpdateOverlayZOrder", [(DirectDrawUpdateOverlayZOrderFlags, "dwFlags"), (LPDIRECTDRAWSURFACE3, "lpDDSReference")]),
-    StdMethod(DDRESULT, "GetDDInterface", [Out(LPUNKNOWN, "lplpDD")]),
+    StdMethod(DDRESULT, "GetDDInterface", [Out(Pointer(LPVOID), "lplpDD")]),
     StdMethod(DDRESULT, "PageLock", [(DWORD, "dwFlags")]),
     StdMethod(DDRESULT, "PageUnlock", [(DWORD, "dwFlags")]),
     StdMethod(DDRESULT, "SetSurfaceDesc", [(LPDDSURFACEDESC, "lpDDSD"), (DWORD, "dwFlags")]),
@@ -1661,3 +1661,8 @@ ddraw.addFunctions([
     # TODO: SetAppCompatData
 ])
 
+# Add otherwise unreferenced interfaces
+ddraw.addInterfaces([
+    IDirectDrawSurface2,
+    IDirectDrawSurface3,
+])


### PR DESCRIPTION
Without this commit, surface->QueryInterface(IID_IDirectDrawSurface2) and surface->QueryInterface(IID_IDirectDrawSurface3) return an unwrapped interface.