### PR TITLE
CMakeList: do not overwrite module path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if (NOT WIN32)
     endif ()
 endif ()
 
-set (CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+list (APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include (ConvenienceLibrary)
 include (InstallPDB)
 


### PR DESCRIPTION
Currently, the CMakeList.txt completely overwrites the CMAKE_MODULE_PATH
variable.

This is problematic when an upper-layer buildsystem wants to set its own
module path to use custom modules.

For example, Buldroot [0] provides a custom platform description [1] to
fix cross-compilation issue. Overwriting the module path means that this
custom platform description is not found:

    System is unknown to cmake, create:
    Platform/Buildroot to use this system, please send your config file
    to cmake@www.cmake.org so it can be added to cmake

Providing such a custom platform description is what the upstream cmake
devs suggest [2], quoting:

    If a toolchain file specifies CMAKE_SYSTEM_NAME such that a custom
    `Platform/MySystem.cmake` file is loaded then the latter can set
    them [*] as needed for the target platform.

[*] offending settings causing RPATH issues during cross-compilation.

So we need to append to the module path, rather than replace it blindly.

[0] https://buildroot.org/
[1] https://git.buildroot.org/buildroot/tree/support/misc/Buildroot.cmake
[2] http://public.kitware.com/pipermail/cmake/2017-February/065063.html

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>