### PR TITLE
wrapper: Also generate DLL interposers for D3D11 tracing.

### DIFF
--- a/wrappers/CMakeLists.txt
+++ b/wrappers/CMakeLists.txt
@@ -223,20 +223,48 @@ if (WIN32)
                 ${CMAKE_SOURCE_DIR}/specs/winapi.py
                 ${CMAKE_SOURCE_DIR}/specs/stdapi.py
         )
-        add_library (dxgitrace MODULE
+        add_library (dxgitrace SHARED
             dxgitrace.def
             dxgitrace.cpp
             d3dcommonshader.cpp
         )
+
         target_link_libraries (dxgitrace
             d3dhelpers
             trace
         )
+
         set_target_properties (dxgitrace
             PROPERTIES PREFIX ""
         )
-        install (TARGETS dxgitrace LIBRARY DESTINATION ${WRAPPER_INSTALL_DIR})
+        install (TARGETS dxgitrace RUNTIME DESTINATION ${WRAPPER_INSTALL_DIR})
         install_pdb (dxgitrace DESTINATION ${WRAPPER_INSTALL_DIR})
+
+        add_library (dxgi MODULE
+            dxgi.def
+        )
+
+        target_link_libraries (dxgi
+            dxgitrace
+        )
+
+        set_target_properties (dxgi
+            PROPERTIES PREFIX "" LINK_FLAGS "/NOENTRY"
+        )
+        install (TARGETS dxgi LIBRARY DESTINATION ${WRAPPER_INSTALL_DIR})
+
+        add_library (d3d11 MODULE
+            d3d11.def
+        )
+
+        target_link_libraries (d3d11
+            dxgitrace
+        )
+
+        set_target_properties (d3d11
+            PROPERTIES PREFIX "" LINK_FLAGS "/NOENTRY"
+        )
+        install (TARGETS d3d11 LIBRARY DESTINATION ${WRAPPER_INSTALL_DIR})
     endif ()
 
     # d2d1.dll, dwrite.dll

--- a/wrappers/d3d11.def
+++ b/wrappers/d3d11.def
@@ -1,7 +1,4 @@
 EXPORTS
-	CreateDXGIFactory
-	CreateDXGIFactory1
-	CreateDXGIFactory2
 	D3D10CreateDevice
 	D3D10CreateDeviceAndSwapChain
 	D3D10CreateDevice1

--- a/wrappers/dxgi.def
+++ b/wrappers/dxgi.def
@@ -1,0 +1,4 @@
+EXPORTS
+	CreateDXGIFactory
+	CreateDXGIFactory1
+	CreateDXGIFactory2


### PR DESCRIPTION
This lets me trace D3D11 games that don't want to run through apitrace.exe such as Far Cry 5 and Assassin's Creed: Origins.