### PR TITLE
memtrace: Fix pointer arithmetic of MemoryShadow::cover

### DIFF
--- a/wrappers/memtrace.cpp
+++ b/wrappers/memtrace.cpp
@@ -118,7 +118,7 @@ mm_crc32_u32(uint32_t crc, uint32_t current)
 uint32_t
 hashBlock(const void *p)
 {
-    assert((intptr_t)p % BLOCK_SIZE == 0);
+    assert((uintptr_t)p % BLOCK_SIZE == 0);
 
     uint32_t crc;
 
@@ -185,7 +185,7 @@ void MemoryShadow::cover(void *_ptr, size_t _size, bool _discard)
     assert(_ptr);
 
     if (_size != size) {
-        nBlocks = ((intptr_t)_ptr + _size + BLOCK_SIZE - 1)/BLOCK_SIZE - (intptr_t)_ptr/BLOCK_SIZE;
+        nBlocks = ((uintptr_t)_ptr + _size + BLOCK_SIZE - 1)/BLOCK_SIZE - (uintptr_t)_ptr/BLOCK_SIZE;
 
         hashPtr = (uint32_t *)realloc(hashPtr, nBlocks * sizeof *hashPtr);
         size = _size;


### PR DESCRIPTION
Pointers have unsigned type thus casting them to `intptr_t` could lead to a negative value which in one part of the expression is being implicitly converted to `size_t` resulting in:
 `nBlocks = big_positive_number - negative_number`

This rarely happens on x64 but would often happen on x32 resulting in memory access violation.

Fixes: bac0ea039e15c219d243f2ffea40fe9b6181ce32

<details><summary>Some debugging info</summary>
<p>

That's the crash trace I've got with x32 apitrace running under wine:

```
_Z9hashBlockPKv() Address = 0x67de32bc (filename not found) [in dxgitrace.dll]

_ZN12MemoryShadow5coverEPvjb() Address = 0x67de3877 (filename not found) [in dxgitrace.dll]

_ZN24WrapID3D11DeviceContext13MapEP14ID3D11Resourcej9D3D11_MAPjP24D3D11_MAPPED_SUBRESOURCE@24() Address = 0x67cf67e5 (filename not found) [in dxgitrace.dll]

```

And the logs before the crash:

```
shadow map desc: pdata DC527000, size 4194304, map type 5, discard 0, flags 0
_ptr -598577152, _size 4194304, BLOCK_SIZE 512          <- _ptr is negative when casted to int
cover: _ptr dc527000, realptr dc527000, hashptr 14024020, _size 4194304, nBlocks 8396800
```

</p>
</details>