### PR TITLE
Tracking the mapped buffer size for retracing

### DIFF
--- a/retrace/glstate.cpp
+++ b/retrace/glstate.cpp
@@ -173,6 +173,7 @@ BufferBinding::~BufferBinding() {
 BufferMapping::BufferMapping() :
     target(GL_NONE),
     buffer(0),
+    map_size(0),
     map_pointer(NULL),
     unmap(false)
 {
@@ -187,6 +188,7 @@ BufferMapping::map(GLenum _target, GLuint _buffer)
 
     target = _target;
     buffer = _buffer;
+    map_size = 0;
     map_pointer = NULL;
     unmap = false;
 
@@ -218,7 +220,14 @@ BufferMapping::map(GLenum _target, GLuint _buffer)
         }
     }
 
+    glGetBufferParameteriv(target, GL_BUFFER_SIZE, (GLint*)&map_size);
+
     return map_pointer;
+}
+
+GLuint
+BufferMapping::getSize() const {
+    return map_size;
 }
 
 BufferMapping::~BufferMapping() {

--- a/retrace/glstate_internal.hpp
+++ b/retrace/glstate_internal.hpp
@@ -156,6 +156,7 @@ class BufferMapping
 {
     GLuint target;
     GLuint buffer;
+    GLuint map_size;
     GLvoid *map_pointer;
     bool unmap;
 
@@ -164,6 +165,9 @@ public:
 
     GLvoid *
     map(GLenum _target, GLuint _buffer);
+
+    GLuint
+    getSize() const;
 
     ~BufferMapping();
 };

--- a/retrace/glstate_shaders.cpp
+++ b/retrace/glstate_shaders.cpp
@@ -419,6 +419,14 @@ dumpUniformBlock(StateWriter &writer,
     if (raw_data) {
         std::string qualifiedName = resolveUniformName(name, size);
 
+        GLuint actual_count = mapping.getSize() / array_stride;
+        if (actual_count < desc.size) {
+            std::cerr
+                << "warning: uniform " << qualifiedName << " has fewer actual elements (" << actual_count
+                << ") than declared as used by the shader (" << desc.size << ")\n";
+            desc.size = actual_count;
+        }
+
         dumpAttribArray(writer, qualifiedName, desc, raw_data + start + offset);
     }
 }


### PR DESCRIPTION
Fixes #494

Reason it crashes is because the user provided a buffer object smaller than the UBO structure declared in the shader. This is valid for as long as the shader doesn't access the data outside of the provided region.
