### PR TITLE
Fix some warnings found when using MSAA for depth/Stencil

### DIFF
--- a/retrace/glstate.cpp
+++ b/retrace/glstate.cpp
@@ -209,6 +209,8 @@ getBufferBinding(GLenum target) {
         return GL_COPY_READ_BUFFER_BINDING;
     case GL_COPY_WRITE_BUFFER:
         return GL_COPY_WRITE_BUFFER_BINDING;
+    case GL_DRAW_BUFFER:
+        return GL_DRAW_BUFFER;
     case GL_DRAW_INDIRECT_BUFFER:
         return GL_DRAW_INDIRECT_BUFFER_BINDING;
     case GL_FRAMEBUFFER:
@@ -223,6 +225,8 @@ getBufferBinding(GLenum target) {
         return GL_PIXEL_UNPACK_BUFFER_BINDING;
     case GL_QUERY_BUFFER:
         return GL_QUERY_BUFFER_BINDING;
+    case GL_READ_BUFFER:
+        return GL_READ_BUFFER;
     case GL_RENDERBUFFER:
         return GL_RENDERBUFFER_BINDING;
     case GL_SHADER_STORAGE_BUFFER:
@@ -251,6 +255,12 @@ BufferBinding::BufferBinding(GLenum _target, GLuint _buffer) :
     if (prevBuffer != buffer) {
         switch(target)
         {
+        case GL_DRAW_BUFFER:
+            glDrawBuffer(buffer);
+            break;
+        case GL_READ_BUFFER:
+            glReadBuffer(buffer);
+            break;
         case GL_FRAMEBUFFER:
             glBindFramebuffer(target, buffer);
             break;
@@ -268,6 +278,12 @@ BufferBinding::~BufferBinding() {
     if (prevBuffer != buffer) {
         switch(target)
         {
+        case GL_DRAW_BUFFER:
+            glDrawBuffer(prevBuffer);
+            break;
+        case GL_READ_BUFFER:
+            glReadBuffer(prevBuffer);
+            break;
         case GL_FRAMEBUFFER:
             glBindFramebuffer(target, prevBuffer);
             break;

--- a/retrace/glstate_images.cpp
+++ b/retrace/glstate_images.cpp
@@ -649,7 +649,19 @@ getTexImageMSAA(GLenum target, GLenum format, GLenum type,
     glEnableVertexAttribArray(0);
 
     glTexImage2D(GL_TEXTURE_2D, 0, desc.internalFormat, desc.width, viewport_height, 0, format, type, NULL);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, bt.ID(), 0);
+
+    switch(format)
+    {
+        case GL_DEPTH_COMPONENT:
+            glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, bt.ID(), 0);
+            break;
+        case GL_STENCIL_INDEX:
+            glFramebufferTexture(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, bt.ID(), 0);
+            break;
+        default:
+            glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, bt.ID(), 0);
+            break;
+    }
 
     GLuint result = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (result != GL_FRAMEBUFFER_COMPLETE)
@@ -659,7 +671,7 @@ getTexImageMSAA(GLenum target, GLenum format, GLenum type,
     }
 
     glClearColor(0.1f, 0.2f, 0.3f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 

--- a/retrace/glstate_shaders.cpp
+++ b/retrace/glstate_shaders.cpp
@@ -421,10 +421,10 @@ dumpUniformBlock(StateWriter &writer,
         GLchar* block_name = new GLchar[active_uniform_block_max_name_length];
 
         GLint block_data_size = 0;
-        glGetActiveUniformBlockiv(program, index, GL_UNIFORM_BLOCK_DATA_SIZE, &block_data_size);
+        glGetActiveUniformBlockiv(program, block_index, GL_UNIFORM_BLOCK_DATA_SIZE, &block_data_size);
 
         GLsizei length = 0;
-        glGetActiveUniformBlockName(program, index, active_uniform_block_max_name_length, &length, block_name);
+        glGetActiveUniformBlockName(program, block_index, active_uniform_block_max_name_length, &length, block_name);
 
         std::cerr
             << "uniform `" << name << "`, size " << size << ", type " << enumToString(desc.type) << "\n"
@@ -440,12 +440,18 @@ dumpUniformBlock(StateWriter &writer,
     GLint start = 0;
     glGetIntegeri_v(GL_UNIFORM_BUFFER_START, slot, &start);
 
-    BufferMapping mapping;
-    const GLbyte *raw_data = (const GLbyte *)mapping.map(GL_UNIFORM_BUFFER, ubo);
-    if (raw_data) {
-        std::string qualifiedName = resolveUniformName(name, size);
+    /* If ubo is zero, don't try to map to a 0 bound buffer. */
+    if (ubo) {
+        BufferMapping mapping;
+        const GLbyte *raw_data = (const GLbyte *)mapping.map(GL_UNIFORM_BUFFER, ubo);
+        if (raw_data) {
+            std::string qualifiedName = resolveUniformName(name, size);
 
-        dumpAttribArray(writer, qualifiedName, desc, raw_data + start + offset);
+            dumpAttribArray(writer, qualifiedName, desc, raw_data + start + offset);
+        }
+    }
+    else {
+        std::cerr << "Uniform buffer object not bound.\n";
     }
 }
 


### PR DESCRIPTION
Avoid looking up state on unbound features. Make sure to replace state for GL_READ and GL_DRAW buffers.