### PR TITLE
glws_waffle: Add egl surfaceless support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ endif ()
 
 if (ENABLE_EGL AND ENABLE_WAFFLE)
     # Use Waffle for eglretrace
-    find_package (Waffle REQUIRED)
+    find_package (Waffle 1.6 REQUIRED)
 endif ()
 
 

--- a/retrace/glws_waffle.cpp
+++ b/retrace/glws_waffle.cpp
@@ -143,6 +143,9 @@ init(void)
             waffle_platform = WAFFLE_PLATFORM_WAYLAND;
         } else if (strcmp(waffle_platform_name, "x11_egl") == 0) {
             waffle_platform = WAFFLE_PLATFORM_X11_EGL;
+        } else if ((strcmp(waffle_platform_name, "surfaceless_egl") == 0) ||
+                   (strcmp(waffle_platform_name, "sl") == 0)) {
+            waffle_platform = WAFFLE_PLATFORM_SURFACELESS_EGL;
         } else {
             std::cerr << "error: unsupported WAFFLE_PLATFORM \"" << waffle_platform_name << "\"\n";
             exit(1);


### PR DESCRIPTION
Bump the waffle version requirement to 1.6 and handle the new platform
token for EGL surfaceless.

EGL surfaceless is useful when running in a headless setup, typically as
part of some CI system.

Note that for eglretrace to work correctly with EGL surfaceless a [recent](https://gitlab.freedesktop.org/mesa/waffle/commit/8a5f50234b171d227796571b8cb2c882f7a2f26f)
version of waffle is required. 

Signed-off-by: Emil Velikov <emil.velikov@collabora.com>
Signed-off-by: Alexandros Frantzis <alexandros.frantzis@collabora.com>