### PR TITLE
Add call filtering for sed command

### DIFF
--- a/lib/trace/trace_callset.hpp
+++ b/lib/trace/trace_callset.hpp
@@ -173,15 +173,15 @@ namespace trace {
         }
 
         inline bool
-        contains(const trace::Call &call) {
+        contains(const trace::Call &call) const {
             return contains(call.no, call.flags);
         }
 
-        CallNo getFirst() {
+        CallNo getFirst() const {
             return limits.start;
         }
 
-        CallNo getLast() {
+        CallNo getLast() const {
             return limits.stop;
         }
     };


### PR DESCRIPTION
"trace sed" now accepts a parameter like the trim command:

    --calls=CALLSET parameter

It applies the sed renaming only to those callsets specified.

Use case: Rename enums only for certain specific calls, not globally in
the whole trace.