### PR TITLE
Support libc that don't have RTLD_DEEPBIND

### DIFF
--- a/dispatch/glproc_gl.cpp
+++ b/dispatch/glproc_gl.cpp
@@ -148,6 +148,9 @@ _getPrivateProcAddress(const char *procName)
 
 #else
 
+#ifndef RTLD_DEEPBIND
+#define RTLD_DEEPBIND 0
+#endif
 
 static inline void
 logSymbol(const char *name, void *ptr) {


### PR DESCRIPTION
Same as https://github.com/apitrace/apitrace/commit/508a26ab7d613a82d8024309582dd34f400ded8e but for `glproc_gl.cpp`