### PR TITLE
dxgitrace: Fix a thread safety of a d3d11 CreateBuffer method

### DIFF
--- a/wrappers/dxgitrace.py
+++ b/wrappers/dxgitrace.py
@@ -197,6 +197,16 @@ class D3DCommonTracer(DllTracer):
             print('    }')
 
     def invokeMethod(self, interface, base, method):
+        if method.name == 'CreateBuffer':
+            if interface.name.upper().find("D3D11") >= 0:
+                print(r'    D3D11_SUBRESOURCE_DATA initialData;')
+            else:
+                print(r'    D3D10_SUBRESOURCE_DATA initialData;')
+            print(r'    if (!pInitialData) {')
+            print(r'        pInitialData = &initialData;')
+            print(r'        _initialBufferAlloc(pDesc, &initialData);')
+            print(r'    }')
+
         DllTracer.invokeMethod(self, interface, base, method)
 
         # When D2D is used on top of WARP software rasterizer it seems to do
@@ -218,8 +228,8 @@ class D3DCommonTracer(DllTracer):
         # Ensure buffers are initialized, otherwise we can fail to detect
         # changes when unititialized data matches what the app wrote.
         if method.name == 'CreateBuffer':
-            print(r'    if (SUCCEEDED(_result) && !pInitialData) {')
-            print(r'        _initializeBuffer(_this, pDesc, *ppBuffer);')
+            print(r'    if (pInitialData == &initialData) {')
+            print(r'        _initialBufferFree(&initialData);')
             print(r'    }')
 
 

--- a/wrappers/trace.py
+++ b/wrappers/trace.py
@@ -528,6 +528,10 @@ class Tracer:
         print('#endif')
         print()
         print()
+        print(r'/*')
+        print(r' * g_WrappedObjects is already protected by trace::LocalWriter::mutex')
+        print(r' * This lock is hold during the beginEnter/endEnter and beginLeave/endLeave sections')
+        print(r' */')
         print('static std::map<void *, void *> g_WrappedObjects;')
 
     def footer(self, api):


### PR DESCRIPTION
According to directx 11 spec all device methods are thread safe:
   "All ID3D11Device interface methods are free-threaded, which means
    it is safe to have multiple threads call the functions
    at the same time."

But all device-context methods according to directx 11 spec:
   "Any context – immediate or deferred – can be used on any thread
    as long as the context is only used in one thread at a time."

So without this fix WrapID3D11Device*::CreateBuffer methods are not
thread safe. It could lead to the crash in some games which are
create buffers in different threads.

Signed-off-by: Andrii Simiklit <andrii.simiklit@globallogic.com>