### PR TITLE
d3d9trace: Capture undocumented ShaderValidator

### DIFF
--- a/specs/d3d9.py
+++ b/specs/d3d9.py
@@ -449,3 +449,18 @@ d3dperf.addFunctions([
     StdFunction(Void, "D3DPERF_SetOptions", [(DWORD, "dwOptions")], sideeffects=False),
     StdFunction(DWORD, "D3DPERF_GetStatus", [], fail='0', sideeffects=False),
 ])
+
+IDirect3DShaderValidator9 = Interface("IDirect3DShaderValidator9", IUnknown)
+PDIRECT3DSHADERVALIDATOR9 = ObjPointer(IDirect3DShaderValidator9)
+
+# undocumented interface
+IDirect3DShaderValidator9.methods += [
+    StdMethod(HRESULT, "Begin", [(OpaquePointer(Void), "arg1"), (OpaquePointer(Void), "arg2"), (ULONG, "arg3")]),
+    StdMethod(HRESULT, "Instruction", [(OpaquePointer(Void), "arg1"), (UINT, "arg2"), (ULONG, "arg3"), (UINT, "arg4")]),
+    StdMethod(HRESULT, "End", []),
+]
+
+d3d9shadervalidator = Module("d3d9")
+d3d9shadervalidator.addFunctions([
+    StdFunction(PDIRECT3DSHADERVALIDATOR9, "Direct3DShaderValidatorCreate9", [], fail='NULL'),
+])

--- a/wrappers/d3d9.def
+++ b/wrappers/d3d9.def
@@ -12,3 +12,4 @@ EXPORTS
         D3DPERF_GetStatus
         DXVA2CreateDirect3DDeviceManager9
         DXVA2CreateVideoService
+        Direct3DShaderValidatorCreate9

--- a/wrappers/d3d9trace.py
+++ b/wrappers/d3d9trace.py
@@ -26,7 +26,7 @@
 
 from dlltrace import DllTracer
 from specs.stdapi import API, Pointer, ObjPointer
-from specs.d3d9 import d3d9, D3DSHADER9, IDirect3DSwapChain9Ex, d3dperf
+from specs.d3d9 import d3d9, D3DSHADER9, IDirect3DSwapChain9Ex, d3dperf, d3d9shadervalidator
 from specs.dxva2 import dxva2
 
 
@@ -145,6 +145,7 @@ if __name__ == '__main__':
     print
 
     d3d9.mergeModule(d3dperf)
+    d3d9.mergeModule(d3d9shadervalidator)
 
     api = API()
     api.addModule(d3d9)


### PR DESCRIPTION
Add support for undocumented IDirect3DShaderValidator9 interface.
Requires updated dxsdk headers.

Signed-off-by: Patrick Rudolph <siro@das-labor.org>