### PR TITLE
List Shader Storage Buffer Blocks

### DIFF
--- a/gui/apitracecall.cpp
+++ b/gui/apitracecall.cpp
@@ -483,6 +483,9 @@ ApiTraceState::ApiTraceState(const QVariantMap &parsedJson)
 
     m_buffers = parsedJson[QLatin1String("buffers")].toMap();
 
+    m_shaderStorageBufferBlocks =
+        parsedJson[QLatin1String("shaderstoragebufferblocks")].toMap();
+
     {
         QVariantMap textures =
             parsedJson[QLatin1String("textures")].toMap();
@@ -539,6 +542,11 @@ const QVariantMap & ApiTraceState::uniforms() const
 const QVariantMap & ApiTraceState::buffers() const
 {
     return m_buffers;
+}
+
+const QVariantMap &ApiTraceState::shaderStorageBufferBlocks() const
+{
+    return m_shaderStorageBufferBlocks;
 }
 
 bool ApiTraceState::isEmpty() const

--- a/gui/apitracecall.h
+++ b/gui/apitracecall.h
@@ -149,6 +149,7 @@ public:
     const QMap<QString, QString> & shaderSources() const;
     const QVariantMap & uniforms() const;
     const QVariantMap & buffers() const;
+    const QVariantMap & shaderStorageBufferBlocks() const;
     const QList<ApiTexture> & textures() const;
     const QList<ApiFramebuffer> & framebuffers() const;
 
@@ -158,6 +159,7 @@ private:
     QMap<QString, QString> m_shaderSources;
     QVariantMap m_uniforms;
     QVariantMap m_buffers;
+    QVariantMap m_shaderStorageBufferBlocks;
     QList<ApiTexture> m_textures;
     QList<ApiFramebuffer> m_framebuffers;
 };

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -826,6 +826,32 @@ static void setValueOfSSBBItem(const ApiTraceState &state,
     auto bufferName = SSB["GL_SHADER_STORAGE_BUFFER_BINDING"].toInt();
 
     QString bindingText = QString("Binding %0").arg(bufferBindingIndex);
+    QStringList referencingShaders = {"GL_REFERENCED_BY_VERTEX_SHADER"};
+
+    for(int i = 0; i < bufferItem->childCount(); ++i) {
+        const auto &text = bufferItem->child(i)->text(0);
+        if (text.startsWith("GL_REFERENCED_BY_") && text.endsWith("_SHADER")) {
+            referencingShaders.append(text);
+        }
+    }
+
+    static QMap<QString, QString> map = {
+            {"GL_REFERENCED_BY_VERTEX_SHADER", "VS"},
+            {"GL_REFERENCED_BY_TESS_CONTROL_SHADER", "TCS"},
+            {"GL_REFERENCED_BY_TESS_EVALUATION_SHADER", "TES"},
+            {"GL_REFERENCED_BY_GEOMETRY_SHADER", "GS"},
+            {"GL_REFERENCED_BY_FRAGMENT_SHADER", "FS"},
+            {"GL_REFERENCED_BY_COMPUTE_SHADER", "CS"}};
+    // shorten list
+    for(auto &referencingShader: referencingShaders) {
+        assert(map.count(referencingShader));
+        referencingShader = map[referencingShader];
+    }
+    if (!referencingShaders.empty()) {
+        bindingText += " in ";
+        bindingText += referencingShaders.join(", ");
+    }
+
     QString bufferText;
     if (bufferName != 0) {
         bufferText = QString("Buffer %0").arg(bufferName);

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -854,6 +854,22 @@ void MainWindow::fillStateForFrame()
         m_ui.surfacesTab->setEnabled(true);
     }
     m_ui.stateDock->show();
+
+    {
+        const bool hasSSBs = state.shaderStorageBufferBlocks().size() > 0;
+        m_ui.ssbsTreeWidget->clear();
+        QList<QTreeWidgetItem *> buffersItems;
+        variantMapToItems(state.shaderStorageBufferBlocks(), QVariantMap(),
+                          buffersItems);
+        for (auto const &bufferItem : buffersItems) {
+            if (bufferItem->child(0)->text(0) == "Buffer") {
+                bufferItem->setText(
+                    1, QString("Buffer %0").arg(bufferItem->child(0)->text(1)));
+            }
+        }
+        m_ui.ssbsTreeWidget->insertTopLevelItems(0, buffersItems);
+        m_ui.ssbsTreeWidget->setVisible(hasSSBs);
+    }
 }
 
 void MainWindow::showSettings()

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -856,11 +856,11 @@ void MainWindow::fillStateForFrame()
     m_ui.stateDock->show();
 
     {
-        const bool hasSSBs = state.shaderStorageBufferBlocks().size() > 0;
         m_ui.ssbsTreeWidget->clear();
         QList<QTreeWidgetItem *> buffersItems;
         variantMapToItems(state.shaderStorageBufferBlocks(), QVariantMap(),
                           buffersItems);
+        const bool hasSSBs = buffersItems.size() > 0;
         for (auto const &bufferItem : buffersItems) {
             if (bufferItem->child(0)->text(0) == "Buffer") {
                 bufferItem->setText(
@@ -868,7 +868,7 @@ void MainWindow::fillStateForFrame()
             }
         }
         m_ui.ssbsTreeWidget->insertTopLevelItems(0, buffersItems);
-        m_ui.ssbsTreeWidget->setVisible(hasSSBs);
+        m_ui.ssbTab->setEnabled(hasSSBs);
     }
 }
 

--- a/gui/ui/mainwindow.ui
+++ b/gui/ui/mainwindow.ui
@@ -298,6 +298,39 @@
          </item>
         </layout>
        </widget>
+       <widget class="QWidget" name="ssbTab">
+        <attribute name="title">
+         <string>SSBBs</string>
+        </attribute>
+        <attribute name="toolTip">
+         <string>Shader Storage Buffer Blocks</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_8">
+         <item>
+          <widget class="QTreeWidget" name="ssbsTreeWidget">
+           <property name="editTriggers">
+            <set>QAbstractItemView::NoEditTriggers</set>
+           </property>
+           <property name="alternatingRowColors">
+            <bool>true</bool>
+           </property>
+           <property name="allColumnsShowFocus">
+            <bool>true</bool>
+           </property>
+           <column>
+            <property name="text">
+             <string>Name</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Value</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
     </layout>

--- a/retrace/glstate.cpp
+++ b/retrace/glstate.cpp
@@ -61,6 +61,8 @@ Context::Context(void) {
     EXT_debug_label = ext.has("GL_EXT_debug_label");
     ARB_direct_state_access = ext.has("GL_ARB_direct_state_access");
     ARB_shader_image_load_store = ext.has("GL_ARB_shader_image_load_store");
+    ARB_shader_storage_buffer_object = ext.has("GL_ARB_shader_storage_buffer_object");
+    ARB_program_interface_query = ext.has("GL_ARB_program_interface_query");
 
     NV_read_depth_stencil = ES && ext.has("GL_NV_read_depth_stencil");
 }

--- a/retrace/glstate_internal.hpp
+++ b/retrace/glstate_internal.hpp
@@ -52,6 +52,8 @@ struct Context
     unsigned NV_read_depth_stencil:1;  /* ES only */
     unsigned ARB_shader_image_load_store:1;
     unsigned ARB_direct_state_access:1;
+    unsigned ARB_shader_storage_buffer_object:1;
+    unsigned ARB_program_interface_query:1;
 
     Context(void);
 };
@@ -191,6 +193,8 @@ void dumpObjectLabel(StateWriter &writer, Context &context, GLenum identifier, G
 void dumpParameters(StateWriter &writer, Context &context);
 
 void dumpShadersUniforms(StateWriter &writer, Context &context);
+
+void dumpShadersStorageBufferBlocks(StateWriter &writer, Context &context, GLuint program);
 
 void dumpTextures(StateWriter &writer, Context &context);
 

--- a/retrace/glstate_shaders.cpp
+++ b/retrace/glstate_shaders.cpp
@@ -1138,6 +1138,28 @@ void dumpShadersStorageBufferBlocks(StateWriter &writer, Context &context,
                 "GL_BUFFER_DATA_SIZE",
                 getProgramResourcei(program, GL_SHADER_STORAGE_BLOCK,
                                     ssbbResourceIndex, GL_BUFFER_DATA_SIZE));
+
+            auto outputIfReferenced = [&writer,ssbbResourceIndex, program](
+                const char *propertyName, GLenum property) {
+                const auto value =
+                    getProgramResourcei(program, GL_SHADER_STORAGE_BLOCK,
+                                        ssbbResourceIndex, property);
+                if (value) {
+                    writer.writeBoolMember(propertyName, true);
+                }
+            };
+#ifdef OUTPUT_IF_REFERENCED
+#error "OUTPUT_IF_REFERENCED should not be defined here!"
+#endif
+#define OUTPUT_IF_REFERENCED(NAME) outputIfReferenced(#NAME, NAME)
+
+            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_VERTEX_SHADER);
+            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_TESS_CONTROL_SHADER);
+            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_TESS_EVALUATION_SHADER);
+            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_GEOMETRY_SHADER);
+            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_FRAGMENT_SHADER);
+            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_COMPUTE_SHADER);
+#undef OUTPUT_IF_REFERENCED
             GLint bufferName = 0;
             glGetIntegeri_v(GL_SHADER_STORAGE_BUFFER_BINDING, bufferBinding, &bufferName);
             if(bufferName != 0) {

--- a/retrace/glstate_shaders.cpp
+++ b/retrace/glstate_shaders.cpp
@@ -1152,11 +1152,7 @@ void dumpShadersStorageBufferBlocks(StateWriter &writer, Context &context,
                     writer.writeBoolMember(enumToString(property), true);
                 }
             }
-            GLint bufferName = 0;
-            glGetIntegeri_v(GL_SHADER_STORAGE_BUFFER_BINDING, bufferBinding, &bufferName);
-            if(bufferName != 0) {
-               writer.writeIntMember("Buffer", bufferName);
-            }
+
             writer.beginMember("activeVariables");
             writer.beginObject();
             for (GLint variableIndex : activeVariables) {

--- a/retrace/glstate_shaders.cpp
+++ b/retrace/glstate_shaders.cpp
@@ -1139,27 +1139,19 @@ void dumpShadersStorageBufferBlocks(StateWriter &writer, Context &context,
                 getProgramResourcei(program, GL_SHADER_STORAGE_BLOCK,
                                     ssbbResourceIndex, GL_BUFFER_DATA_SIZE));
 
-            auto outputIfReferenced = [&writer,ssbbResourceIndex, program](
-                const char *propertyName, GLenum property) {
+            for (auto property : {GL_REFERENCED_BY_VERTEX_SHADER,
+                                    GL_REFERENCED_BY_TESS_CONTROL_SHADER,
+                                    GL_REFERENCED_BY_TESS_EVALUATION_SHADER,
+                                    GL_REFERENCED_BY_GEOMETRY_SHADER,
+                                    GL_REFERENCED_BY_FRAGMENT_SHADER,
+                                    GL_REFERENCED_BY_COMPUTE_SHADER}) {
                 const auto value =
                     getProgramResourcei(program, GL_SHADER_STORAGE_BLOCK,
                                         ssbbResourceIndex, property);
                 if (value) {
-                    writer.writeBoolMember(propertyName, true);
+                    writer.writeBoolMember(enumToString(property), true);
                 }
-            };
-#ifdef OUTPUT_IF_REFERENCED
-#error "OUTPUT_IF_REFERENCED should not be defined here!"
-#endif
-#define OUTPUT_IF_REFERENCED(NAME) outputIfReferenced(#NAME, NAME)
-
-            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_VERTEX_SHADER);
-            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_TESS_CONTROL_SHADER);
-            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_TESS_EVALUATION_SHADER);
-            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_GEOMETRY_SHADER);
-            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_FRAGMENT_SHADER);
-            OUTPUT_IF_REFERENCED(GL_REFERENCED_BY_COMPUTE_SHADER);
-#undef OUTPUT_IF_REFERENCED
+            }
             GLint bufferName = 0;
             glGetIntegeri_v(GL_SHADER_STORAGE_BUFFER_BINDING, bufferBinding, &bufferName);
             if(bufferName != 0) {
@@ -1173,24 +1165,14 @@ void dumpShadersStorageBufferBlocks(StateWriter &writer, Context &context,
                 writer.beginMember(variableName);
                 writer.beginObject();
 
-#define DUMP_BUFFER_VARIABLE_INT(NAME)                                         \
-    do {                                                                       \
-        int value = getProgramResourcei(program, GL_BUFFER_VARIABLE,           \
-                                        variableIndex, NAME);                  \
-        writer.writeIntMember(#NAME, value);                                   \
-    } while (false)
-
-                DUMP_BUFFER_VARIABLE_INT(GL_TYPE);
-                DUMP_BUFFER_VARIABLE_INT(GL_ARRAY_SIZE);
-                DUMP_BUFFER_VARIABLE_INT(GL_OFFSET);
-                DUMP_BUFFER_VARIABLE_INT(GL_BLOCK_INDEX);
-                DUMP_BUFFER_VARIABLE_INT(GL_ARRAY_STRIDE);
-                DUMP_BUFFER_VARIABLE_INT(GL_MATRIX_STRIDE);
-                DUMP_BUFFER_VARIABLE_INT(GL_IS_ROW_MAJOR);
-                DUMP_BUFFER_VARIABLE_INT(GL_TOP_LEVEL_ARRAY_SIZE);
-                DUMP_BUFFER_VARIABLE_INT(GL_TOP_LEVEL_ARRAY_STRIDE);
-
-#undef DUMP_BUFFER_VARIABLE_INT
+                for (auto property :
+                     {GL_TYPE, GL_ARRAY_SIZE, GL_OFFSET, GL_BLOCK_INDEX,
+                      GL_ARRAY_STRIDE, GL_MATRIX_STRIDE, GL_IS_ROW_MAJOR,
+                      GL_TOP_LEVEL_ARRAY_SIZE, GL_TOP_LEVEL_ARRAY_STRIDE}) {
+                    int value = getProgramResourcei(program, GL_BUFFER_VARIABLE,
+                                                    variableIndex, property);
+                    writer.writeIntMember(enumToString(property), value);
+                }
 
                 writer.endObject();
                 writer.endMember();// variableName


### PR DESCRIPTION
Add a new tab for Shader Storage Buffer Blocks from all shaders.

This is the prerequisite for a new viewer that will offer to inspect a buffer via the structure of a specific shader storage buffer block.

The viewer is already being worked on but I want to wait for this to make it into master before relying on it. The viewer would need the contents of buffers, which would have to be exported as well. We would need to discuss how to export them as they might be several GiB in size.