### PR TITLE
MSAA Texture Resolve / Unresolve surface feature with GUI checkbox

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -368,6 +368,7 @@ void MainWindow::replayTrace(bool dumpState, bool dumpThumbnails)
     m_retracer->setFileName(m_trace->fileName());
     m_retracer->setAPI(m_api);
     m_retracer->setCaptureState(dumpState);
+    m_retracer->setMsaaResolve(m_ui.surfacesResolveMSAA->isChecked());
     m_retracer->setCaptureThumbnails(dumpThumbnails);
     if (m_retracer->captureState() && m_selectedEvent) {
         int index = 0;
@@ -924,7 +925,7 @@ void MainWindow::showSelectedSurface()
 
     ImageViewer *viewer =
         new ImageViewer(this, m_ui.surfacesOpaqueCB->isChecked(),
-                        m_ui.surfacesAlphaCB->isChecked());
+                              m_ui.surfacesAlphaCB->isChecked());
 
     QString title;
     if (selectedCall()) {
@@ -1156,6 +1157,8 @@ void MainWindow::initConnections()
     connect(m_ui.surfacesOpaqueCB, SIGNAL(stateChanged(int)), this,
             SLOT(updateSurfacesView()));
     connect(m_ui.surfacesAlphaCB, SIGNAL(stateChanged(int)), this,
+            SLOT(updateSurfacesView()));
+    connect(m_ui.surfacesResolveMSAA, SIGNAL(stateChanged(int)), this,
             SLOT(updateSurfacesView()));
 }
 

--- a/gui/retracer.cpp
+++ b/gui/retracer.cpp
@@ -133,6 +133,7 @@ Retracer::Retracer(QObject *parent)
       m_doubleBuffered(true),
       m_singlethread(false),
       m_useCoreProfile(false),
+      m_msaaResolve(true),
       m_captureState(false),
       m_captureThumbnails(false),
       m_captureCall(0),
@@ -233,6 +234,16 @@ void Retracer::setProfiling(bool gpu, bool cpu, bool pixels)
     m_profileGpu = gpu;
     m_profileCpu = cpu;
     m_profilePixels = pixels;
+}
+
+bool Retracer::isMsaaResolve() const
+{
+    return m_msaaResolve;
+}
+
+void Retracer::setMsaaResolve(bool resolve)
+{
+    m_msaaResolve = resolve;
 }
 
 void Retracer::setCaptureAtCallNumber(qlonglong num)
@@ -345,6 +356,10 @@ void Retracer::run()
 
     if (m_useCoreProfile) {
         arguments << QLatin1String("--core");
+    }
+
+    if (!m_msaaResolve) {
+        arguments << QLatin1String("--msaa-no-resolve");
     }
 
     if (m_captureState) {

--- a/gui/retracer.h
+++ b/gui/retracer.h
@@ -43,6 +43,9 @@ public:
     bool isProfiling() const;
     void setProfiling(bool gpu, bool cpu, bool pixels);
 
+    bool isMsaaResolve() const;
+    void setMsaaResolve(bool resolve);
+
     void setCaptureAtCallNumber(qlonglong num);
     qlonglong captureAtCallNumber() const;
 
@@ -77,6 +80,7 @@ private:
     bool m_doubleBuffered;
     bool m_singlethread;
     bool m_useCoreProfile;
+    bool m_msaaResolve;
     bool m_captureState;
     bool m_captureThumbnails;
     qlonglong m_captureCall;

--- a/gui/ui/imageviewer.ui
+++ b/gui/ui/imageviewer.ui
@@ -203,6 +203,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="resolveMSAACheckBox">
+       <property name="text">
+        <string>resolveMSAA</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Zoom:</string>

--- a/gui/ui/mainwindow.ui
+++ b/gui/ui/mainwindow.ui
@@ -103,7 +103,7 @@
    </property>
    <property name="minimumSize">
     <size>
-     <width>77</width>
+     <width>85</width>
      <height>100</height>
     </size>
    </property>
@@ -215,7 +215,17 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0" colspan="2">
+         <item row="1" column="2">
+          <widget class="QCheckBox" name="surfacesResolveMSAA">
+           <property name="text">
+            <string>Resolve (MSAA)</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0" colspan="3">
           <widget class="QTreeWidget" name="surfacesTreeWidget">
            <column>
             <property name="text">
@@ -455,7 +465,7 @@
          <property name="maximum">
           <number>1024</number>
          </property>
-       </widget>
+        </widget>
        </item>
       </layout>
      </item>

--- a/retrace/dxgiretrace.py
+++ b/retrace/dxgiretrace.py
@@ -455,7 +455,9 @@ class D3DRetracer(Retracer):
             print r'    }'
             # Interpret argument as string
             Retracer.extractArg(self, function, arg, LPCSTR, lvalue, rvalue)
-            print r'    assert(pData);'
+            print r'    if (!pData) {'
+            print r'        return;'
+            print r'    }'
             print r'    assert(DataSize >= strlen((const char *)pData));'
             print r'    // Some applications include the trailing zero terminator in the data'
             print r'    DataSize = strlen((const char *)pData);'

--- a/retrace/glstate.cpp
+++ b/retrace/glstate.cpp
@@ -122,6 +122,81 @@ PixelPackState::~PixelPackState() {
     }
 }
 
+TempId::TempId(GLenum _target) :
+    target(_target),
+    id(0)
+{
+    switch (target){
+    case GL_ARRAY_BUFFER:
+        glGenBuffers(1, &id);
+        break;
+    case GL_FRAMEBUFFER:
+        glGenFramebuffers(1, &id);
+        break;
+    case GL_PROGRAM:
+        id = glCreateProgram();
+        break;
+    case GL_RENDERBUFFER:
+        glGenRenderbuffers(1, &id);
+        break;
+    case GL_TEXTURE:
+        glGenTextures(1, &id);
+        break;
+    case GL_VERTEX_ARRAY:
+        glGenVertexArrays(1, &id);
+        break;
+    default:
+        assert(false);
+        id = 0;
+        return;
+    }
+}
+
+TempId::~TempId()
+{
+    switch (target){
+    case GL_ARRAY_BUFFER:
+        glDeleteBuffers(1, &id);
+        break;
+    case GL_FRAMEBUFFER:
+        glDeleteFramebuffers(1, &id);
+        break;
+    case GL_PROGRAM:
+        glDeleteProgram(id);
+        break;
+    case GL_RENDERBUFFER:
+        glGenRenderbuffers(1, &id);
+        break;
+    case GL_TEXTURE:
+        glDeleteTextures(1, &id);
+        break;
+    case GL_VERTEX_ARRAY:
+        glGenVertexArrays(1, &id);
+        break;
+    default:
+        assert(false);
+        id = 0;
+        return;
+    }
+}
+
+TextureBinding::TextureBinding(GLenum _target, GLuint _id) :
+    target(_target),
+    id(_id),
+    prev_id(0)
+{
+    GLenum binding = getTextureBinding(target);
+    glGetIntegerv(binding, (GLint *) &prev_id);
+    if (prev_id != id) {
+        glBindTexture(target, id);
+    }
+}
+
+TextureBinding::~TextureBinding() {
+    if (prev_id != id) {
+        glBindTexture(target, prev_id);
+    }
+}
 
 static GLenum
 getBufferBinding(GLenum target) {
@@ -136,6 +211,8 @@ getBufferBinding(GLenum target) {
         return GL_COPY_WRITE_BUFFER_BINDING;
     case GL_DRAW_INDIRECT_BUFFER:
         return GL_DRAW_INDIRECT_BUFFER_BINDING;
+    case GL_FRAMEBUFFER:
+        return GL_FRAMEBUFFER_BINDING;
     case GL_DISPATCH_INDIRECT_BUFFER:
         return GL_DISPATCH_INDIRECT_BUFFER_BINDING;
     case GL_ELEMENT_ARRAY_BUFFER:
@@ -146,6 +223,8 @@ getBufferBinding(GLenum target) {
         return GL_PIXEL_UNPACK_BUFFER_BINDING;
     case GL_QUERY_BUFFER:
         return GL_QUERY_BUFFER_BINDING;
+    case GL_RENDERBUFFER:
+        return GL_RENDERBUFFER_BINDING;
     case GL_SHADER_STORAGE_BUFFER:
         return GL_SHADER_STORAGE_BUFFER_BINDING;
     case GL_TEXTURE_BUFFER:
@@ -170,13 +249,35 @@ BufferBinding::BufferBinding(GLenum _target, GLuint _buffer) :
     glGetIntegerv(binding, (GLint *) &prevBuffer);
 
     if (prevBuffer != buffer) {
-        glBindBuffer(target, buffer);
+        switch(target)
+        {
+        case GL_FRAMEBUFFER:
+            glBindFramebuffer(target, buffer);
+            break;
+        case GL_RENDERBUFFER:
+            glBindRenderbuffer(target, buffer);
+            break;
+        default:
+            glBindBuffer(target, buffer);
+            break;
+        }
     }
 }
 
 BufferBinding::~BufferBinding() {
     if (prevBuffer != buffer) {
-        glBindBuffer(target, prevBuffer);
+        switch(target)
+        {
+        case GL_FRAMEBUFFER:
+            glBindFramebuffer(target, prevBuffer);
+            break;
+        case GL_RENDERBUFFER:
+            glBindRenderbuffer(target, prevBuffer);
+            break;
+        default:
+            glBindBuffer(target, prevBuffer);
+            break;
+        }
     }
 }
 

--- a/retrace/glstate_internal.hpp
+++ b/retrace/glstate_internal.hpp
@@ -132,6 +132,38 @@ public:
 const PixelFormat *
 getPixelFormat(GLenum internalFormat);
 
+/**
+ * Helper class to temporarily create a temporary id for a specified target until
+ * control leaves the declaration scope.
+ */
+class TempId
+{
+private:
+    GLenum target;
+    GLuint id;
+
+public:
+    TempId(GLenum _target);
+    GLuint ID(){ return id; }
+    ~TempId();
+};
+
+/**
+ * Helper class to temporarily bind a texture to the specified target until
+ * control leaves the declaration scope.
+ */
+class TextureBinding
+{
+private:
+    GLenum target;
+    GLuint id;
+    GLuint prev_id;
+
+public:
+    TextureBinding(GLenum _target, GLuint _id);
+    GLuint ID(){ return id; }
+    ~TextureBinding();
+};
 
 /**
  * Helper class to temporarily bind a buffer to the specified target until
@@ -149,7 +181,6 @@ public:
 
     ~BufferBinding();
 };
-
 
 /**
  * Helper class to temporarily map a buffer (if necessary), and unmap when

--- a/retrace/retrace_main.cpp
+++ b/retrace/retrace_main.cpp
@@ -84,6 +84,8 @@ bool forceWindowed = true;
 bool dumpingState = false;
 bool dumpingSnapshots = false;
 
+bool resolveMSAA = true;
+
 Driver driver = DRIVER_DEFAULT;
 const char *driverModule = NULL;
 
@@ -351,7 +353,7 @@ private:
     RelayRace *race;
 
     unsigned leg;
-    
+
     os::mutex mutex;
     os::condition_variable wake_cond;
 
@@ -593,7 +595,7 @@ static void
 mainLoop() {
     addCallbacks(retracer);
 
-    long long startTime = 0; 
+    long long startTime = 0;
     frameNo = 0;
 
     startTime = os::getTime();
@@ -614,7 +616,7 @@ mainLoop() {
     float timeInterval = (endTime - startTime) * (1.0 / os::timeFrequency);
 
     if ((retrace::verbosity >= -1) || (retrace::profiling)) {
-        std::cout << 
+        std::cout <<
             "Rendered " << frameNo << " frames"
             " in " <<  timeInterval << " secs,"
             " average of " << (frameNo/timeInterval) << " fps\n";
@@ -633,7 +635,7 @@ mainLoop() {
 
 static void
 usage(const char *argv0) {
-    std::cout << 
+    std::cout <<
         "Usage: " << argv0 << " [OPTION] TRACE [...]\n"
         "Replay TRACE.\n"
         "\n"
@@ -658,6 +660,7 @@ usage(const char *argv0) {
         "      --headless          don't show windows\n"
         "      --sb                use a single buffer visual\n"
         "  -m, --mrt               dump all MRTs and depth/stencil\n"
+        "      --msaa-no-resolve   dump raw sample images of multisampled texture instead of resolved texture\n"
         "  -s, --snapshot-prefix=PREFIX    take snapshots; `-` for PNM stdout output\n"
         "      --snapshot-alpha    Include alpha channel in snapshots.\n"
         "      --snapshot-format=FMT       use (PNM, RGB, or MD5; default is PNM) when writing to stdout output\n"
@@ -692,6 +695,7 @@ enum {
     PDRAWCALLS_OPT,
     PLMETRICS_OPT,
     GENPASS_OPT,
+    MSAA_NO_RESOLVE_OPT,
     SB_OPT,
     LOOP_OPT,
     SINGLETHREAD_OPT,
@@ -723,6 +727,7 @@ longOptions[] = {
     {"headless", no_argument, 0, HEADLESS_OPT},
     {"help", no_argument, 0, 'h'},
     {"mrt", no_argument, 0, 'm'},
+    {"msaa-no-resolve", no_argument, 0, MSAA_NO_RESOLVE_OPT},
     {"pcpu", no_argument, 0, PCPU_OPT},
     {"pgpu", no_argument, 0, PGPU_OPT},
     {"ppd", no_argument, 0, PPD_OPT},
@@ -887,6 +892,9 @@ int main(int argc, char **argv)
             break;
         case 'm':
             retrace::snapshotMRT = true;
+            break;
+        case MSAA_NO_RESOLVE_OPT:
+            retrace::resolveMSAA = false;
             break;
         case SB_OPT:
             retrace::doubleBuffer = false;


### PR DESCRIPTION
Squashed commits into 1. Fixed early returns.

Provide msaa texture resolve feature with GUI checkbox. Requires a retrace to change the output and uses the CLI argument --no-msaa-resolve to fetch all the sample frames in a vertical array. Shows up in the surfaces tab of the texture.