### PR TITLE
retrace: when looping on last frame, re-use Call objects

### DIFF
--- a/lib/trace/trace_model.hpp
+++ b/lib/trace/trace_model.hpp
@@ -561,6 +561,7 @@ public:
 
     CallFlags flags;
     Backtrace* backtrace;
+    bool reuse_call;
 
     Call(const FunctionSig *_sig, const CallFlags &_flags, unsigned _thread_id) :
         thread_id(_thread_id), 
@@ -568,7 +569,8 @@ public:
         args(_sig->num_args), 
         ret(0),
         flags(_flags),
-        backtrace(0) {
+        backtrace(0),
+        reuse_call(false) {
     }
 
     ~Call();

--- a/retrace/retrace_main.cpp
+++ b/retrace/retrace_main.cpp
@@ -433,7 +433,8 @@ public:
             assert(call->thread_id == leg);
 
             retraceCall(call);
-            delete call;
+            if (!call->reuse_call)
+                delete call;
             call = parser->parse_call();
 
         } while (call && call->thread_id == leg);
@@ -605,7 +606,8 @@ mainLoop() {
         trace::Call *call;
         while ((call = parser->parse_call())) {
             retraceCall(call);
-            delete call;
+            if (!call->reuse_call)
+                delete call;
         }
     } else {
         RelayRace race;


### PR DESCRIPTION
Call objects are unnecessarily parsed when looping on the last frame.
Parsing incurs significant CPU overhead, often limiting performance
and making Apitrace unusable for benchmarking.

https://github.com/apitrace/apitrace/issues/142