### PR TITLE
os: fix getConfigDir on Android

### DIFF
--- a/common/os_posix.cpp
+++ b/common/os_posix.cpp
@@ -33,6 +33,8 @@
 #include <unistd.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <pwd.h>
 #include <fcntl.h>
 #include <signal.h>
 
@@ -150,10 +152,17 @@ getConfigDir(void)
         path = configHomeDir;
     } else {
         const char *homeDir = getenv("HOME");
+        if (!homeDir) {
+            struct passwd *user = getpwuid(getuid());
+            if (user != NULL)
+                homeDir = user->pw_dir;
+        }
         assert(homeDir);
         if (homeDir) {
             path = homeDir;
+#if !defined(ANDROID)
             path.join(".config");
+#endif
         }
     }
 #endif


### PR DESCRIPTION
getenv("HOME") always return null on android and the homeDir variable
assertion will always abort the program. This change makes it look for
the home directory in the users password database if the directory is
not in the HOME environment variable.

Also, don't append the ".config" directory for android, the settings are
usually stored in a folder under the /data directory.