### PR TITLE
trace: Fix uint serialization

### DIFF
--- a/lib/trace/trace_writer.cpp
+++ b/lib/trace/trace_writer.cpp
@@ -102,7 +102,7 @@ Writer::_writeByte(char c) {
 
 void inline
 Writer::_writeUInt(unsigned long long value) {
-    char buf[2 * sizeof value];
+    unsigned char buf[2 * sizeof value];
     unsigned len;
 
     len = 0;


### PR DESCRIPTION
`_writeUInt` wrongly serialized certain numbers: 255, 383, ...

Closes: #633

See http://cpp.sh/5w3av for example reproducing the issue.