### PR TITLE
gltrace: Remove the incorrect offset in GLMemoryShadow::updateForReads()

### DIFF
--- a/wrappers/glmemshadow.cpp
+++ b/wrappers/glmemshadow.cpp
@@ -379,7 +379,7 @@ void GLMemoryShadow::updateForReads()
 
     memProtect(protectStart, protectSize, MemProtection::READ_WRITE);
 
-    memcpy(shadowMemory + mappedStart, glMemory + mappedStart, mappedSize);
+    memcpy(shadowMemory + mappedStart, glMemory, mappedSize);
 
     memProtect(protectStart, protectSize, MemProtection::READ_ONLY);
 }


### PR DESCRIPTION
This commit fixes these tests:
https://github.com/apitrace/apitrace-tests/pull/4
https://github.com/apitrace/apitrace-tests/pull/5
