### PR TITLE
Changing working directory from GUI

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -41,6 +41,7 @@
 #include <QUrl>
 #include <QVBoxLayout>
 #include <QTextBrowser>
+#include <QToolTip>
 
 typedef QLatin1String _;
 
@@ -56,6 +57,7 @@ MainWindow::MainWindow()
     updateActionsState(false);
     initObjects();
     initConnections();
+    updateRecentLaunchesMenu();
 }
 
 MainWindow::~MainWindow()
@@ -67,7 +69,7 @@ MainWindow::~MainWindow()
     delete m_model;
 }
 
-void MainWindow::createTrace()
+void MainWindow::createTrace(const RecentLaunch* optionLaunch)
 {
     if (!m_traceProcess->canTrace()) {
         QMessageBox::warning(
@@ -78,14 +80,30 @@ void MainWindow::createTrace()
     }
 
     TraceDialog dialog;
+
+    if(optionLaunch) {
+        dialog.setApi(optionLaunch->api);
+        dialog.setApplicationPath(optionLaunch->execPath);
+        dialog.setWorkingDirPath(optionLaunch->workingDir);
+        dialog.setArguments(optionLaunch->args);
+    }
+
     if (dialog.exec() == QDialog::Accepted) {
         qDebug()<< "App : " <<dialog.applicationPath();
         qDebug()<< "  Arguments: "<<dialog.arguments();
-        m_traceProcess->setApi(dialog.api());
-		m_traceProcess->setExecutablePathAndWorkingDir(
-					dialog.applicationPath(),
-					dialog.workingDirPath());
-        m_traceProcess->setArguments(dialog.arguments());
+
+        RecentLaunch rl;
+        rl.api = dialog.api();
+        rl.execPath = dialog.applicationPath();
+        rl.workingDir = dialog.workingDirPath();
+        rl.args = dialog.arguments();
+        addRecentLaunch(rl);
+        updateRecentLaunchesMenu();
+
+        m_traceProcess->setApi(rl.api);
+        m_traceProcess->setExecutablePathAndWorkingDir(
+                    rl.execPath, rl.workingDir);
+        m_traceProcess->setArguments(rl.args);
         m_traceProcess->start();
     }
 }
@@ -1914,9 +1932,88 @@ void MainWindow::slotJumpToResult(ApiTraceCall *call)
 
 void MainWindow::thumbnailCallback(void *object, int thumbnailIdx)
 {
-	//qDebug() << QLatin1String("debug: transfer from trace to retracer thumbnail index: ") << thumbnailIdx;
+    //qDebug() << QLatin1String("debug: transfer from trace to retracer thumbnail index: ") << thumbnailIdx;
     MainWindow *mySelf = (MainWindow *) object;
     mySelf->m_retracer->addThumbnailToCapture(thumbnailIdx);
+}
+
+void MainWindow::addRecentLaunch(const RecentLaunch& launch)
+{
+    QList<RecentLaunch> launches = readRecentLaunches();
+
+    for(int i = 0; i < launches.size(); ++i) {
+        const RecentLaunch& rl = launches[i];
+
+        if(rl.api == launch.api
+                && rl.execPath == launch.execPath
+                && rl.workingDir == launch.workingDir
+                && rl.args == launch.args) {
+            launches.removeAt(i);
+        } else {
+            ++i;
+        }
+    }
+
+    launches.push_front(launch);
+
+    const int maxHistorySize = 10;
+    if(launches.size() > maxHistorySize) {
+        launches.erase(launches.begin() + maxHistorySize, launches.end());
+    }
+
+    QSettings settings;
+    settings.beginWriteArray("launch-history", launches.size());
+    for(int i = 0; i < launches.size(); ++i) {
+        settings.setArrayIndex(i);
+        settings.setValue("api", launches[i].api);
+        settings.setValue("exec", launches[i].execPath);
+        settings.setValue("working-dir", launches[i].workingDir);
+        settings.setValue("args", launches[i].args);
+    }
+    settings.endArray();
+}
+
+QList<MainWindow::RecentLaunch> MainWindow::readRecentLaunches() const
+{
+    QList<RecentLaunch> launches;
+    QSettings settings;
+
+    int historySize = settings.beginReadArray("launch-history");
+    for(int i = 0; i < historySize; ++i) {
+        settings.setArrayIndex(i);
+
+        RecentLaunch rl;
+        rl.execPath = settings.value("exec").toString();
+        rl.workingDir = settings.value("working-dir").toString();
+        rl.args = settings.value("args").toStringList();
+        launches.push_back(rl);
+    }
+    settings.endArray();
+
+    return launches;
+}
+
+void MainWindow::updateRecentLaunchesMenu()
+{
+    QList<RecentLaunch> launches = readRecentLaunches();
+
+    QMenu* rootMenu = m_ui.actionRecentLaunches->menu();
+    if(!rootMenu) {
+        rootMenu = new QMenu();
+        m_ui.actionRecentLaunches->setMenu(rootMenu);
+    }
+
+    rootMenu->clear();
+    for(int i = 0; i < launches.size(); ++i) {
+        const RecentLaunch& rl = launches[i];
+        QAction* action = rootMenu->addAction(rl.execPath);
+
+        connect(action, &QAction::triggered, [this, i](){
+            QList<RecentLaunch> launches = readRecentLaunches();
+            if(i < launches.size())
+                createTrace(&launches[i]);
+        });
+    }
 }
 
 #include "mainwindow.moc"

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -82,7 +82,9 @@ void MainWindow::createTrace()
         qDebug()<< "App : " <<dialog.applicationPath();
         qDebug()<< "  Arguments: "<<dialog.arguments();
         m_traceProcess->setApi(dialog.api());
-        m_traceProcess->setExecutablePath(dialog.applicationPath());
+		m_traceProcess->setExecutablePathAndWorkingDir(
+					dialog.applicationPath(),
+					dialog.workingDirPath());
         m_traceProcess->setArguments(dialog.arguments());
         m_traceProcess->start();
     }

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -41,7 +41,6 @@
 #include <QUrl>
 #include <QVBoxLayout>
 #include <QTextBrowser>
-#include <QToolTip>
 
 typedef QLatin1String _;
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -38,6 +38,14 @@ class MainWindow : public QMainWindow
 {
     Q_OBJECT
 public:
+    struct RecentLaunch
+    {
+        QString api;
+        QString execPath;
+        QString workingDir;
+        QStringList args;
+    };
+
     MainWindow();
     ~MainWindow();
 
@@ -49,7 +57,7 @@ public slots:
 private slots:
     void callItemSelected(const QModelIndex &index);
     void callItemActivated(const QModelIndex &index);
-    void createTrace();
+    void createTrace(const RecentLaunch* optionalLaunch = nullptr);
     void openTrace();
     void saveTrace();
     void pullTrace();
@@ -135,6 +143,10 @@ private:
     void addSurface(const ApiSurface &surface, const QString &label, QTreeWidgetItem *parent);
     template <typename Surface>
     void addSurfaces(const QList<Surface> &images, const char *label);
+
+    void addRecentLaunch(const RecentLaunch& launch);
+    QList<RecentLaunch> readRecentLaunches() const;
+    void updateRecentLaunchesMenu();
 
 protected:
     virtual void closeEvent(QCloseEvent * event) override;

--- a/gui/tracedialog.cpp
+++ b/gui/tracedialog.cpp
@@ -21,10 +21,17 @@ TraceDialog::TraceDialog(QWidget *parent)
     apiComboBox->addItem("EGL");
 #endif
 
-	connect(browseButton, SIGNAL(clicked()),
-			this, SLOT(browseApplication()));
-	connect(browseWorkingDirButton, SIGNAL(clicked()),
-			this, SLOT(browseWorkingDir()));
+    connect(browseButton, SIGNAL(clicked()),
+            this, SLOT(browseApplication()));
+    connect(browseWorkingDirButton, SIGNAL(clicked()),
+            this, SLOT(browseWorkingDir()));
+}
+
+void TraceDialog::setApi(const QString &api)
+{
+    int index = apiComboBox->findText(api);
+    if(index >= 0)
+        apiComboBox->setCurrentIndex(index);
 }
 
 QString TraceDialog::api() const
@@ -32,20 +39,36 @@ QString TraceDialog::api() const
     return apiComboBox->currentText().toLower();
 }
 
+void TraceDialog::setApplicationPath(const QString &path)
+{
+    applicationEdit->setText(path);
+}
+
 QString TraceDialog::applicationPath() const
 {
     return applicationEdit->text();
 }
 
+void TraceDialog::setWorkingDirPath(const QString &path)
+{
+    workingDirEdit->setText(path);
+}
+
 QString TraceDialog::workingDirPath() const
 {
-	QString workingDir = workingDirEdit->text();
+    QString workingDir = workingDirEdit->text();
 
-	if(workingDir.isEmpty()) {
-		return QDir::currentPath();
-	}
+    if(workingDir.isEmpty()) {
+        return QDir::currentPath();
+    }
 
-	return workingDir;
+    return workingDir;
+}
+
+void TraceDialog::setArguments(const QStringList &args)
+{
+    QString argsStr = args.join(";");
+    argumentsEdit->setText(argsStr);
 }
 
 QStringList TraceDialog::arguments() const
@@ -70,21 +93,21 @@ void TraceDialog::browseApplication()
 
 void TraceDialog::browseWorkingDir()
 {
-	QString path =
-			QFileDialog::getExistingDirectory(
-				this,
-				tr("Choose working directory"),
-				workingDirPath());
+    QString path =
+            QFileDialog::getExistingDirectory(
+                this,
+                tr("Choose working directory"),
+                workingDirPath());
 
-	if(!path.isEmpty() && isDirOk(path)) {
-		workingDirEdit->setText(path);
-	}
+    if(!path.isEmpty() && isDirOk(path)) {
+        workingDirEdit->setText(path);
+    }
 }
 
 void TraceDialog::accept()
 {
-	if (isFileOk(applicationEdit->text())
-			&& isDirOk(workingDirPath())) {
+    if (isFileOk(applicationEdit->text())
+            && isDirOk(workingDirPath())) {
         QDialog::accept();
     }
 }
@@ -111,23 +134,23 @@ bool TraceDialog::isFileOk(const QString &fileName)
 
 bool TraceDialog::isDirOk(const QString &path)
 {
-	QFileInfo fi(path);
+    QFileInfo fi(path);
 
-	if(!fi.exists()) {
-		QMessageBox::warning(this, tr("Directory Does Not Exist"),
-							 tr("Directory '%1' doesn't exist.").
-							 arg(fi.fileName()));
-		return false;
-	}
+    if(!fi.exists()) {
+        QMessageBox::warning(this, tr("Directory Does Not Exist"),
+                             tr("Directory '%1' doesn't exist.").
+                             arg(fi.fileName()));
+        return false;
+    }
 
-	if(!fi.isDir()) {
-		QMessageBox::warning(this, tr("Directory Does Not Exist"),
-							 tr("Path '%1' is not a directory").
-							 arg(fi.fileName()));
-		return false;
-	}
+    if(!fi.isDir()) {
+        QMessageBox::warning(this, tr("Directory Does Not Exist"),
+                             tr("Path '%1' is not a directory").
+                             arg(fi.fileName()));
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 #include "tracedialog.moc"

--- a/gui/tracedialog.cpp
+++ b/gui/tracedialog.cpp
@@ -21,8 +21,10 @@ TraceDialog::TraceDialog(QWidget *parent)
     apiComboBox->addItem("EGL");
 #endif
 
-    connect(browseButton, SIGNAL(clicked()),
-            this, SLOT(browse()));
+	connect(browseButton, SIGNAL(clicked()),
+			this, SLOT(browseApplication()));
+	connect(browseWorkingDirButton, SIGNAL(clicked()),
+			this, SLOT(browseWorkingDir()));
 }
 
 QString TraceDialog::api() const
@@ -35,6 +37,17 @@ QString TraceDialog::applicationPath() const
     return applicationEdit->text();
 }
 
+QString TraceDialog::workingDirPath() const
+{
+	QString workingDir = workingDirEdit->text();
+
+	if(workingDir.isEmpty()) {
+		return QDir::currentPath();
+	}
+
+	return workingDir;
+}
+
 QStringList TraceDialog::arguments() const
 {
     QStringList args =
@@ -42,7 +55,7 @@ QStringList TraceDialog::arguments() const
     return args;
 }
 
-void TraceDialog::browse()
+void TraceDialog::browseApplication()
 {
     QString fileName =
         QFileDialog::getOpenFileName(
@@ -55,9 +68,23 @@ void TraceDialog::browse()
     }
 }
 
+void TraceDialog::browseWorkingDir()
+{
+	QString path =
+			QFileDialog::getExistingDirectory(
+				this,
+				tr("Choose working directory"),
+				workingDirPath());
+
+	if(!path.isEmpty() && isDirOk(path)) {
+		workingDirEdit->setText(path);
+	}
+}
+
 void TraceDialog::accept()
 {
-    if (isFileOk(applicationEdit->text())) {
+	if (isFileOk(applicationEdit->text())
+			&& isDirOk(workingDirPath())) {
         QDialog::accept();
     }
 }
@@ -80,6 +107,27 @@ bool TraceDialog::isFileOk(const QString &fileName)
     }
 
     return true;
+}
+
+bool TraceDialog::isDirOk(const QString &path)
+{
+	QFileInfo fi(path);
+
+	if(!fi.exists()) {
+		QMessageBox::warning(this, tr("Directory Does Not Exist"),
+							 tr("Directory '%1' doesn't exist.").
+							 arg(fi.fileName()));
+		return false;
+	}
+
+	if(!fi.isDir()) {
+		QMessageBox::warning(this, tr("Directory Does Not Exist"),
+							 tr("Path '%1' is not a directory").
+							 arg(fi.fileName()));
+		return false;
+	}
+
+	return true;
 }
 
 #include "tracedialog.moc"

--- a/gui/tracedialog.h
+++ b/gui/tracedialog.h
@@ -11,16 +11,23 @@ public:
 
     void accept() override;
 
+    void setApi(const QString &api);
     QString api() const;
+
+    void setApplicationPath(const QString &path);
     QString applicationPath() const;
-	QString workingDirPath() const;
+
+    void setWorkingDirPath(const QString &path);
+    QString workingDirPath() const;
+
+    void setArguments(const QStringList &args);
     QStringList arguments() const;
 
 private slots:
-	void browseApplication();
-	void browseWorkingDir();
+    void browseApplication();
+    void browseWorkingDir();
 
 private:
     bool isFileOk(const QString &fileName);
-	bool isDirOk(const QString &path);
+    bool isDirOk(const QString &path);
 };

--- a/gui/tracedialog.h
+++ b/gui/tracedialog.h
@@ -13,11 +13,14 @@ public:
 
     QString api() const;
     QString applicationPath() const;
+	QString workingDirPath() const;
     QStringList arguments() const;
 
 private slots:
-    void browse();
+	void browseApplication();
+	void browseWorkingDir();
 
 private:
     bool isFileOk(const QString &fileName);
+	bool isDirOk(const QString &path);
 };

--- a/gui/traceprocess.cpp
+++ b/gui/traceprocess.cpp
@@ -26,24 +26,26 @@ void TraceProcess::setApi(const QString &str)
     m_api = str;
 }
 
-void TraceProcess::setExecutablePath(const QString &str)
+void TraceProcess::setExecutablePathAndWorkingDir(const QString &execPath, const QString &workingDir)
 {
-    m_execPath = str;
+	m_execPath = execPath;
+	m_workingDir = workingDir;
 
     QFileInfo fi(m_execPath);
     QString baseName = fi.baseName();
 
     QString format = QString::fromLatin1("%1.trace");
 
-    m_tracePath = format
-                  .arg(baseName);
+	QDir traceFileDir(workingDir);
+	m_tracePath = traceFileDir.filePath(format
+				  .arg(baseName));
 
     int i = 1;
     while (QFile::exists(m_tracePath)) {
         format = QString::fromLatin1("%1.%2.trace");
-        m_tracePath = format
-                      .arg(baseName)
-                      .arg(i++);
+		m_tracePath = traceFileDir.filePath(
+					format.arg(baseName)
+					.arg(i++));
     }
 }
 
@@ -96,6 +98,7 @@ void TraceProcess::start()
     arguments << m_execPath;
     arguments << m_args;
 
+	m_process->setWorkingDirectory(m_workingDir);
     m_process->start(QLatin1String("apitrace"), arguments);
 }
 

--- a/gui/traceprocess.h
+++ b/gui/traceprocess.h
@@ -13,8 +13,9 @@ public:
     bool canTrace() const;
 
     void setApi(const QString &str);
-    void setExecutablePath(const QString &str);
+	void setExecutablePathAndWorkingDir(const QString &execPath, const QString &workingDir);
     QString executablePath() const;
+	QString workingDirectory() const;
 
     void setArguments(const QStringList &args);
     QStringList arguments() const;
@@ -33,6 +34,7 @@ private slots:
 private:
     QString m_api;
     QString m_execPath;
+	QString m_workingDir;
     QStringList m_args;
     QString m_tracePath;
     QProcess *m_process;

--- a/gui/ui/mainwindow.ui
+++ b/gui/ui/mainwindow.ui
@@ -45,7 +45,7 @@
      <x>0</x>
      <y>0</y>
      <width>787</width>
-     <height>24</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -66,6 +66,7 @@
      <addaction name="actionRetraceOnAndroid"/>
     </widget>
     <addaction name="actionNew"/>
+    <addaction name="actionRecentLaunches"/>
     <addaction name="actionOpen"/>
     <addaction name="actionSave"/>
     <addaction name="separator"/>
@@ -118,7 +119,7 @@
    </property>
    <property name="minimumSize">
     <size>
-     <width>77</width>
+     <width>88</width>
      <height>100</height>
     </size>
    </property>
@@ -828,6 +829,11 @@
    </property>
    <property name="toolTip">
     <string>trace opengl object leaks</string>
+   </property>
+  </action>
+  <action name="actionRecentLaunches">
+   <property name="text">
+    <string>Recent launches...</string>
    </property>
   </action>
   <zorder>stateDock</zorder>

--- a/gui/ui/tracedialog.ui
+++ b/gui/ui/tracedialog.ui
@@ -50,7 +50,7 @@
      <item row="2" column="1">
       <widget class="QLineEdit" name="workingDirEdit">
        <property name="placeholderText">
-        <string>Same as application's directory</string>
+        <string>QApiTrace's working directory</string>
        </property>
       </widget>
      </item>

--- a/gui/ui/tracedialog.ui
+++ b/gui/ui/tracedialog.ui
@@ -6,69 +6,79 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>401</width>
-    <height>95</height>
+    <width>500</width>
+    <height>250</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Tracing</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QLabel" name="label_3">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>API:</string>
+        <string>Working directory:</string>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QComboBox" name="apiComboBox"/>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Application:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
+     <item row="1" column="1">
       <widget class="QLineEdit" name="applicationEdit">
        <property name="placeholderText">
         <string>Application to trace</string>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QPushButton" name="browseButton">
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>Browse...</string>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
+        <string>Application:</string>
        </property>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="apiComboBox"/>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>API:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="workingDirEdit">
+       <property name="placeholderText">
+        <string>Same as application's directory</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Arguments:</string>
        </property>
       </widget>
      </item>
-     <item>
+     <item row="3" column="1">
       <widget class="QLineEdit" name="argumentsEdit">
        <property name="placeholderText">
         <string>Separate arguments with &quot;;&quot;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QToolButton" name="browseButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QToolButton" name="browseWorkingDirButton">
+       <property name="text">
+        <string>...</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Hello,
this PR adds edit in trace dialog for setting working directory of a traced process. When it is left empty, working directory won't be changed (so it has the same behavior as before). It also adds history of recent launches (File > Recent launches...)
This fixes #102 
