### PR TITLE
retrace: fixed DDLOCK_DONOTWAIT flag clear mask

### DIFF
--- a/retrace/ddrawretrace.py
+++ b/retrace/ddrawretrace.py
@@ -71,7 +71,7 @@ class D3DRetracer(Retracer):
             # way to cope with it (other than retry).
             mapFlagsArg = method.getArgByName('dwFlags')
             if mapFlagsArg is not None:
-                print r'    dwFlags &= DDLOCK_DONOTWAIT;'
+                print r'    dwFlags &= ~DDLOCK_DONOTWAIT;'
                 print r'    dwFlags |= DDLOCK_WAIT;'
 
         Retracer.invokeInterfaceMethod(self, interface, method)


### PR DESCRIPTION
This was unintentionally clearing all other lock flags, as well as
potentially having both wait and do-not-wait set simultaneously.