### PR TITLE
INSTALL.markdown Linux dependencies

### DIFF
--- a/docs/INSTALL.markdown
+++ b/docs/INSTALL.markdown
@@ -39,8 +39,8 @@ Requirements:
 
 Optional dependencies:
 
+* libqt5webkit5-dev (for `qapitrace`)
 * libprocps (procps development libraries)
-
 * libdwarf
 
 Build as:

--- a/docs/INSTALL.markdown
+++ b/docs/INSTALL.markdown
@@ -32,7 +32,11 @@ self contained, and to prevent symbol collisions when tracing.
 
 # Linux #
 
-Additional optional dependencies:
+Requirements:
+
+* g++
+
+Optional dependencies:
 
 * libprocps (procps development libraries)
 

--- a/docs/INSTALL.markdown
+++ b/docs/INSTALL.markdown
@@ -35,6 +35,7 @@ self contained, and to prevent symbol collisions when tracing.
 Requirements:
 
 * g++
+* libx11-dev
 
 Optional dependencies:
 


### PR DESCRIPTION
g++ and X11 headers are needed for Linux