### PR TITLE
libbacktrace: add HAVE_STDINT_H in config.h.in.cmake

### DIFF
--- a/thirdparty/libbacktrace/backtrace.h
+++ b/thirdparty/libbacktrace/backtrace.h
@@ -35,6 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.  */
 
 #include <stddef.h>
 #include <stdio.h>
+#include "config.h"
 
 /* We want to get a definition for uintptr_t, but we still care about
    systems that don't have <stdint.h>.  */

--- a/thirdparty/libbacktrace/config.h.in.cmake
+++ b/thirdparty/libbacktrace/config.h.in.cmake
@@ -25,3 +25,6 @@
 
 /* Define to 1 if dwarf.h is in the libdwarf folder */
 #cmakedefine HAVE_LIBDWARF_DWARF_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H @HAVE_STDINT_H@


### PR DESCRIPTION
HAVE_STDINT_H is used by backtrace.h