### PR TITLE
Add an option to use regex when searching in qapitrace

### DIFF
--- a/gui/apitrace.cpp
+++ b/gui/apitrace.cpp
@@ -308,15 +308,16 @@ void ApiTrace::loaderFrameLoaded(ApiTraceFrame *frame,
 void ApiTrace::findNext(ApiTraceFrame *frame,
                         ApiTraceCall *from,
                         const QString &str,
-                        Qt::CaseSensitivity sensitivity)
+                        Qt::CaseSensitivity sensitivity,
+                        bool useRegex)
 {
     ApiTraceCall *foundCall = 0;
     int frameIdx = m_frames.indexOf(frame);
     SearchRequest request(SearchRequest::Next,
-                          frame, from, str, sensitivity);
+                          frame, from, str, sensitivity, useRegex);
 
     if (frame->isLoaded()) {
-        foundCall = frame->findNextCall(from, str, sensitivity);
+        foundCall = frame->findNextCall(from, str, sensitivity, useRegex);
         if (foundCall) {
             emit findResult(request, SearchResult_Found, foundCall);
             return;
@@ -336,7 +337,7 @@ void ApiTrace::findNext(ApiTraceFrame *frame,
             emit loaderSearch(request);
             return;
         } else {
-            ApiTraceCall *call = frame->findNextCall(0, str, sensitivity);
+            ApiTraceCall *call = frame->findNextCall(0, str, sensitivity, useRegex);
             if (call) {
                 emit findResult(request, SearchResult_Found, call);
                 return;
@@ -349,15 +350,16 @@ void ApiTrace::findNext(ApiTraceFrame *frame,
 void ApiTrace::findPrev(ApiTraceFrame *frame,
                         ApiTraceCall *from,
                         const QString &str,
-                        Qt::CaseSensitivity sensitivity)
+                        Qt::CaseSensitivity sensitivity,
+                        bool useRegex)
 {
     ApiTraceCall *foundCall = 0;
     int frameIdx = m_frames.indexOf(frame);
     SearchRequest request(SearchRequest::Prev,
-                          frame, from, str, sensitivity);
+                          frame, from, str, sensitivity, useRegex);
 
     if (frame->isLoaded()) {
-        foundCall = frame->findPrevCall(from, str, sensitivity);
+        foundCall = frame->findPrevCall(from, str, sensitivity, useRegex);
         if (foundCall) {
             emit findResult(request, SearchResult_Found, foundCall);
             return;
@@ -376,7 +378,7 @@ void ApiTrace::findPrev(ApiTraceFrame *frame,
             emit loaderSearch(request);
             return;
         } else {
-            ApiTraceCall *call = frame->findPrevCall(0, str, sensitivity);
+            ApiTraceCall *call = frame->findPrevCall(0, str, sensitivity, useRegex);
             if (call) {
                 emit findResult(request, SearchResult_Found, call);
                 return;

--- a/gui/apitrace.h
+++ b/gui/apitrace.h
@@ -35,18 +35,21 @@ public:
                       ApiTraceFrame *f,
                       ApiTraceCall *call,
                       QString str,
-                      Qt::CaseSensitivity caseSens)
+                      Qt::CaseSensitivity caseSens,
+                      bool useRegex)
             : direction(dir),
               frame(f),
               from(call),
               text(str),
-              cs(caseSens)
+              cs(caseSens),
+              useRegex(useRegex)
         {}
         Direction direction;
         ApiTraceFrame *frame;
         ApiTraceCall *from;
         QString text;
         Qt::CaseSensitivity cs;
+        bool useRegex;
     };
 
 public:
@@ -95,11 +98,13 @@ public slots:
     void findNext(ApiTraceFrame *frame,
                   ApiTraceCall *call,
                   const QString &str,
-                  Qt::CaseSensitivity sensitivity);
+                  Qt::CaseSensitivity sensitivity,
+                  bool useRegex);
     void findPrev(ApiTraceFrame *frame,
                   ApiTraceCall *call,
                   const QString &str,
-                  Qt::CaseSensitivity sensitivity);
+                  Qt::CaseSensitivity sensitivity,
+                  bool useRegex);
     void findFrameStart(ApiTraceFrame *frame);
     void findFrameEnd(ApiTraceFrame *frame);
     void findCallIndex(int index);

--- a/gui/apitracecall.cpp
+++ b/gui/apitracecall.cpp
@@ -1109,10 +1109,12 @@ int ApiTraceCall::numChildren() const
 }
 
 bool ApiTraceCall::contains(const QString &str,
-                            Qt::CaseSensitivity sensitivity) const
+                            Qt::CaseSensitivity sensitivity,
+                            bool useRegex) const
 {
     QString txt = searchText();
-    return txt.contains(str, sensitivity);
+    return useRegex ? txt.contains(QRegExp(str, sensitivity))
+                    : txt.contains(str, sensitivity);
 }
 
 void ApiTraceCall::missingThumbnail()
@@ -1265,7 +1267,8 @@ int ApiTraceFrame::numChildrenToLoad() const
 ApiTraceCall *
 ApiTraceFrame::findNextCall(ApiTraceCall *from,
                             const QString &str,
-                            Qt::CaseSensitivity sensitivity) const
+                            Qt::CaseSensitivity sensitivity,
+                            bool useRegex) const
 {
     Q_ASSERT(m_loaded);
 
@@ -1277,7 +1280,7 @@ ApiTraceFrame::findNextCall(ApiTraceCall *from,
 
     for (int i = callIndex; i < m_calls.count(); ++i) {
         ApiTraceCall *call = m_calls[i];
-        if (call->contains(str, sensitivity)) {
+        if (call->contains(str, sensitivity, useRegex)) {
             return call;
         }
     }
@@ -1287,7 +1290,8 @@ ApiTraceFrame::findNextCall(ApiTraceCall *from,
 ApiTraceCall *
 ApiTraceFrame::findPrevCall(ApiTraceCall *from,
                             const QString &str,
-                            Qt::CaseSensitivity sensitivity) const
+                            Qt::CaseSensitivity sensitivity,
+                            bool useRegex) const
 {
     Q_ASSERT(m_loaded);
 
@@ -1299,7 +1303,7 @@ ApiTraceFrame::findPrevCall(ApiTraceCall *from,
 
     for (int i = callIndex; i >= 0; --i) {
         ApiTraceCall *call = m_calls[i];
-        if (call->contains(str, sensitivity)) {
+        if (call->contains(str, sensitivity, useRegex)) {
             return call;
         }
     }

--- a/gui/apitracecall.h
+++ b/gui/apitracecall.h
@@ -276,7 +276,8 @@ public:
     void revert();
 
     bool contains(const QString &str,
-                  Qt::CaseSensitivity sensitivity) const;
+                  Qt::CaseSensitivity sensitivity,
+                  bool useRegex) const;
 
     ApiTrace *parentTrace() const;
 
@@ -345,11 +346,13 @@ public:
 
     ApiTraceCall *findNextCall(ApiTraceCall *from,
                                const QString &str,
-                               Qt::CaseSensitivity sensitivity) const;
+                               Qt::CaseSensitivity sensitivity,
+                               bool useRegex) const;
 
     ApiTraceCall *findPrevCall(ApiTraceCall *from,
                                const QString &str,
-                               Qt::CaseSensitivity sensitivity) const;
+                               Qt::CaseSensitivity sensitivity,
+                               bool useRegex) const;
 
     int binaryDataSize() const;
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1145,11 +1145,11 @@ void MainWindow::initConnections()
             SLOT(slotJumpTo(int)));
 
     connect(m_searchWidget,
-            SIGNAL(searchNext(const QString&, Qt::CaseSensitivity)),
-            SLOT(slotSearchNext(const QString&, Qt::CaseSensitivity)));
+            SIGNAL(searchNext(const QString&, Qt::CaseSensitivity, bool)),
+            SLOT(slotSearchNext(const QString&, Qt::CaseSensitivity, bool)));
     connect(m_searchWidget,
-            SIGNAL(searchPrev(const QString&, Qt::CaseSensitivity)),
-            SLOT(slotSearchPrev(const QString&, Qt::CaseSensitivity)));
+            SIGNAL(searchPrev(const QString&, Qt::CaseSensitivity, bool)),
+            SLOT(slotSearchPrev(const QString&, Qt::CaseSensitivity, bool)));
 
     connect(m_traceProcess, SIGNAL(tracedFile(const QString&)),
             SLOT(createdTrace(const QString&)));
@@ -1310,7 +1310,8 @@ void MainWindow::slotSearch()
 }
 
 void MainWindow::slotSearchNext(const QString &str,
-                                Qt::CaseSensitivity sensitivity)
+                                Qt::CaseSensitivity sensitivity,
+                                bool useRegex)
 {
     ApiTraceCall *call = currentCall();
     ApiTraceFrame *frame = currentFrame();
@@ -1324,11 +1325,12 @@ void MainWindow::slotSearchNext(const QString &str,
     }
     Q_ASSERT(frame);
 
-    m_trace->findNext(frame, call, str, sensitivity);
+    m_trace->findNext(frame, call, str, sensitivity, useRegex);
 }
 
 void MainWindow::slotSearchPrev(const QString &str,
-                                Qt::CaseSensitivity sensitivity)
+                                Qt::CaseSensitivity sensitivity,
+                                bool useRegex)
 {
     ApiTraceCall *call = currentCall();
     ApiTraceFrame *frame = currentFrame();
@@ -1342,7 +1344,7 @@ void MainWindow::slotSearchPrev(const QString &str,
     }
     Q_ASSERT(frame);
 
-    m_trace->findPrev(frame, call, str, sensitivity);
+    m_trace->findPrev(frame, call, str, sensitivity, useRegex);
 }
 
 void MainWindow::fillState(bool nonDefaults)
@@ -1643,10 +1645,10 @@ void MainWindow::slotSearchResult(const ApiTrace::SearchRequest &request,
 
             if (request.direction == ApiTrace::SearchRequest::Next) {
                 m_trace->findNext(call->parentFrame(), call,
-                                  request.text, request.cs);
+                                  request.text, request.cs, request.useRegex);
             } else {
                 m_trace->findNext(call->parentFrame(), call,
-                                  request.text, request.cs);
+                                  request.text, request.cs, request.useRegex);
             }
         }
     }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -89,8 +89,8 @@ private slots:
     void createdTrim(const QString &path);
     void trimError(const QString &msg);
     void slotSearch();
-    void slotSearchNext(const QString &str, Qt::CaseSensitivity sensitivity);
-    void slotSearchPrev(const QString &str, Qt::CaseSensitivity sensitivity);
+    void slotSearchNext(const QString &str, Qt::CaseSensitivity sensitivity, bool useRegex);
+    void slotSearchPrev(const QString &str, Qt::CaseSensitivity sensitivity, bool useRegex);
     void fillState(bool nonDefaults);
     void customContextMenuRequested(QPoint pos);
     void editCall();

--- a/gui/searchwidget.cpp
+++ b/gui/searchwidget.cpp
@@ -33,14 +33,14 @@ void SearchWidget::slotSearchNext()
 {
     QString txt = m_ui.lineEdit->text();
     if (!txt.isEmpty())
-        emit searchNext(txt, caseSensitivity());
+        emit searchNext(txt, caseSensitivity(), regexEnabled());
 }
 
 void SearchWidget::slotSearchPrev()
 {
     QString txt = m_ui.lineEdit->text();
     if (!txt.isEmpty())
-        emit searchPrev(txt, caseSensitivity());
+        emit searchPrev(txt, caseSensitivity(), regexEnabled());
 }
 
 void SearchWidget::slotCancel()
@@ -59,6 +59,11 @@ Qt::CaseSensitivity SearchWidget::caseSensitivity() const
         return Qt::CaseSensitive;
     else
         return Qt::CaseInsensitive;
+}
+
+bool SearchWidget::regexEnabled() const
+{
+    return m_ui.regexBox->isChecked();
 }
 
 bool SearchWidget::eventFilter(QObject *object, QEvent* event)

--- a/gui/searchwidget.h
+++ b/gui/searchwidget.h
@@ -15,8 +15,8 @@ public:
     void setFound(bool f);
     void show();
 signals:
-    void searchNext(const QString &str, Qt::CaseSensitivity cs = Qt::CaseInsensitive);
-    void searchPrev(const QString &str, Qt::CaseSensitivity cs = Qt::CaseInsensitive);
+    void searchNext(const QString &str, Qt::CaseSensitivity cs = Qt::CaseInsensitive, bool useRegex=false);
+    void searchPrev(const QString &str, Qt::CaseSensitivity cs = Qt::CaseInsensitive, bool useRegex=false);
 
 private slots:
     void slotSearchNext();
@@ -29,6 +29,7 @@ protected:
 
 private:
     Qt::CaseSensitivity caseSensitivity() const;
+    bool regexEnabled() const;
 private:
     Ui_SearchWidget m_ui;
     QPalette m_origPalette;

--- a/gui/traceloader.cpp
+++ b/gui/traceloader.cpp
@@ -196,7 +196,7 @@ void TraceLoader::searchNext(const ApiTrace::SearchRequest &request)
     trace::Call *call = 0;
     while ((call = m_parser.parse_call())) {
 
-        if (callContains(call, request.text, request.cs)) {
+        if (callContains(call, request.text, request.cs, request.useRegex)) {
             unsigned frameIdx = callInFrame(call->no);
             ApiTraceFrame *frame = m_createdFrames[frameIdx];
             const QVector<ApiTraceCall*> calls =
@@ -264,7 +264,7 @@ bool TraceLoader::searchCallsBackwards(const QList<trace::Call*> &calls,
 {
     for (int i = calls.count() - 1; i >= 0; --i) {
         trace::Call *call = calls[i];
-        if (callContains(call, request.text, request.cs)) {
+        if (callContains(call, request.text, request.cs, request.useRegex)) {
             ApiTraceFrame *frame = m_createdFrames[frameIdx];
             const QVector<ApiTraceCall*> apiCalls =
                     fetchFrameContents(frame);
@@ -301,14 +301,15 @@ int TraceLoader::callInFrame(int callIdx) const
 
 bool TraceLoader::callContains(trace::Call *call,
                                const QString &str,
-                               Qt::CaseSensitivity sensitivity)
+                               Qt::CaseSensitivity sensitivity,
+                               bool useRegex)
 {
     /*
      * FIXME: do string comparison directly on trace::Call
      */
     ApiTraceCall *apiCall = apiCallFromTraceCall(call, m_helpHash,
                                                  0, 0, this);
-    bool result = apiCall->contains(str, sensitivity);
+    bool result = apiCall->contains(str, sensitivity, useRegex);
     delete apiCall;
     return result;
 }

--- a/gui/traceloader.h
+++ b/gui/traceloader.h
@@ -100,7 +100,8 @@ private:
     int callInFrame(int callIdx) const;
     bool callContains(trace::Call *call,
                       const QString &str,
-                      Qt::CaseSensitivity sensitivity);
+                      Qt::CaseSensitivity sensitivity,
+                      bool useRegex);
      QVector<ApiTraceCall*> fetchFrameContents(ApiTraceFrame *frame);
      bool searchCallsBackwards(const QList<trace::Call*> &calls,
                                int frameIdx,

--- a/gui/ui/searchwidget.ui
+++ b/gui/ui/searchwidget.ui
@@ -89,6 +89,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="regexBox">
+     <property name="text">
+      <string>&amp;Regex</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="notFoundLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">


### PR DESCRIPTION
This commit adds a checkbox in the search widget to use regular expressions when searching. This lets in particular find exact numbers: e.g. `\b204\b` would match the number `204` but not `1.7204e-3`. Another use case: search for calls using patterns like `gl(Named)?BufferData`.