### PR TITLE
memtrace: Update nBlocks when pointer changes in MemoryShadow::cover

### DIFF
--- a/wrappers/memtrace.cpp
+++ b/wrappers/memtrace.cpp
@@ -184,7 +184,7 @@ void MemoryShadow::cover(void *_ptr, size_t _size, bool _discard)
 {
     assert(_ptr);
 
-    if (_size != size) {
+    if (_size != size || _ptr != realPtr) {
         nBlocks = ((uintptr_t)_ptr + _size + BLOCK_SIZE - 1)/BLOCK_SIZE - (uintptr_t)_ptr/BLOCK_SIZE;
 
         hashPtr = (uint32_t *)realloc(hashPtr, nBlocks * sizeof *hashPtr);


### PR DESCRIPTION
During each ::Map different pointers could be returned by DirectX.
Thus for the same resource with the same subresource having the same size
pointer may change between calls of MemoryShadow::cover. With the pointer
change number of blocks also may change, which may later cause memory
access violation in MemoryShadow::update.