### PR TITLE
Add CMAKE_INSTALL_DOCDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,7 @@ endif ()
 
 set (SCRIPTS_INSTALL_DIR ${LIB_INSTALL_DIR}/scripts)
 set (WRAPPER_INSTALL_DIR ${LIB_ARCH_INSTALL_DIR}/wrappers)
+set (CMAKE_INSTALL_DOCDIR "${DOC_INSTALL_DIR}" CACHE PATH "Install documentation")
 
 
 ##############################################################################
@@ -540,11 +541,11 @@ install (
         docs/BUGS.markdown
         docs/NEWS.markdown
         docs/USAGE.markdown
-    DESTINATION ${DOC_INSTALL_DIR}
+    DESTINATION ${CMAKE_INSTALL_DOCDIR}
 )
 install (
     FILES LICENSE
-    DESTINATION ${DOC_INSTALL_DIR}
+    DESTINATION ${CMAKE_INSTALL_DOCDIR}
     RENAME LICENSE.txt
 )
 

--- a/thirdparty/snappy/CMakeLists.txt
+++ b/thirdparty/snappy/CMakeLists.txt
@@ -18,6 +18,6 @@ add_convenience_library (snappy_bundled EXCLUDE_FROM_ALL
 
 install (
     FILES COPYING
-    DESTINATION ${DOC_INSTALL_DIR}
+    DESTINATION ${CMAKE_INSTALL_DOCDIR}
     RENAME LICENSE-snappy.txt
 )


### PR DESCRIPTION
Adds a `CMAKE_INSTALL_DOCDIR` option so that the documentation directory can be set during configure.

If compiled with `-DCMAKE_INSTALL_DOCDIR=/usr/doc/$PRGNAM-$VERSION` it will install to the desired path.
```
usr/doc/apitrace-7.1/LICENSE-snappy.txt
usr/doc/apitrace-7.1/LICENSE.txt
usr/doc/apitrace-7.1/USAGE.markdown
usr/doc/apitrace-7.1/NEWS.markdown
usr/doc/apitrace-7.1/BUGS.markdown
usr/doc/apitrace-7.1/README.markdown
```
If compiled without, it will use the default still.
```
usr/share/doc/apitrace/LICENSE-snappy.txt
usr/share/doc/apitrace/LICENSE.txt
usr/share/doc/apitrace/USAGE.markdown
usr/share/doc/apitrace/NEWS.markdown
usr/share/doc/apitrace/BUGS.markdown
usr/share/doc/apitrace/README.markdown
```
And lastly if `cmake -LAH` is used it will report the option.
```
// Install documentation
CMAKE_INSTALL_DOCDIR:PATH=share/doc/apitrace
```

This would fix https://github.com/apitrace/apitrace/issues/411