### PR TITLE
gui: Add checkboxes for alpha/opaque in surfaces view (fixes #374)

### DIFF
--- a/gui/apisurface.h
+++ b/gui/apisurface.h
@@ -10,6 +10,7 @@ namespace image {
 
 class ApiSurface
 {
+    static constexpr float DefaultLowerValue = 0.f, DefaultUpperValue = 1.f;
 public:
     ApiSurface();
 
@@ -23,25 +24,27 @@ public:
     void setFormatName(const QString &str);
 
     void setData(const QByteArray &data);
+    QImage calculateThumbnail(bool opaque, bool alpha) const;
 
     QByteArray data() const;
-    QImage thumb() const;
 
     static image::Image *imageFromData(const QByteArray &data);
     static QImage qimageFromRawImage(const image::Image *img,
-                                     float lowerValue = 0.0f,
-                                     float upperValue = 1.0f,
+                                     float lowerValue = DefaultLowerValue,
+                                     float upperValue = DefaultUpperValue,
                                      bool opaque = false,
                                      bool alpha = false);
 
 private:
+
     QSize  m_size;
     QByteArray m_data;
-    QImage m_thumb;
     int m_depth;
     QString m_formatName;
-};
 
+    QImage calculateThumbnail(const QByteArray &data, bool opaque,
+                              bool alpha) const;
+};
 
 class ApiTexture : public ApiSurface
 {

--- a/gui/apitracemodel.cpp
+++ b/gui/apitracemodel.cpp
@@ -75,7 +75,7 @@ QVariant ApiTraceModel::data(const QModelIndex &index, int role) const
                         ", %1kb";
 
                 ApiFramebuffer fbo = frame->state()->colorBuffer();
-                QImage thumb = fbo.thumb();
+                QImage thumb = fbo.calculateThumbnail(false, false);
                 if (!thumb.isNull()) {
                     QByteArray ba;
                     QBuffer buffer(&ba);

--- a/gui/imageviewer.cpp
+++ b/gui/imageviewer.cpp
@@ -10,11 +10,13 @@
 #include <QPixmap>
 #include <QScrollBar>
 
-ImageViewer::ImageViewer(QWidget *parent)
+ImageViewer::ImageViewer(QWidget *parent, bool opaque, bool alpha)
     : QDialog(parent),
       m_image(0)
 {
     setupUi(this);
+    opaqueCheckBox->setChecked(opaque);
+    alphaCheckBox->setChecked(alpha);
 
     connect(lowerSpinBox, SIGNAL(valueChanged(double)),
             SLOT(slotUpdate()));
@@ -65,9 +67,7 @@ void ImageViewer::setData(const QByteArray &data)
 {
     delete m_image;
     m_image = ApiSurface::imageFromData(data);
-    m_convertedImage = ApiSurface::qimageFromRawImage(m_image);
-    m_pixelWidget->setSurface(m_convertedImage);
-    updateGeometry();
+    slotUpdate();
 }
 
 void ImageViewer::slotUpdate()

--- a/gui/imageviewer.h
+++ b/gui/imageviewer.h
@@ -14,7 +14,7 @@ class ImageViewer : public QDialog, public Ui_ImageViewer
 {
     Q_OBJECT
 public:
-    ImageViewer(QWidget *parent = 0);
+    ImageViewer(QWidget *parent = 0, bool opaque = false, bool alpha = false);
     ~ImageViewer();
 
     void setData(const QByteArray &data);

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -104,6 +104,7 @@ private slots:
     void slotFoundFrameEnd(ApiTraceFrame *frame);
     void slotJumpToResult(ApiTraceCall *call);
     void replayTrace(bool dumpState, bool dumpThumbnails);
+    void updateSurfacesView();
 
 private:
     void initObjects();
@@ -113,6 +114,7 @@ private:
     void updateActionsState(bool traceLoaded, bool stopped = true);
     void newTraceFile(const QString &fileName);
     void trimEvent();
+    void updateSurfacesView(const ApiTraceState &state);
     void fillStateForFrame();
 
     /* there's a difference between selected frame/call and
@@ -130,6 +132,7 @@ private:
     QString linkedAndroidTrace(const QString &localFile);
     void addSurface(const ApiTexture &image, QTreeWidgetItem *parent);
     void addSurface(const ApiFramebuffer &image, QTreeWidgetItem *parent);
+    void addSurface(const ApiSurface &surface, const QString &label, QTreeWidgetItem *parent);
     template <typename Surface>
     void addSurfaces(const QList<Surface> &images, const char *label);
 

--- a/gui/ui/mainwindow.ui
+++ b/gui/ui/mainwindow.ui
@@ -215,8 +215,22 @@
         <attribute name="title">
          <string>Surfaces</string>
         </attribute>
-        <layout class="QVBoxLayout" name="verticalLayout_5">
-         <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="surfacesOpaqueCB">
+           <property name="text">
+            <string>opaque</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="surfacesAlphaCB">
+           <property name="text">
+            <string>alpha</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0" colspan="2">
           <widget class="QTreeWidget" name="surfacesTreeWidget">
            <column>
             <property name="text">


### PR DESCRIPTION
- pass alpha/opaque settings through to image viewer
- removed caching of thumbnails in ApiSurface instances
  - updating thumbnails (due to changed alpha/opaque settings) did not
mesh with constness
  - ApiSurfaces should be unaware of thumbnails -> caching should happen
e.g. in SurfacesView