### PR TITLE
Support writable coherent buffers

### DIFF
--- a/wrappers/CMakeLists.txt
+++ b/wrappers/CMakeLists.txt
@@ -88,6 +88,8 @@ add_convenience_library (gltrace_common
     config.cpp
     gltrace_arrays.cpp
     gltrace_state.cpp
+    glmemshadow.hpp
+    glmemshadow.cpp
 )
 add_dependencies (gltrace_common glproc)
 target_link_libraries (gltrace_common

--- a/wrappers/glmemshadow.cpp
+++ b/wrappers/glmemshadow.cpp
@@ -1,0 +1,408 @@
+/*
+ * Copyright © 2019 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "glmemshadow.hpp"
+
+#include <unordered_map>
+#include <algorithm>
+
+#include <assert.h>
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+#else
+
+#include <unistd.h>
+#include <signal.h>
+#include <sys/mman.h>
+
+#endif
+
+#include "gltrace.hpp"
+#include "os_thread.hpp"
+#include "os.hpp"
+
+static bool sInitialized = false;
+
+static std::unordered_map<size_t, GLMemoryShadow*> sPages;
+static size_t sPageSize;
+
+static os::mutex mutex;
+
+enum class MemProtection {
+#ifdef _WIN32
+    NO_ACCESS = PAGE_NOACCESS,
+    READ_ONLY = PAGE_READONLY,
+    READ_WRITE = PAGE_READWRITE,
+#else
+    NO_ACCESS = PROT_NONE,
+    READ_ONLY = PROT_READ,
+    READ_WRITE = PROT_READ | PROT_WRITE,
+#endif
+};
+
+size_t getSystemPageSize() {
+#ifdef _WIN32
+    SYSTEM_INFO info;
+    GetSystemInfo(&info);
+    return info.dwPageSize;
+#else
+    return sysconf(_SC_PAGESIZE);
+#endif
+}
+
+void memProtect(void *addr, size_t size, MemProtection protection) {
+#ifdef _WIN32
+    DWORD flOldProtect;
+    BOOL bRet = VirtualProtect(addr, size, static_cast<DWORD>(protection), &flOldProtect);
+    if (!bRet) {
+        DWORD dwLastError = GetLastError();
+        os::log("apitrace: error: VirtualProtect failed with error 0x%lx\n", dwLastError);
+        os::abort();
+    }
+#else
+    const int err = mprotect(addr, size, static_cast<int>(protection));
+    if (err) {
+        const char *errorStr = strerror(err);
+        os::log("apitrace: error: mprotect failed with error \"%s\"\n", errorStr);
+        os::abort();
+    }
+#endif
+}
+
+template<typename T, typename U>
+auto divRoundUp(T a, U b) -> decltype(a / b) {
+    return (a + b - 1) / b;
+}
+
+#ifdef _WIN32
+static LONG CALLBACK
+VectoredHandler(PEXCEPTION_POINTERS pExceptionInfo)
+{
+    PEXCEPTION_RECORD pExceptionRecord = pExceptionInfo->ExceptionRecord;
+    DWORD ExceptionCode = pExceptionRecord->ExceptionCode;
+
+    if (ExceptionCode == EXCEPTION_ACCESS_VIOLATION &&
+        pExceptionRecord->NumberParameters >= 2 &&
+        pExceptionRecord->ExceptionInformation[0] == 1) { // writing
+
+        const uintptr_t addr = static_cast<uintptr_t>(pExceptionRecord->ExceptionInformation[1]);
+        const size_t page = addr / sPageSize;
+
+        os::unique_lock<os::mutex> lock(mutex);
+
+        const auto it = sPages.find(page);
+        if (it != sPages.end()) {
+            GLMemoryShadow *shadow = it->second;
+            shadow->onAddressWrite(addr, page);
+            return EXCEPTION_CONTINUE_EXECUTION;
+        } else {
+            os::log("apitrace: error: %s: access violation at non-tracked page\n", __FUNCTION__);
+            os::abort();
+        }
+    }
+
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+#else
+
+void PageGuardExceptionHandler(int sig, siginfo_t *si, void *unused) {
+    if (sig == SIGSEGV && si->si_code == SEGV_ACCERR) {
+        const uintptr_t addr = reinterpret_cast<uintptr_t>(si->si_addr);
+        const size_t page = addr / sPageSize;
+
+        os::unique_lock<os::mutex> lock(mutex);
+
+        const auto it = sPages.find(page);
+        if (it != sPages.end()) {
+            GLMemoryShadow *shadow = it->second;
+            shadow->onAddressWrite(addr, page);
+        } else {
+            os::log("apitrace: error: %s: access violation at non-tracked page\n", __FUNCTION__);
+            os::abort();
+        }
+    }
+}
+#endif
+
+void initializeGlobals()
+{
+    sPageSize = getSystemPageSize();
+
+#ifdef _WIN32
+    if (AddVectoredExceptionHandler(1, VectoredHandler) == NULL) {
+        os::log("apitrace: error: %s: add vectored exception handler failed\n", __FUNCTION__);
+    }
+#else
+    struct sigaction sa, oldSa;
+    sa.sa_flags = SA_SIGINFO;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_sigaction = PageGuardExceptionHandler;
+    if (sigaction(SIGSEGV, &sa, &oldSa) == -1) {
+        os::log("apitrace: error: %s: set page guard exception handler failed\n", __FUNCTION__);
+    }
+#endif
+}
+
+GLMemoryShadow::~GLMemoryShadow()
+{
+    os::unique_lock<os::mutex> lock(mutex);
+
+    const size_t startPage = reinterpret_cast<uintptr_t>(shadowMemory) / sPageSize;
+    for (size_t i = 0; i < nPages; i++) {
+        sPages.erase(startPage + i);
+    }
+
+#ifdef _WIN32
+    VirtualFree(shadowMemory, nPages * sPageSize, MEM_RELEASE);
+#else
+    munmap(shadowMemory, nPages * sPageSize);
+#endif
+}
+
+bool GLMemoryShadow::init(const void *data, size_t size)
+{
+    if (!sInitialized) {
+        initializeGlobals();
+        sInitialized = true;
+    }
+
+    nPages = divRoundUp(size, sPageSize);
+    const size_t adjustedSize = nPages * sPageSize;
+
+#ifdef _WIN32
+    shadowMemory = reinterpret_cast<uint8_t*>(VirtualAlloc(nullptr, adjustedSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
+#else
+    shadowMemory = reinterpret_cast<uint8_t*>(mmap(nullptr, adjustedSize, PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+#endif
+
+    if (!shadowMemory) {
+        os::log("apitrace: error: %s: Failed to allocate shadow memory!\n", __FUNCTION__);
+        return false;
+    }
+
+    if (data != nullptr) {
+        memcpy(shadowMemory, data, size);
+    }
+
+    memProtect(shadowMemory, adjustedSize, MemProtection::NO_ACCESS);
+
+    {
+        os::unique_lock<os::mutex> lock(mutex);
+
+        const size_t startPage = reinterpret_cast<uintptr_t>(shadowMemory) / sPageSize;
+        for (size_t i = 0; i < nPages; i++) {
+            sPages.emplace(startPage + i, this);
+        }
+    }
+
+    dirtyPages.resize(divRoundUp(nPages, 32));
+
+    return true;
+}
+
+void *GLMemoryShadow::map(gltrace::Context *_ctx, void *_glMemory, GLbitfield _flags, size_t start, size_t size)
+{
+    ctx = _ctx;
+    glMemory = reinterpret_cast<uint8_t*>(_glMemory);
+    flags = _flags;
+    mappedStart = start;
+    mappedSize = size;
+
+    mappedStartPage = start / sPageSize;
+    mappedEndPage = divRoundUp(start + size, sPageSize);
+
+    uint8_t *protectStart = shadowMemory + mappedStartPage * sPageSize;
+    const size_t protectSize = (mappedEndPage - mappedStartPage) * sPageSize;
+
+    // The buffer may have been updated before the mapping.
+    // TODO: handle write only buffers
+    if (flags & GL_MAP_READ_BIT) {
+        memProtect(protectStart, protectSize, MemProtection::READ_WRITE);
+        memcpy(shadowMemory + start, glMemory, size);
+    }
+
+    memProtect(protectStart, protectSize, MemProtection::READ_ONLY);
+
+    return shadowMemory + start;
+}
+
+void GLMemoryShadow::unmap(Callback callback)
+{
+    if (isDirty) {
+        os::unique_lock<os::mutex> lock(mutex);
+        commitWrites(callback);
+    }
+
+    {
+        os::unique_lock<os::mutex> lock(mutex);
+
+        auto it = std::find(ctx->dirtyShadows.begin(), ctx->dirtyShadows.end(), this);
+        if (it != ctx->dirtyShadows.end()) {
+            ctx->dirtyShadows.erase(it);
+        }
+    }
+
+    memProtect(shadowMemory, nPages * sPageSize, MemProtection::NO_ACCESS);
+
+    ctx = nullptr;
+    glMemory = nullptr;
+    flags = 0;
+    mappedStart = 0;
+    mappedSize = 0;
+    pagesToDirtyOnConsecutiveWrites = 1;
+}
+
+void GLMemoryShadow::onAddressWrite(uintptr_t addr, size_t page)
+{
+    const size_t relativePage = (addr - reinterpret_cast<uintptr_t>(shadowMemory)) / sPageSize;
+    if (isPageDirty(relativePage)) {
+        // It is possible if writing to the same buffer from two threads
+        return;
+    }
+
+    if ((relativePage == lastDirtiedRelativePage + 1) && isPageDirty(relativePage - 1)) {
+        /* Ensure that we would have log(n) page exceptions if traced application writes
+         * to n consecutive pages.
+         */
+        pagesToDirtyOnConsecutiveWrites *= 2;
+    } else {
+        pagesToDirtyOnConsecutiveWrites = 1;
+    }
+
+    const size_t endPageToDirty = std::min(relativePage + pagesToDirtyOnConsecutiveWrites, nPages);
+    for (size_t pageToDirty = relativePage; pageToDirty < endPageToDirty; pageToDirty++) {
+        setPageDirty(pageToDirty);
+    }
+
+    lastDirtiedRelativePage = endPageToDirty - 1;
+
+    memProtect(reinterpret_cast<void*>(page * sPageSize),
+               (endPageToDirty - relativePage) * sPageSize, MemProtection::READ_WRITE);
+}
+
+GLbitfield GLMemoryShadow::getMapFlags() const
+{
+    return flags;
+}
+
+void GLMemoryShadow::setPageDirty(size_t relativePage)
+{
+    assert(relativePage < nPages);
+    dirtyPages[relativePage / 32] |= 1U << (relativePage % 32);
+
+    if (!isDirty) {
+        ctx->dirtyShadows.push_back(this);
+        isDirty = true;
+    }
+}
+
+bool GLMemoryShadow::isPageDirty(size_t relativePage)
+{
+    assert(relativePage < nPages);
+    return dirtyPages[relativePage / 32] & (1U << (relativePage % 32));
+}
+
+void GLMemoryShadow::commitWrites(Callback callback)
+{
+    assert(isDirty);
+
+    uint8_t *shadowSlice = shadowMemory + mappedStartPage * sPageSize;
+    const size_t glStartOffset = mappedStart % sPageSize;
+
+    /* Other thread may write to the buffers at this very moment
+     * so we need to protect pages before we read from them.
+     * The other thread will have to wait until we commit all writes we want.
+     */
+    for (size_t i = mappedStartPage; i < mappedEndPage; i++) {
+        if (isPageDirty(i)) {
+            memProtect(shadowMemory + i * sPageSize, sPageSize, MemProtection::READ_ONLY);
+        }
+    }
+
+    if (isPageDirty(mappedStartPage)) {
+        const size_t shadowOffset = mappedStart % sPageSize;
+        const size_t size = std::min(sPageSize - glStartOffset, mappedSize);
+
+        memcpy(glMemory, shadowSlice + shadowOffset, size);
+        callback(shadowSlice + shadowOffset, size);
+    }
+
+    for (size_t i = mappedStartPage + 1; i < mappedEndPage; i++) {
+        if (isPageDirty(i)) {
+            const size_t shadowOffset = (i - mappedStartPage) * sPageSize;
+            const size_t glOffset = shadowOffset - glStartOffset;
+            const size_t size = std::min(glStartOffset + mappedSize - shadowOffset, sPageSize);
+
+            memcpy(glMemory + glOffset, shadowSlice + shadowOffset, size);
+            callback(shadowSlice + shadowOffset, size);
+        }
+    }
+
+    std::fill(dirtyPages.begin(), dirtyPages.end(), 0);
+    isDirty = false;
+    pagesToDirtyOnConsecutiveWrites = 1;
+    lastDirtiedRelativePage = UINT32_MAX - 1;
+}
+
+void GLMemoryShadow::updateForReads()
+{
+    uint8_t *protectStart = shadowMemory + mappedStartPage * sPageSize;
+    const size_t protectSize = (mappedEndPage - mappedStartPage) * sPageSize;
+
+    memProtect(protectStart, protectSize, MemProtection::READ_WRITE);
+
+    memcpy(shadowMemory + mappedStart, glMemory + mappedStart, mappedSize);
+
+    memProtect(protectStart, protectSize, MemProtection::READ_ONLY);
+}
+
+void GLMemoryShadow::commitAllWrites(gltrace::Context *_ctx, Callback callback)
+{
+    if (!_ctx->dirtyShadows.empty()) {
+        os::unique_lock<os::mutex> lock(mutex);
+
+        for (GLMemoryShadow *memoryShadow : _ctx->dirtyShadows) {
+            memoryShadow->commitWrites(callback);
+        }
+
+        _ctx->dirtyShadows.clear();
+    }
+}
+
+void GLMemoryShadow::syncAllForReads(gltrace::Context *_ctx)
+{
+    if (!_ctx->bufferToShadowMemory.empty()) {
+        os::unique_lock<os::mutex> lock(mutex);
+
+        for (auto& it : _ctx->bufferToShadowMemory) {
+            GLMemoryShadow* memoryShadow = it.second.get();
+            if (memoryShadow->getMapFlags() & GL_MAP_READ_BIT) {
+                memoryShadow->updateForReads();
+            }
+        }
+    }
+}

--- a/wrappers/glmemshadow.hpp
+++ b/wrappers/glmemshadow.hpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2019 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include "glimports.hpp"
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <vector>
+
+namespace gltrace
+{
+class Context;
+}
+
+class GLMemoryShadow
+{
+private:
+    gltrace::Context *ctx = nullptr;
+
+    GLbitfield flags = 0;
+
+    uint8_t *glMemory = nullptr;
+    uint8_t *shadowMemory = nullptr;
+
+    size_t mappedStart = 0;
+    size_t mappedSize = 0;
+
+    size_t nPages = 0;
+
+    size_t mappedStartPage = 0;
+    size_t mappedEndPage = 0;
+
+    bool isDirty = false;
+    std::vector<uint32_t> dirtyPages;
+    uint32_t pagesToDirtyOnConsecutiveWrites = 1;
+    uint32_t lastDirtiedRelativePage = UINT32_MAX - 1;
+
+public:
+
+    typedef void (*Callback)(const void *ptr, size_t size);
+
+    ~GLMemoryShadow();
+
+    bool init(const void *data, size_t size);
+
+    void *map(gltrace::Context *_ctx, void *_glMemory, GLbitfield _flags, size_t start, size_t size);
+    void unmap(Callback callback);
+
+    void commitWrites(Callback callback);
+    void updateForReads();
+
+    void onAddressWrite(uintptr_t addr, size_t page);
+
+    GLbitfield getMapFlags() const;
+
+    static void commitAllWrites(gltrace::Context *_ctx, Callback callback);
+    static void syncAllForReads(gltrace::Context *_ctx);
+
+private:
+
+    void setPageDirty(size_t relativePage);
+    bool isPageDirty(size_t relativePage);
+};

--- a/wrappers/gltrace.hpp
+++ b/wrappers/gltrace.hpp
@@ -30,10 +30,14 @@
 
 #include "glfeatures.hpp"
 
+#include "glmemshadow.hpp"
+
+#include <map>
+#include <vector>
+#include <memory>
 
 void APIENTRY _fake_glScissor(GLint x, GLint y, GLsizei width, GLsizei height);
 void APIENTRY _fake_glViewport(GLint x, GLint y, GLsizei width, GLsizei height);
-
 
 namespace gltrace {
 
@@ -55,6 +59,10 @@ public:
 
     // whether glLockArraysEXT() has ever been called
     GLuint lockedArrayCount = 0;
+
+    std::map<GLint, std::unique_ptr<GLMemoryShadow>> bufferToShadowMemory;
+
+    std::vector<GLMemoryShadow*> dirtyShadows;
 
     Context(void) :
         profile(glfeatures::API_GL, 1, 0)

--- a/wrappers/gltrace.py
+++ b/wrappers/gltrace.py
@@ -111,13 +111,44 @@ class GlTracer(Tracer):
     # arrays available in ES1
     arrays_es1 = ("Vertex", "Normal", "Color", "TexCoord")
 
+    buffer_targets = [
+        "GL_ARRAY_BUFFER",
+        "GL_ATOMIC_COUNTER_BUFFER",
+        "GL_COPY_READ_BUFFER",
+        "GL_COPY_WRITE_BUFFER",
+        "GL_DRAW_INDIRECT_BUFFER",
+        "GL_DISPATCH_INDIRECT_BUFFER",
+        "GL_ELEMENT_ARRAY_BUFFER",
+        "GL_PIXEL_PACK_BUFFER",
+        "GL_PIXEL_UNPACK_BUFFER",
+        "GL_QUERY_BUFFER",
+        "GL_SHADER_STORAGE_BUFFER",
+        "GL_TEXTURE_BUFFER",
+        "GL_TRANSFORM_FEEDBACK_BUFFER",
+        "GL_UNIFORM_BUFFER",
+    ]
+
+    # Names of the functions that can pack into the current pixel buffer
+    # object.  See also the ARB_pixel_buffer_object specification.
+    pack_function_regex = re.compile(r'^gl(' + r'|'.join([
+        r'Getn?Histogram',
+        r'Getn?PolygonStipple',
+        r'Getn?PixelMap[a-z]+v',
+        r'Getn?Minmax',
+        r'Getn?(Convolution|Separable)Filter',
+        r'Getn?(Compressed)?(Multi)?Tex(ture)?(Sub)?Image',
+        r'Readn?Pixels',
+    ]) + r')[0-9A-Z]*$')
+
     def header(self, api):
         Tracer.header(self, api)
 
         print('#include <algorithm>')
+        print('#include "cxx_compat.hpp"')
         print()
         print('#include "gltrace.hpp"')
         print('#include "gltrace_arrays.hpp"')
+        print('#include "glmemshadow.hpp"')
         print()
 
         # Whether we need user arrays
@@ -230,6 +261,29 @@ class GlTracer(Tracer):
         print(r'        os::log("apitrace: warning: %s: unknown GLenum 0x%04X\n", __FUNCTION__, pname);')
         print('        return 1;')
         print('    }')
+        print('}')
+        print()
+
+        # Generate a helper function to get buffer binding
+        print('static GLenum')
+        print('getBufferBinding(GLenum target) {')
+        print('    switch (target) {')
+        for target in self.buffer_targets:
+            print('    case %s:' % target)
+            print('        return %s_BINDING;' % target)
+        print('    default:')
+        print('        assert(false);')
+        print('        return 0;')
+        print('    }')
+        print('}')
+        print()
+
+        print('static GLint')
+        print('getBufferName(GLenum target) {')
+        print('    GLint bufferName = 0;')
+        print('    _glGetIntegerv(getBufferBinding(target), &bufferName);')
+        print('    assert(bufferName != 0);')
+        print('    return bufferName;')
         print('}')
         print()
 
@@ -425,6 +479,9 @@ class GlTracer(Tracer):
         if mo:
             functionRadical = mo.group('radical')
             print('    gltrace::Context *_ctx = gltrace::getContext();')
+
+            print('    GLMemoryShadow::commitAllWrites(_ctx, trace::fakeMemcpy);')
+
             print('    if (_need_user_arrays(_ctx)) {')
             if 'Indirect' in function.name:
                 print(r'        os::log("apitrace: warning: %s: indirect user arrays not supported\n");' % (function.name,))
@@ -450,6 +507,11 @@ class GlTracer(Tracer):
                 print('        GLuint _count = _glDraw_count(_ctx, _params);')
                 print('        _trace_user_arrays(_ctx, _count);')
             print('    }')
+
+        if function.name.startswith("glDispatchCompute"):
+            print('    gltrace::Context *_ctx = gltrace::getContext();')
+            print('    GLMemoryShadow::commitAllWrites(_ctx, trace::fakeMemcpy);')
+
         if function.name == 'glLockArraysEXT':
             print('    gltrace::Context *_ctx = gltrace::getContext();')
             print('    if (_ctx) {')
@@ -487,6 +549,17 @@ class GlTracer(Tracer):
             print('    } else {')
             print('        _glGetBufferParameteriv%s(target, GL_BUFFER_ACCESS, &access);' % suffix)
             print('        flush = access != GL_READ_ONLY;')
+            print('    }')
+            print('    if ((access_flags & GL_MAP_COHERENT_BIT) && (access_flags & GL_MAP_WRITE_BIT)) {')
+            print('        gltrace::Context *_ctx = gltrace::getContext();')
+            print('        GLint buffer = getBufferName(target);')
+            print('        auto it = _ctx->bufferToShadowMemory.find(buffer);')
+            print('        if (it != _ctx->bufferToShadowMemory.end()) {')
+            print('            it->second->unmap(trace::fakeMemcpy);')
+            print('        } else {')
+            print(r'            os::log("apitrace: error: %s: cannot find memory shadow\n", __FUNCTION__);')
+            print('        }')
+            print('        flush = false;')
             print('    }')
             print('    if (flush) {')
             print('        GLvoid *map = NULL;')
@@ -550,8 +623,16 @@ class GlTracer(Tracer):
         if function.name == 'glUnmapNamedBuffer':
             print('    GLint access_flags = 0;')
             print('    _glGetNamedBufferParameteriv(buffer, GL_BUFFER_ACCESS_FLAGS, &access_flags);')
-            print('    if ((access_flags & GL_MAP_WRITE_BIT) &&')
-            print('        !(access_flags & (GL_MAP_FLUSH_EXPLICIT_BIT | GL_MAP_PERSISTENT_BIT))) {')
+            print('    if ((access_flags & GL_MAP_COHERENT_BIT) && (access_flags & GL_MAP_WRITE_BIT)) {')
+            print('        gltrace::Context *_ctx = gltrace::getContext();')
+            print('        auto it = _ctx->bufferToShadowMemory.find(buffer);')
+            print('        if (it != _ctx->bufferToShadowMemory.end()) {')
+            print('            it->second->unmap(trace::fakeMemcpy);')
+            print('        } else {')
+            print(r'            os::log("apitrace: error: %s: cannot find memory shadow\n", __FUNCTION__);')
+            print('        }')
+            print('    } else if ((access_flags & GL_MAP_WRITE_BIT) &&')
+            print('               !(access_flags & (GL_MAP_FLUSH_EXPLICIT_BIT | GL_MAP_PERSISTENT_BIT))) {')
             print('        GLvoid *map = NULL;')
             print('        _glGetNamedBufferPointerv(buffer, GL_BUFFER_MAP_POINTER, &map);')
             print('        GLint length = 0;')
@@ -563,8 +644,16 @@ class GlTracer(Tracer):
         if function.name == 'glUnmapNamedBufferEXT':
             print('    GLint access_flags = 0;')
             print('    _glGetNamedBufferParameterivEXT(buffer, GL_BUFFER_ACCESS_FLAGS, &access_flags);')
-            print('    if ((access_flags & GL_MAP_WRITE_BIT) &&')
-            print('        !(access_flags & (GL_MAP_FLUSH_EXPLICIT_BIT | GL_MAP_PERSISTENT_BIT))) {')
+            print('    if ((access_flags & GL_MAP_COHERENT_BIT) && (access_flags & GL_MAP_WRITE_BIT)) {')
+            print('        gltrace::Context *_ctx = gltrace::getContext();')
+            print('        auto it = _ctx->bufferToShadowMemory.find(buffer);')
+            print('        if (it != _ctx->bufferToShadowMemory.end()) {')
+            print('            it->second->unmap(trace::fakeMemcpy);')
+            print('        } else {')
+            print(r'            os::log("apitrace: error: %s: cannot find memory shadow\n", __FUNCTION__);')
+            print('        }')
+            print('    } else if ((access_flags & GL_MAP_WRITE_BIT) &&')
+            print('               !(access_flags & (GL_MAP_FLUSH_EXPLICIT_BIT | GL_MAP_PERSISTENT_BIT))) {')
             print('        GLvoid *map = NULL;')
             print('        _glGetNamedBufferPointervEXT(buffer, GL_BUFFER_MAP_POINTER, &map);')
             print('        GLint length = 0;')
@@ -604,7 +693,7 @@ class GlTracer(Tracer):
             self.emit_memcpy('(const char *)map + offset', 'length')
             print('    }')
 
-        # FIXME: We don't support coherent/pinned memory mappings
+        # FIXME: We don't support AMD_pinned_memory
         if function.name in ('glBufferStorage', 'glNamedBufferStorage', 'glNamedBufferStorageEXT'):
             print(r'    if (flags & GL_MAP_NOTIFY_EXPLICIT_BIT_VMWX) {')
             print(r'        if (!(flags & GL_MAP_PERSISTENT_BIT)) {')
@@ -614,6 +703,19 @@ class GlTracer(Tracer):
             print(r'            os::log("apitrace: warning: %s: MAP_NOTIFY_EXPLICIT_BIT_VMWX set w/o MAP_WRITE_BIT\n", __FUNCTION__);')
             print(r'        }')
             print(r'        flags &= ~GL_MAP_NOTIFY_EXPLICIT_BIT_VMWX;')
+            print(r'    }')
+            print(r'')
+            print(r'    if ((flags & GL_MAP_COHERENT_BIT) && (flags & GL_MAP_WRITE_BIT)) {')
+            print(r'        gltrace::Context *_ctx = gltrace::getContext();')
+            if function.name in ('glBufferStorage'):
+                print(r'        GLint buffer = getBufferName(target);')
+            print(r'        auto memoryShadow = std::make_unique<GLMemoryShadow>();')
+            print(r'        const bool success = memoryShadow->init(data, size);')
+            print(r'        if (success) {')
+            print(r'            _ctx->bufferToShadowMemory.insert(std::make_pair(buffer, std::move(memoryShadow)));')
+            print(r'        } else {')
+            print(r'            os::log("apitrace: error: %s: cannot create memory shadow\n", __FUNCTION__);')
+            print(r'        }')
             print(r'    }')
         if function.name in ('glMapBufferRange', 'glMapBufferRangeEXT', 'glMapNamedBufferRange', 'glMapNamedBufferRangeEXT'):
             print(r'    if (access & GL_MAP_NOTIFY_EXPLICIT_BIT_VMWX) {')
@@ -627,13 +729,6 @@ class GlTracer(Tracer):
             print(r'            os::log("apitrace: warning: %s: MAP_NOTIFY_EXPLICIT_BIT_VMWX set w/ MAP_FLUSH_EXPLICIT_BIT\n", __FUNCTION__);')
             print(r'        }')
             print(r'        access &= ~GL_MAP_NOTIFY_EXPLICIT_BIT_VMWX;')
-            print(r'    } else if (access & GL_MAP_WRITE_BIT) {')
-            print(r'        if (access & GL_MAP_COHERENT_BIT) {')
-            print(r'            os::log("apitrace: warning: %s: MAP_COHERENT_BIT|MAP_WRITE_BIT unsupported <https://git.io/vV9kM>\n", __FUNCTION__);')
-            print(r'        } else if ((access & GL_MAP_PERSISTENT_BIT) &&')
-            print(r'                   !(access & GL_MAP_FLUSH_EXPLICIT_BIT)) {')
-            print(r'            os::log("apitrace: warning: %s: MAP_PERSISTENT_BIT|MAP_WRITE_BIT w/o MAP_FLUSH_EXPLICIT_BIT unsupported <https://git.io/vV9kM>\n", __FUNCTION__);')
-            print(r'        }')
             print(r'    }')
         if function.name in ('glBufferData', 'glBufferDataARB'):
             print(r'    if (target == GL_EXTERNAL_VIRTUAL_MEMORY_BUFFER_AMD) {')
@@ -645,6 +740,12 @@ class GlTracer(Tracer):
             print(r'    if (access & GL_MAP_WRITE_BIT) {')
             print(r'        os::log("apitrace: warning: GL_INTEL_map_texture not fully supported\n");')
             print(r'    }')
+
+        # Operations on PBO may use coherent buffers so we must commit them first
+        if self.unpack_function_regex.match(function.name) or self.pack_function_regex.match(function.name):
+            print('    gltrace::Context *_ctx = gltrace::getContext();')
+            print('    GLMemoryShadow::commitAllWrites(_ctx, trace::fakeMemcpy);')
+            print('')
 
         # Don't leave vertex attrib locations to chance.  Instead emit fake
         # glBindAttribLocation calls to ensure that the same locations will be
@@ -804,6 +905,38 @@ class GlTracer(Tracer):
 
         Tracer.doInvokeFunction(self, function)
 
+        if function.name in ('glMapBufferRange', 'glMapBufferRangeEXT', 'glMapNamedBufferRange', 'glMapNamedBufferRangeEXT'):
+            print(r'    if ((access & GL_MAP_COHERENT_BIT) && (access & GL_MAP_WRITE_BIT)) {')
+            print(r'        gltrace::Context *_ctx = gltrace::getContext();')
+            if function.name in ('glMapBufferRange', 'glMapBufferRangeEXT'):
+                print(r'        GLint buffer = getBufferName(target);')
+            print(r'        auto it = _ctx->bufferToShadowMemory.find(buffer);')
+            print(r'        if (it != _ctx->bufferToShadowMemory.end()) {')
+            print(r'            _result = it->second->map(_ctx, _result, access, offset, length);')
+            print(r'        } else {')
+            print(r'            os::log("apitrace: error: %s: cannot find memory shadow\n", __FUNCTION__);')
+            print(r'        }')
+            print(r'    }')
+
+        # We should sync back readable coherent buffers only when a fence become signaled
+        # because in any other moment application cannot know if changes from operations on
+        # GPU are done and buffers are updated.
+        if function.name == 'glWaitSync':
+            print(r'    gltrace::Context *_ctx = gltrace::getContext();')
+            print(r'    GLMemoryShadow::syncAllForReads(_ctx);')
+
+        if function.name == 'glClientWaitSync':
+            print(r'    if (_result == GL_ALREADY_SIGNALED || _result == GL_CONDITION_SATISFIED) {')
+            print(r'        gltrace::Context *_ctx = gltrace::getContext();')
+            print(r'        GLMemoryShadow::syncAllForReads(_ctx);')
+            print(r'    }')
+
+        if function.name == 'glGetSynciv':
+            print(r'    if (pname == GL_SYNC_STATUS && bufSize > 0 && values[0] == GL_SIGNALED) {')
+            print(r'        gltrace::Context *_ctx = gltrace::getContext();')
+            print(r'        GLMemoryShadow::syncAllForReads(_ctx);')
+            print(r'    }')
+
         if function.name == 'glGetProgramiv':
             print(r'    if (params && pname == GL_PROGRAM_BINARY_LENGTH) {')
             print(r'        *params = 0;')
@@ -812,20 +945,6 @@ class GlTracer(Tracer):
             print(r'    if (length) {')
             print(r'        *length = 0;')
             print(r'    }')
-
-    buffer_targets = [
-        'ARRAY_BUFFER',
-        'ELEMENT_ARRAY_BUFFER',
-        'PIXEL_PACK_BUFFER',
-        'PIXEL_UNPACK_BUFFER',
-        'UNIFORM_BUFFER',
-        'TEXTURE_BUFFER',
-        'TRANSFORM_FEEDBACK_BUFFER',
-        'COPY_READ_BUFFER',
-        'COPY_WRITE_BUFFER',
-        'DRAW_INDIRECT_BUFFER',
-        'ATOMIC_COUNTER_BUFFER',
-    ]
 
     def wrapRet(self, function, instance):
         Tracer.wrapRet(self, function, instance)


### PR DESCRIPTION
This implements handling of writeonly and read-write coherent buffers. Detailed descriptions could be found in respective commit messages.

Would close #232 

### Current shortcomings:
- Buffer's contents may be changed from inside the shaders however this wouldn't be reflected in shadow memory and if the same page is changed on CPU side and on GPU side even if offsets are different the data on the GPU will be overwritten.

- Small changes in buffer result in full page write.

- All readable buffers are synced back to cpu on fence signal instead of only potentially changed ones. I did not found anything that writes and reads from the same buffers with the exception of Wine which would do this if DX11 game would to such thing. Since the case is rare I didn't want to add complexity. 

### What is tested
On Linux:
- CS:GO - works
- Bioshock Infinite - works
- Super Tux Kart - works
- Some synthetic tests from piglit and several other random tests - work
- Dota2 - doesn't, it shows several good frames and after that some vertices start having wrong values resulting in many flashing polygons. And I'm not able to identify the cause.
- DiRT Showdown - didn't test
- Wine with some DX11 app using coherent buffers - didn't test 

On Windows I've tested with Super Tux Kart to check the platform specific path and tracing works.

### Tests

Tests for apitrace-tests  would hopefully come soon.

### Some code considerations:

Application may write from several threads to coherent buffers so I've added a broad mutex in relevant places and since I didn't see anyone heavily writing from several threads simultaneously I didn't do any optimizations for it. The only game that wrote from several threads was Dota2.