### PR TITLE
Fixed issue with state dumping and multithreading

### DIFF
--- a/retrace/retrace_main.cpp
+++ b/retrace/retrace_main.cpp
@@ -280,7 +280,8 @@ retraceCall(trace::Call *call) {
         }
     }
 
-    if (call->no >= dumpStateCallNo &&
+    // dumpStateCallNo is 0 when fetching default state
+    if ((call->no == dumpStateCallNo || dumpStateCallNo == 0) &&
         dumper->canDump()) {
         StateWriter *writer = stateWriterFactory(std::cout);
         dumper->dumpState(*writer);


### PR DESCRIPTION
Fixed issue where state could be dumped before the requested call had been executed in a multithreaded trace (for example when getting state for a particular Draw call, the framebuffer could contain the contents prior to the Draw call)