### PR TITLE
dlsym: Fix build under uClibc

### DIFF
--- a/wrappers/dlsym.cpp
+++ b/wrappers/dlsym.cpp
@@ -34,7 +34,7 @@
 #include "os.hpp"
 
 
-#ifdef __GLIBC__
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
 
 
 #include <dlfcn.h>


### PR DESCRIPTION
uClibc defines the ```__GLIBC__``` macro too (I know, right?), so verify that
```__UCLIBC__``` is not defined before we can use glibc-specific internal
functions.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>