### PR TITLE
glretrace: Show current frame number in window title

### DIFF
--- a/retrace/glretrace_main.cpp
+++ b/retrace/glretrace_main.cpp
@@ -565,6 +565,14 @@ frame_complete(trace::Call &call) {
         retrace::warning(call) << "could not infer drawable size (glViewport never called)\n";
     }
 
+	/* Display the frame number in the window title, except in benchmark mode
+     * as compositor/window manager activity may affect the profile. */
+	if (retrace::debug > 0 && !retrace::profiling) {
+        std::ostringstream str;
+        str << "glretrace [frame: " << retrace::frameNo << "]";
+        currentDrawable->setName(str.str().c_str());
+    }
+
     if (curMetricBackend) {
         curMetricBackend->beginQuery(QUERY_BOUNDARY_FRAME);
     }

--- a/retrace/glws.hpp
+++ b/retrace/glws.hpp
@@ -148,6 +148,8 @@ public:
         visible = true;
     }
 
+    virtual void setName(const char *name) {}
+
     virtual void copySubBuffer(int x, int y, int width, int height);
 
     virtual void swapBuffers(void) = 0;

--- a/retrace/glws_glx.cpp
+++ b/retrace/glws_glx.cpp
@@ -135,6 +135,14 @@ public:
         Drawable::show();
     }
 
+    void setName(const char *name) override {
+        if (!window) {
+            return;
+        }
+
+        setWindowName(window, name);
+    }
+
     void copySubBuffer(int x, int y, int width, int height) override {
         glXCopySubBufferMESA(display, drawable, x, y, width, height);
 

--- a/retrace/glws_xlib.cpp
+++ b/retrace/glws_xlib.cpp
@@ -248,4 +248,11 @@ showWindow(Window window)
 }
 
 
+void
+setWindowName(Window window, const char *name)
+{
+    XStoreName(display, window, const_cast<char *>(name));
+}
+
+
 } /* namespace glws */

--- a/retrace/glws_xlib.hpp
+++ b/retrace/glws_xlib.hpp
@@ -63,6 +63,8 @@ resizeWindow(Window, int width, int height);
 void
 showWindow(Window window);
 
+void
+setWindowName(Window window, const char *name);
 
 } /* namespace glws */
 


### PR DESCRIPTION
I find this can be useful to roughly identify which frames I want to be
looking at for a specific issue in a large trace, by replaying the trace
and looking at the current frame number when the issue occurs.
