### PR TITLE
dxgitrace: Fix null pointer dereference in createWindowForSwapChain

### DIFF
--- a/retrace/dxgiretrace.py
+++ b/retrace/dxgiretrace.py
@@ -62,7 +62,9 @@ class D3DRetracer(Retracer):
         if function.name in self.createDeviceFunctionNames:
             # create windows as neccessary
             if 'pSwapChainDesc' in function.argNames():
-                print(r'    d3dretrace::createWindowForSwapChain(pSwapChainDesc);')
+                print(r'    if (pSwapChainDesc) {')
+                print(r'        d3dretrace::createWindowForSwapChain(pSwapChainDesc);')
+                print(r'    }')
 
             # Compensate for the fact we don't trace DXGI object creation
             if function.name.startswith('D3D11CreateDevice'):


### PR DESCRIPTION
CreateDeviceAndSwapChain family of functions can accept null pSwapChainDesc.

Found when tried to record and replay a trace of looped RenderDoc's trace to find what call hangs the driver.  Call to CreateDeviceAndSwapChain in RenderDoc - [renderdoc/driver/d3d11/d3d11_replay.cpp#L3701](https://github.com/baldurk/renderdoc/blob/e4333291a112f9fbf5491e367ae900ddc837ee20/renderdoc/driver/d3d11/d3d11_replay.cpp#L3701)