### PR TITLE
Add parallel snapshotting in retrace

### DIFF
--- a/common/os_thread.hpp
+++ b/common/os_thread.hpp
@@ -421,11 +421,16 @@ namespace os {
         ~thread() {
         }
 
-        template< class Function, class Arg >
-        explicit thread( Function &f, Arg arg ) {
-            typedef CallbackParam< Function, Arg > Param;
-            Param *pParam = new Param(f, arg);
-            _native_handle = _create(pParam);
+        // XXX
+        static unsigned int
+        hardware_concurrency() {
+            return 4;
+        }
+
+        template< class Function, class... Args >
+        explicit thread( Function &&f, Args&&... args ) {
+            auto callback = std::bind(std::forward<Function>(f), std::forward<Args>(args)...);
+            _native_handle = _create(&callback);
         }
 
         inline thread &
@@ -451,23 +456,6 @@ namespace os {
     private:
         native_handle_type _native_handle;
 
-        template< typename Function, typename Arg >
-        struct CallbackParam {
-            Function &f;
-            Arg arg;
-
-            inline
-            CallbackParam(Function &_f, Arg _arg) :
-                f(_f),
-                arg(_arg)
-            {}
-
-            inline void
-            operator () (void) {
-                f(arg);
-            }
-        };
-
         template< typename Param >
         static
 #ifdef _WIN32
@@ -484,13 +472,13 @@ namespace os {
 
         template< typename Param >
         static inline native_handle_type
-        _create(Param *pParam) {
+        _create(Param *function) {
 #ifdef _WIN32
-            uintptr_t handle =_beginthreadex(NULL, 0, &_callback<Param>, static_cast<void *>(pParam), 0, NULL);
+            uintptr_t handle =_beginthreadex(NULL, 0, &_callback<Param>, function, 0, NULL);
             return reinterpret_cast<HANDLE>(handle);
 #else
             pthread_t t;
-            pthread_create(&t, NULL, &_callback<Param>, static_cast<void *>(pParam));
+            pthread_create(&t, NULL, &_callback<Param>, function);
             return t;
 #endif
         }

--- a/common/thread_pool.hpp
+++ b/common/thread_pool.hpp
@@ -1,0 +1,116 @@
+/**************************************************************************
+ *
+ * Copyright (c) 2012 Jakob Progsch, Václav Zeman
+ * Copyright (c) 2015 Emmanuel Gil Peyrot, Collabora Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ *    1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ *    2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ *    3. This notice may not be removed or altered from any source
+ *    distribution.
+ *
+ **************************************************************************/
+
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+#include <queue>
+#include <thread>
+#include <mutex>
+#include <functional>
+#include <condition_variable>
+#include <stdexcept>
+
+
+class ThreadPool {
+public:
+    ThreadPool(size_t);
+    template<class F, class... Args>
+    void enqueue(F&& f, Args&&... args);
+    ~ThreadPool();
+private:
+    // need to keep track of threads so we can join them
+    std::vector<std::thread> workers;
+    // the task queue
+    std::queue<std::function<void()>> tasks;
+
+    // synchronization
+    std::mutex queue_mutex;
+    std::condition_variable condition;
+    bool stop;
+};
+
+
+// the constructor just launches some amount of workers
+inline ThreadPool::ThreadPool(size_t threads)
+    :   stop(false)
+{
+    for(size_t i = 0;i<threads;++i)
+        workers.emplace_back(
+            [this]
+            {
+                for(;;)
+                {
+                    std::function<void()> task;
+
+                    {
+                        std::unique_lock<std::mutex> lock(this->queue_mutex);
+                        this->condition.wait(lock,
+                            [this]{ return this->stop || !this->tasks.empty(); });
+                        if(this->stop && this->tasks.empty())
+                            return;
+                        task = std::move(this->tasks.front());
+                        this->tasks.pop();
+                    }
+
+                    task();
+                }
+            }
+        );
+}
+
+// add new work item to the pool
+template<class F, class... Args>
+void ThreadPool::enqueue(F&& f, Args&&... args)
+{
+    auto task = std::bind(std::forward<F>(f), std::forward<Args>(args)...);
+
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+
+        // don't allow enqueueing after stopping the pool
+        if(stop)
+            throw std::runtime_error("enqueue on stopped ThreadPool");
+
+        tasks.emplace(task);
+    }
+    condition.notify_one();
+}
+
+// the destructor joins all threads
+inline ThreadPool::~ThreadPool()
+{
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+        stop = true;
+    }
+    condition.notify_all();
+    for(std::thread &worker: workers)
+        worker.join();
+}

--- a/retrace/CMakeLists.txt
+++ b/retrace/CMakeLists.txt
@@ -38,6 +38,7 @@ if (WIN32)
 endif ()
 
 add_library (retrace_common STATIC
+    relay_race.cpp
     retrace.cpp
     retrace_main.cpp
     retrace_stdc.cpp

--- a/retrace/relay_race.cpp
+++ b/retrace/relay_race.cpp
@@ -1,0 +1,324 @@
+/**************************************************************************
+ *
+ * Copyright 2011 Jose Fonseca
+ * Copyright (C) 2013 Intel Corporation. All rights reversed.
+ * Author: Shuang He <shuang.he@intel.com>
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ **************************************************************************/
+
+
+#include <cassert>
+#include <iostream>
+
+#include "os_thread.hpp"
+#include "relay_race.hpp"
+#include "retrace.hpp"
+#include "trace_model.hpp"
+#include "trace_parser.hpp"
+
+
+namespace retrace {
+void retraceCall(trace::Call *call);
+void flushRendering();
+}
+
+static trace::ParseBookmark lastFrameStart;
+
+
+/**
+ * Each runner is a thread.
+ *
+ * The fore runner doesn't have its own thread, but instead uses the thread
+ * where the race started.
+ */
+class RelayRunner
+{
+private:
+    friend class RelayRace;
+
+    RelayRace *race;
+
+    unsigned leg;
+    
+    os::mutex mutex;
+    os::condition_variable wake_cond;
+
+    /**
+     * There are protected by the mutex.
+     */
+    bool finished;
+    trace::Call *baton;
+
+    os::thread thread;
+
+    static void
+    runnerThread(RelayRunner *_this);
+
+public:
+    RelayRunner(RelayRace *race, unsigned _leg) :
+        race(race),
+        leg(_leg),
+        finished(false),
+        baton(0)
+    {
+        /* The fore runner does not need a new thread */
+        if (leg) {
+            thread = os::thread(runnerThread, this);
+        }
+    }
+
+    ~RelayRunner() {
+        if (thread.joinable()) {
+            thread.join();
+        }
+    }
+
+    /**
+     * Thread main loop.
+     */
+    void
+    runRace(void) {
+        os::unique_lock<os::mutex> lock(mutex);
+
+        while (1) {
+            while (!finished && !baton) {
+                wake_cond.wait(lock);
+            }
+
+            if (finished) {
+                break;
+            }
+
+            assert(baton);
+            trace::Call *call = baton;
+            baton = 0;
+
+            runLeg(call);
+        }
+
+        if (0) std::cerr << "leg " << leg << " actually finishing\n";
+
+        if (leg == 0) {
+            race->stopRunners();
+        }
+    }
+
+    /**
+     * Interpret successive calls.
+     */
+    void
+    runLeg(trace::Call *call) {
+
+        /* Consume successive calls for this thread. */
+        do {
+            bool callEndsFrame = false;
+            static trace::ParseBookmark frameStart;
+
+            assert(call);
+            assert(call->thread_id == leg);
+
+            if (retrace::loopCount && call->flags & trace::CALL_FLAG_END_FRAME) {
+                callEndsFrame = true;
+                retrace::parser.getBookmark(frameStart);
+            }
+
+            retrace::retraceCall(call);
+            delete call;
+            call = retrace::parser.parse_call();
+
+            /* Restart last frame if looping is requested. */
+            if (retrace::loopCount) {
+                if (!call) {
+                    retrace::parser.setBookmark(lastFrameStart);
+                    call = retrace::parser.parse_call();
+                    if (retrace::loopCount > 0) {
+                        --retrace::loopCount;
+                    }
+                } else if (callEndsFrame) {
+                    lastFrameStart = frameStart;
+                }
+            }
+
+        } while (call && call->thread_id == leg);
+
+        if (call) {
+            /* Pass the baton */
+            assert(call->thread_id != leg);
+            retrace::flushRendering();
+            race->passBaton(call);
+        } else {
+            /* Reached the finish line */
+            if (0) std::cerr << "finished on leg " << leg << "\n";
+            if (leg) {
+                /* Notify the fore runner */
+                race->finishLine();
+            } else {
+                /* We are the fore runner */
+                finished = true;
+            }
+        }
+    }
+
+    /**
+     * Called by other threads when relinquishing the baton.
+     */
+    void
+    receiveBaton(trace::Call *call) {
+        assert (call->thread_id == leg);
+
+        mutex.lock();
+        baton = call;
+        mutex.unlock();
+
+        wake_cond.notify_one();
+    }
+
+    /**
+     * Called by the fore runner when the race is over.
+     */
+    void
+    finishRace() {
+        if (0) std::cerr << "notify finish to leg " << leg << "\n";
+
+        mutex.lock();
+        finished = true;
+        mutex.unlock();
+
+        wake_cond.notify_one();
+    }
+};
+
+
+void
+RelayRunner::runnerThread(RelayRunner *_this) {
+    _this->runRace();
+}
+
+
+RelayRace::RelayRace() {
+    runners.push_back(new RelayRunner(this, 0));
+}
+
+
+RelayRace::~RelayRace() {
+    assert(runners.size() >= 1);
+    std::vector<RelayRunner*>::const_iterator it;
+    for (it = runners.begin(); it != runners.end(); ++it) {
+        RelayRunner* runner = *it;
+        if (runner) {
+            delete runner;
+        }
+    }
+}
+
+
+/**
+ * Get (or instantiate) a runner for the specified leg.
+ */
+RelayRunner *
+RelayRace::getRunner(unsigned leg) {
+    RelayRunner *runner;
+
+    if (leg >= runners.size()) {
+        runners.resize(leg + 1);
+        runner = 0;
+    } else {
+        runner = runners[leg];
+    }
+    if (!runner) {
+        runner = new RelayRunner(this, leg);
+        runners[leg] = runner;
+    }
+    return runner;
+}
+
+
+/**
+ * Start the race.
+ */
+void
+RelayRace::run(void) {
+    trace::Call *call;
+    call = retrace::parser.parse_call();
+    if (!call) {
+        /* Nothing to do */
+        return;
+    }
+
+    /* If the user wants to loop we need to get a bookmark target. We
+     * usually get this after replaying a call that ends a frame, but
+     * for a trace that has only one frame we need to get it at the
+     * beginning. */
+    if (retrace::loopCount) {
+        retrace::parser.getBookmark(lastFrameStart);
+    }
+
+    RelayRunner *foreRunner = getForeRunner();
+    if (call->thread_id == 0) {
+        /* We are the forerunner thread, so no need to pass baton */
+        foreRunner->baton = call;
+    } else {
+        passBaton(call);
+    }
+
+    /* Start the forerunner thread */
+    foreRunner->runRace();
+}
+
+
+/**
+ * Pass the baton (i.e., the call) to the appropriate thread.
+ */
+void
+RelayRace::passBaton(trace::Call *call) {
+    if (0) std::cerr << "switching to thread " << call->thread_id << "\n";
+    RelayRunner *runner = getRunner(call->thread_id);
+    runner->receiveBaton(call);
+}
+
+
+/**
+ * Called when a runner other than the forerunner reaches the finish line.
+ *
+ * Only the fore runner can finish the race, so inform him that the race is
+ * finished.
+ */
+void
+RelayRace::finishLine(void) {
+    RelayRunner *foreRunner = getForeRunner();
+    foreRunner->finishRace();
+}
+
+
+/**
+ * Called by the fore runner after finish line to stop all other runners.
+ */
+void
+RelayRace::stopRunners(void) {
+    std::vector<RelayRunner*>::const_iterator it;
+    for (it = runners.begin() + 1; it != runners.end(); ++it) {
+        RelayRunner* runner = *it;
+        if (runner) {
+            runner->finishRace();
+        }
+    }
+}

--- a/retrace/relay_race.hpp
+++ b/retrace/relay_race.hpp
@@ -1,0 +1,76 @@
+/**************************************************************************
+ *
+ * Copyright 2011 Jose Fonseca
+ * Copyright (C) 2013 Intel Corporation. All rights reversed.
+ * Author: Shuang He <shuang.he@intel.com>
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ **************************************************************************/
+
+
+#include <vector>
+
+
+namespace trace {
+    class Call;
+}
+
+
+class RelayRunner;
+
+
+/**
+ * Implement multi-threading by mimicking a relay race.
+ */
+class RelayRace
+{
+private:
+    /**
+     * Runners indexed by the leg they run (i.e, the thread_ids from the
+     * trace).
+     */
+    std::vector<RelayRunner*> runners;
+
+public:
+    RelayRace();
+
+    ~RelayRace();
+
+    RelayRunner *
+    getRunner(unsigned leg);
+
+    inline RelayRunner *
+    getForeRunner() {
+        return getRunner(0);
+    }
+
+    void
+    run(void);
+
+    void
+    passBaton(trace::Call *call);
+
+    void
+    finishLine();
+
+    void
+    stopRunners();
+};

--- a/retrace/retrace.hpp
+++ b/retrace/retrace.hpp
@@ -152,6 +152,7 @@ extern unsigned samples;
 
 extern unsigned frameNo;
 extern unsigned callNo;
+extern int loopCount;
 
 extern trace::DumpFlags dumpFlags;
 

--- a/retrace/retrace_main.cpp
+++ b/retrace/retrace_main.cpp
@@ -571,7 +571,7 @@ int main(int argc, char **argv)
 #endif
 
     if (snapshotThreaded) {
-        snapshotter = new ThreadedSnapshotter(std::thread::hardware_concurrency());
+        snapshotter = new ThreadedSnapshotter(os::thread::hardware_concurrency());
     } else {
         snapshotter = new Snapshotter();
     }

--- a/retrace/threaded_snapshot.hpp
+++ b/retrace/threaded_snapshot.hpp
@@ -1,0 +1,91 @@
+/**************************************************************************
+ *
+ * Copyright (C) 2015 Collabora Ltd.
+ * Author: Emmanuel Gil Peyrot <emmanuel.peyrot@collabora.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ **************************************************************************/
+
+#pragma once
+
+#include <iostream>
+
+#include "image.hpp"
+#include "os_string.hpp"
+#include "thread_pool.hpp"
+#include "retrace.hpp"
+
+namespace image {
+    class Image;
+}
+
+namespace retrace {
+    extern int verbosity;
+}
+
+
+static void
+actuallyWritePNG(const os::String& filename, image::Image *image) {
+    // Alpha channel often has bogus data, so strip it when writing
+    // PNG images to disk to simplify visualization.
+    bool strip_alpha = true;
+
+    if (image->writePNG(filename, strip_alpha) &&
+        retrace::verbosity >= 0) {
+        std::cout << "Wrote " << filename << "\n";
+    }
+
+    delete image;
+}
+
+
+/**
+ * Write one snapshot at a time, blocking until it is finished.
+ */
+class Snapshotter
+{
+public:
+    Snapshotter() {}
+    virtual ~Snapshotter() {}
+
+    virtual void
+    writePNG(const os::String& filename, image::Image *image) {
+        actuallyWritePNG(filename, image);
+    }
+};
+
+
+/**
+ * Write nb_thread snapshots at a time, to better use the available CPU resources.
+ */
+class ThreadedSnapshotter : public Snapshotter
+{
+private:
+    ThreadPool pool;
+    ThreadedSnapshotter() = delete;
+
+public:
+    ThreadedSnapshotter(size_t nb_threads) : pool(nb_threads) {}
+
+    virtual void
+    writePNG(const os::String& filename, image::Image *image) override {
+        pool.enqueue(actuallyWritePNG, filename, image);
+    }
+};


### PR DESCRIPTION
The first commit is just a cleanup.

The second one adds a new option, -t/--snapshot-threaded, enabling threaded encoding of the snapshots into PNG files, using as many threads as there are cores on the machine.