### PR TITLE
glretrace: Implement --borderless option for xlib

### DIFF
--- a/retrace/glretrace_ws.cpp
+++ b/retrace/glretrace_ws.cpp
@@ -79,7 +79,7 @@ static glws::Drawable *
 createDrawableHelper(glfeatures::Profile profile, int width = 32, int height = 32,
                      const glws::pbuffer_info *pbInfo = NULL) {
     glws::Visual *visual = getVisual(profile);
-    glws::Drawable *draw = glws::createDrawable(visual, width, height, pbInfo);
+    glws::Drawable *draw = glws::createDrawable(visual, width, height, pbInfo, retrace::borderlessWindow);
     if (!draw) {
         std::cerr << "error: failed to create OpenGL drawable\n";
         exit(1);

--- a/retrace/glws.hpp
+++ b/retrace/glws.hpp
@@ -118,17 +118,19 @@ public:
     int width;
     int height;
     bool pbuffer;
+    bool borderless;
     bool visible;
 
     // For WGL_ARB_render_texture
     glws::pbuffer_info pbInfo;
     int mipmapLevel, cubeFace;
 
-    Drawable(const Visual *vis, int w, int h, bool pb) :
+    Drawable(const Visual *vis, int w, int h, bool pb, bool borderless) :
         visual(vis),
         width(w),
         height(h),
         pbuffer(pb),
+        borderless(borderless),
         visible(false),
         mipmapLevel(0),
         cubeFace(0)
@@ -204,6 +206,10 @@ createVisual(bool doubleBuffer, unsigned samples, Profile profile);
 Drawable *
 createDrawable(const Visual *visual, int width, int height,
                const glws::pbuffer_info *pbInfo = NULL);
+
+Drawable *
+createDrawable(const Visual *visual, int width, int height,
+               const glws::pbuffer_info *pbInfo, bool borderless = false);
 
 Context *
 createContext(const Visual *visual, Context *shareContext = 0, bool debug = false);

--- a/retrace/glws_egl_xlib.cpp
+++ b/retrace/glws_egl_xlib.cpp
@@ -107,14 +107,14 @@ public:
     EGLenum api;
 
     EglDrawable(const Visual *vis, int w, int h,
-                const glws::pbuffer_info *pbInfo) :
-        Drawable(vis, w, h, pbInfo),
+                const glws::pbuffer_info *pbInfo, bool borderless) :
+        Drawable(vis, w, h, pbInfo, borderless),
         api(EGL_OPENGL_ES_API)
     {
         XVisualInfo *visinfo = static_cast<const EglVisual *>(visual)->visinfo;
 
         const char *name = "eglretrace";
-        window = createWindow(visinfo, name, width, height);
+        window = createWindow(visinfo, name, width, height, borderless);
 
         eglWaitNative(EGL_CORE_NATIVE_ENGINE);
 
@@ -409,9 +409,9 @@ createVisual(bool doubleBuffer, unsigned samples, Profile profile) {
 
 Drawable *
 createDrawable(const Visual *visual, int width, int height,
-               const glws::pbuffer_info *pbInfo)
+               const glws::pbuffer_info *pbInfo, bool borderless)
 {
-    return new EglDrawable(visual, width, height, pbInfo);
+    return new EglDrawable(visual, width, height, pbInfo, borderless);
 }
 
 

--- a/retrace/glws_glx.cpp
+++ b/retrace/glws_glx.cpp
@@ -71,8 +71,8 @@ public:
     GLXDrawable drawable = 0;
 
     GlxDrawable(const Visual *vis, int w, int h,
-                const glws::pbuffer_info *pbInfo) :
-        Drawable(vis, w, h, pbInfo ? true : false)
+                const glws::pbuffer_info *pbInfo, bool borderless) :
+        Drawable(vis, w, h, pbInfo ? true : false, borderless)
     {
         const GlxVisual *glxvisual = static_cast<const GlxVisual *>(visual);
         XVisualInfo *visinfo = glxvisual->visinfo;
@@ -82,7 +82,7 @@ public:
             drawable = createPbuffer(display, glxvisual, pbInfo, w, h);
         }
         else {
-            window = createWindow(visinfo, name, width, height);
+            window = createWindow(visinfo, name, width, height, borderless);
             drawable = glXCreateWindow(display, glxvisual->fbconfig, window, NULL);
             if (has_GLX_EXT_swap_control) {
                 glXSwapIntervalEXT(display, drawable, 0);
@@ -310,7 +310,13 @@ Drawable *
 createDrawable(const Visual *visual, int width, int height,
                const glws::pbuffer_info *pbInfo)
 {
-    return new GlxDrawable(visual, width, height, pbInfo);
+    return new GlxDrawable(visual, width, height, pbInfo, false);
+}
+
+Drawable *
+createDrawable(const Visual *visual, int width, int height, const glws::pbuffer_info *pbInfo, bool borderless)
+{
+    return new GlxDrawable(visual, width, height, pbInfo, borderless);
 }
 
 Context *

--- a/retrace/glws_wgl.cpp
+++ b/retrace/glws_wgl.cpp
@@ -97,9 +97,11 @@ public:
     HDC hDC;
 
     WglDrawable(const Visual *vis, int width, int height,
-                const glws::pbuffer_info *pbInfo) :
-        Drawable(vis, width, height, pbInfo ? true : false)
+                const glws::pbuffer_info *pbInfo, bool borderless) :
+        Drawable(vis, width, height, pbInfo ? true : false, borderless)
     {
+
+        // TODO: Implement borderless
 
         if (pbInfo) {
             createPbuffer(vis, pbInfo, width, height);
@@ -107,7 +109,6 @@ public:
         }
         else {
             hWnd = ws::createWindow("glretrace", width, height);
-
             hDC = GetDC(hWnd);
 
             PIXELFORMATDESCRIPTOR pfd;
@@ -448,9 +449,9 @@ createVisual(bool doubleBuffer, unsigned samples, Profile profile) {
 
 Drawable *
 createDrawable(const Visual *visual, int width, int height,
-               const glws::pbuffer_info *pbInfo)
+               const glws::pbuffer_info *pbInfo, bool borderless)
 {
-    return new WglDrawable(visual, width, height, pbInfo);
+    return new WglDrawable(visual, width, height, pbInfo, borderless);
 }
 
 Context *

--- a/retrace/glws_xlib.cpp
+++ b/retrace/glws_xlib.cpp
@@ -177,7 +177,8 @@ processKeys(Window window)
 Window
 createWindow(XVisualInfo *visinfo,
              const char *name,
-             int width, int height)
+             int width, int height,
+             bool borderless)
 {
     Window root = RootWindow(display, screen);
 
@@ -190,6 +191,11 @@ createWindow(XVisualInfo *visinfo,
 
     unsigned long mask;
     mask = CWBackPixel | CWBorderPixel | CWColormap | CWEventMask;
+
+    if (borderless) {
+        attr.override_redirect = True;
+        mask |= CWOverrideRedirect;
+    }
 
     int x = 0, y = 0;
 

--- a/retrace/glws_xlib.hpp
+++ b/retrace/glws_xlib.hpp
@@ -55,7 +55,8 @@ processKeys(Window window);
 Window
 createWindow(XVisualInfo *visinfo,
              const char *name,
-             int width, int height);
+             int width, int height,
+             bool borderless);
 
 void
 resizeWindow(Window, int width, int height);

--- a/retrace/retrace.hpp
+++ b/retrace/retrace.hpp
@@ -169,6 +169,10 @@ extern bool profilingMemoryUsage;
 extern bool dumpingState;
 extern bool dumpingSnapshots;
 
+/**
+ * Use borderless window on retrace
+ */
+extern bool borderlessWindow;
 
 enum Driver {
     DRIVER_DEFAULT,

--- a/retrace/retrace_main.cpp
+++ b/retrace/retrace_main.cpp
@@ -74,7 +74,7 @@ namespace retrace {
 trace::AbstractParser *parser;
 trace::Profiler profiler;
 
-
+bool borderlessWindow = false;
 int verbosity = 0;
 unsigned debug = 1;
 bool markers = false;
@@ -640,6 +640,7 @@ usage(const char *argv0) {
         "Replay TRACE.\n"
         "\n"
         "  -b, --benchmark         benchmark mode (no error checking or warning messages)\n"
+        "  -B, --borderless        replay in borderless window\n"
         "  -d, --debug             increase debugging checks\n"
         "      --markers           insert call no markers in the command stream\n"
         "      --pcpu              cpu profiling (cpu times per call)\n"
@@ -709,11 +710,12 @@ enum {
 };
 
 const static char *
-shortOptions = "bdD:hms:S:vwt";
+shortOptions = "bBdD:hms:S:vwt";
 
 const static struct option
 longOptions[] = {
     {"benchmark", no_argument, 0, 'b'},
+    {"borderless", no_argument, 0, 'B'},
     {"debug", no_argument, 0, 'd'},
     {"markers", no_argument, 0, MARKERS_OPT},
     {"call-nos", optional_argument, 0, CALL_NOS_OPT },
@@ -838,6 +840,9 @@ int main(int argc, char **argv)
             break;
         case MARKERS_OPT:
             retrace::markers = true;
+            break;
+        case 'B':
+            retrace::borderlessWindow = true;
             break;
         case 'd':
             ++retrace::debug;


### PR DESCRIPTION
Here is a pull request that implements the --borderless option. We have found it useful for replaying traces that were created from an app that runs in a full-screen borderless window.

Unfortunately, this is implemented for xlib only. I don't think it would be that difficult to extend this for other platforms.