### PR TITLE
Fix formatting that causes Github to hide words

### DIFF
--- a/docs/USAGE.markdown
+++ b/docs/USAGE.markdown
@@ -561,6 +561,6 @@ system configuration:
 
 2. The target host must have a functional glretrace binary available
 
-3. The target host must have access to <trace-file> at the same path
-   in the filesystem as the <trace-file> path on the host system being
+3. The target host must have access to `trace-file` at the same path
+   in the filesystem as the `trace-file` path on the host system being
    passed to the qapitrace command line.


### PR DESCRIPTION
When github renders markdown it hides words inside of angle brackets. Replacing the angle brackets with backticks fixes the issue.