### PR TITLE
Added images (glBindImage) to displayed surfaces

### DIFF
--- a/gui/apitracecall.cpp
+++ b/gui/apitracecall.cpp
@@ -489,12 +489,6 @@ ApiTraceState::ApiTraceState(const QVariantMap &parsedJson)
             m_textures.append(getTextureFrom(itr.value().toMap(), itr.key()));
         }
     }
-    {
-        QVariantMap images = parsedJson[QLatin1String("images")].toMap();
-        for (itr = images.constBegin(); itr != images.constEnd(); ++itr) {
-            m_images.append(getTextureFrom(itr.value().toMap(), itr.key()));
-        }
-    }
 
     QVariantMap fbos =
         parsedJson[QLatin1String("framebuffer")].toMap();
@@ -551,18 +545,12 @@ bool ApiTraceState::isEmpty() const
     return m_parameters.isEmpty() &&
            m_shaderSources.isEmpty() &&
            m_textures.isEmpty() &&
-           m_images.isEmpty() &&
            m_framebuffers.isEmpty();
 }
 
 const QList<ApiTexture> & ApiTraceState::textures() const
 {
     return m_textures;
-}
-
-const QList<ApiTexture> & ApiTraceState::images() const
-{
-    return m_images;
 }
 
 const QList<ApiFramebuffer> & ApiTraceState::framebuffers() const

--- a/gui/apitracecall.h
+++ b/gui/apitracecall.h
@@ -150,7 +150,6 @@ public:
     const QVariantMap & uniforms() const;
     const QVariantMap & buffers() const;
     const QList<ApiTexture> & textures() const;
-    const QList<ApiTexture> & images() const;
     const QList<ApiFramebuffer> & framebuffers() const;
 
     ApiFramebuffer colorBuffer() const;
@@ -159,7 +158,7 @@ private:
     QMap<QString, QString> m_shaderSources;
     QVariantMap m_uniforms;
     QVariantMap m_buffers;
-    QList<ApiTexture> m_textures, m_images;
+    QList<ApiTexture> m_textures;
     QList<ApiFramebuffer> m_framebuffers;
 };
 Q_DECLARE_METATYPE(ApiTraceState);

--- a/gui/apitracecall.h
+++ b/gui/apitracecall.h
@@ -150,6 +150,7 @@ public:
     const QVariantMap & uniforms() const;
     const QVariantMap & buffers() const;
     const QList<ApiTexture> & textures() const;
+    const QList<ApiTexture> & images() const;
     const QList<ApiFramebuffer> & framebuffers() const;
 
     ApiFramebuffer colorBuffer() const;
@@ -158,7 +159,7 @@ private:
     QMap<QString, QString> m_shaderSources;
     QVariantMap m_uniforms;
     QVariantMap m_buffers;
-    QList<ApiTexture> m_textures;
+    QList<ApiTexture> m_textures, m_images;
     QList<ApiFramebuffer> m_framebuffers;
 };
 Q_DECLARE_METATYPE(ApiTraceState);

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -831,18 +831,15 @@ void MainWindow::fillStateForFrame() {
 
     const QList<ApiTexture> &textures =
         state.textures();
-    const QList<ApiTexture> &images =
-        state.images();
     const QList<ApiFramebuffer> &fbos =
         state.framebuffers();
 
     m_ui.surfacesTreeWidget->clear();
-    if (textures.isEmpty() && images.isEmpty() && fbos.isEmpty()) {
+    if (textures.isEmpty() && fbos.isEmpty()) {
         m_ui.surfacesTab->setDisabled(false);
     } else {
         m_ui.surfacesTreeWidget->setIconSize(QSize(THUMBNAIL_SIZE, THUMBNAIL_SIZE));
         addSurfaces(textures, "Textures");
-        addSurfaces(images, "Images");
         addSurfaces(fbos, "Framebuffers");
         m_ui.surfacesTab->setEnabled(true);
     }

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -766,8 +766,29 @@ static void addSurfaceItem(const ApiSurface &surface,
     item->setData(0, Qt::UserRole, surface.data());
 }
 
-void MainWindow::fillStateForFrame()
-{
+void MainWindow::addSurface(const ApiTexture &image, QTreeWidgetItem *parent) {
+    addSurfaceItem(image, image.label(), parent, m_ui.surfacesTreeWidget);
+}
+
+void MainWindow::addSurface(const ApiFramebuffer &fbo, QTreeWidgetItem *parent) {
+    addSurfaceItem(fbo, fbo.type(), parent, m_ui.surfacesTreeWidget);
+}
+
+template <typename Surface>
+void MainWindow::addSurfaces(const QList<Surface> &surfaces, const char *label) {
+    if (!surfaces.isEmpty()) {
+        QTreeWidgetItem *imageItem = new QTreeWidgetItem(m_ui.surfacesTreeWidget);
+        imageItem->setText(0, tr(label));
+        if (surfaces.count() <= 6) {
+            imageItem->setExpanded(true);
+        }
+        for (int i = 0; i < surfaces.count(); ++i) {
+            addSurface(surfaces[i], imageItem);
+        }
+    }
+}
+
+void MainWindow::fillStateForFrame() {
     if (!m_selectedEvent || !m_selectedEvent->hasState()) {
         return;
     }
@@ -810,46 +831,19 @@ void MainWindow::fillStateForFrame()
 
     const QList<ApiTexture> &textures =
         state.textures();
+    const QList<ApiTexture> &images =
+        state.images();
     const QList<ApiFramebuffer> &fbos =
         state.framebuffers();
 
     m_ui.surfacesTreeWidget->clear();
-    if (textures.isEmpty() && fbos.isEmpty()) {
+    if (textures.isEmpty() && images.isEmpty() && fbos.isEmpty()) {
         m_ui.surfacesTab->setDisabled(false);
     } else {
         m_ui.surfacesTreeWidget->setIconSize(QSize(THUMBNAIL_SIZE, THUMBNAIL_SIZE));
-        if (!textures.isEmpty()) {
-            QTreeWidgetItem *textureItem =
-                new QTreeWidgetItem(m_ui.surfacesTreeWidget);
-            textureItem->setText(0, tr("Textures"));
-            if (textures.count() <= 6) {
-                textureItem->setExpanded(true);
-            }
-
-            for (int i = 0; i < textures.count(); ++i) {
-                const ApiTexture &texture =
-                    textures[i];
-                addSurfaceItem(texture, texture.label(),
-                               textureItem,
-                               m_ui.surfacesTreeWidget);
-            }
-        }
-        if (!fbos.isEmpty()) {
-            QTreeWidgetItem *fboItem =
-                new QTreeWidgetItem(m_ui.surfacesTreeWidget);
-            fboItem->setText(0, tr("Framebuffers"));
-            if (fbos.count() <= 6) {
-                fboItem->setExpanded(true);
-            }
-
-            for (int i = 0; i < fbos.count(); ++i) {
-                const ApiFramebuffer &fbo =
-                    fbos[i];
-                addSurfaceItem(fbo, fbo.type(),
-                               fboItem,
-                               m_ui.surfacesTreeWidget);
-            }
-        }
+        addSurfaces(textures, "Textures");
+        addSurfaces(images, "Images");
+        addSurfaces(fbos, "Framebuffers");
         m_ui.surfacesTab->setEnabled(true);
     }
     m_ui.stateDock->show();

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -126,6 +126,10 @@ private:
 
     void linkLocalAndroidTrace(const QString &localFile, const QString &deviceFile);
     QString linkedAndroidTrace(const QString &localFile);
+    void addSurface(const ApiTexture &image, QTreeWidgetItem *parent);
+    void addSurface(const ApiFramebuffer &image, QTreeWidgetItem *parent);
+    template <typename Surface>
+    void addSurfaces(const QList<Surface> &images, const char *label);
 
 protected:
     virtual void closeEvent(QCloseEvent * event);

--- a/retrace/glstate.cpp
+++ b/retrace/glstate.cpp
@@ -59,6 +59,8 @@ Context::Context(void) {
     ARB_get_program_binary = ext.has("GL_ARB_get_program_binary");
     KHR_debug = !ES && ext.has("GL_KHR_debug");
     EXT_debug_label = ext.has("GL_EXT_debug_label");
+    ARB_direct_state_access = ext.has("GL_ARB_direct_state_access");
+    ARB_shader_image_load_store = ext.has("GL_ARB_shader_image_load_store");
 
     NV_read_depth_stencil = ES && ext.has("GL_NV_read_depth_stencil");
 }

--- a/retrace/glstate.cpp
+++ b/retrace/glstate.cpp
@@ -507,7 +507,6 @@ void dumpCurrentContext(StateWriter &writer)
 
     dumpShadersUniforms(writer, context);
     dumpTextures(writer, context);
-    dumpImages(writer, context);
     dumpFramebuffer(writer, context);
 
 #ifndef NDEBUG

--- a/retrace/glstate.cpp
+++ b/retrace/glstate.cpp
@@ -505,6 +505,7 @@ void dumpCurrentContext(StateWriter &writer)
 
     dumpShadersUniforms(writer, context);
     dumpTextures(writer, context);
+    dumpImages(writer, context);
     dumpFramebuffer(writer, context);
 
 #ifndef NDEBUG

--- a/retrace/glstate_images.cpp
+++ b/retrace/glstate_images.cpp
@@ -667,18 +667,22 @@ dumpTextures(StateWriter &writer, Context &context)
 
     glActiveTexture(active_texture);
 
+    dumpImages(writer, context, false);
+
     writer.endObject();
     writer.endMember(); // textures
 }
 
 void
-dumpImages(StateWriter &writer, Context &context) {
+dumpImages(StateWriter &writer, Context &context, bool inOwnMember) {
     if(!(context.ARB_shader_image_load_store &&
          context.ARB_direct_state_access)) {
         return;
     }
-    writer.beginMember("textures");
-    writer.beginObject();
+    if (inOwnMember) {
+      writer.beginMember("images");
+      writer.beginObject();
+    }
 
     GLint maxImageUnits = 0;
     glGetIntegerv(GL_MAX_IMAGE_UNITS, &maxImageUnits);
@@ -717,8 +721,10 @@ dumpImages(StateWriter &writer, Context &context) {
         }
     }
 
-    writer.endObject();
-    writer.endMember(); // images
+    if (inOwnMember) {
+      writer.endObject();
+      writer.endMember(); // images
+    }
 }
 
 bool

--- a/retrace/glstate_images.cpp
+++ b/retrace/glstate_images.cpp
@@ -673,6 +673,10 @@ dumpTextures(StateWriter &writer, Context &context)
 
 void
 dumpImages(StateWriter &writer, Context &context) {
+    if(!(context.ARB_shader_image_load_store &&
+         context.ARB_direct_state_access)) {
+        return;
+    }
     writer.beginMember("textures");
     writer.beginObject();
 

--- a/retrace/glstate_images.cpp
+++ b/retrace/glstate_images.cpp
@@ -673,7 +673,7 @@ dumpTextures(StateWriter &writer, Context &context)
 
 void
 dumpImages(StateWriter &writer, Context &context) {
-    writer.beginMember("images");
+    writer.beginMember("textures");
     writer.beginObject();
 
     GLint maxImageUnits = 0;

--- a/retrace/glstate_internal.hpp
+++ b/retrace/glstate_internal.hpp
@@ -194,7 +194,7 @@ void dumpShadersUniforms(StateWriter &writer, Context &context);
 
 void dumpTextures(StateWriter &writer, Context &context);
 
-void dumpImages(StateWriter &writer, Context &context);
+void dumpImages(StateWriter &writer, Context &context, bool dumpIntoOwnMember);
 
 void dumpFramebuffer(StateWriter &writer, Context &context);
 

--- a/retrace/glstate_internal.hpp
+++ b/retrace/glstate_internal.hpp
@@ -50,6 +50,8 @@ struct Context
     unsigned KHR_debug:1;
     unsigned EXT_debug_label:1;
     unsigned NV_read_depth_stencil:1;  /* ES only */
+    unsigned ARB_shader_image_load_store:1;
+    unsigned ARB_direct_state_access:1;
 
     Context(void);
 };

--- a/retrace/glstate_internal.hpp
+++ b/retrace/glstate_internal.hpp
@@ -192,6 +192,8 @@ void dumpShadersUniforms(StateWriter &writer, Context &context);
 
 void dumpTextures(StateWriter &writer, Context &context);
 
+void dumpImages(StateWriter &writer, Context &context);
+
 void dumpFramebuffer(StateWriter &writer, Context &context);
 
 


### PR DESCRIPTION
First time contribution so please bear with me.

## Summary ##
I added dumping and display of textures (that are bound via glBindImage) as "Images" under Current State->Surfaces.

## Motivation ##
I am working with many compute shaders and they're more likely to access textures via image units than via samplers.

## TODOs ##
I am sure I made many mistakes that you have to review but it works at least on my local machine.

As glBindImage is from a more recent GL version than vanilla textures it might be necessary to test if it is available before dumping. 
I have no experience in how to do that within apitrace code so I hope for some helpful reviews.

I am relying on GL_ARB_direct_state_access to get the type of the texture from the texture ID. There are less efficient but more compatible ways to do that but I have gone for this one because it has been available for some time now.