### PR TITLE
Support cross-platform retrace for titles that query uniforms by index

### DIFF
--- a/retrace/glretrace.hpp
+++ b/retrace/glretrace.hpp
@@ -175,6 +175,12 @@ void
 trackResourceName(GLuint program,  GLenum programInterface,
                   GLint index, const std::string &traced_name);
 
+void
+mapUniformBlockName(GLuint program, 
+                    GLint index,
+                    const std::string &traced_name,
+                    std::map<GLuint, retrace::map<GLuint>> &uniformBlock_map);
+
 extern const retrace::Entry gl_callbacks[];
 extern const retrace::Entry cgl_callbacks[];
 extern const retrace::Entry glx_callbacks[];

--- a/retrace/glretrace.hpp
+++ b/retrace/glretrace.hpp
@@ -30,6 +30,7 @@
 #include "metric_backend.hpp"
 
 #include "os_thread.hpp"
+#include "retrace_swizzle.hpp"
 
 
 class MetricWriter;
@@ -164,6 +165,15 @@ checkGlError(trace::Call &call);
 void
 insertCallMarker(trace::Call &call, Context *currentContext);
 
+void
+mapResourceLocation(GLuint program, GLenum programInterface,
+                    GLint index,
+                    const trace::Array *props,
+                    const trace::Array *params,
+                    std::map<GLhandleARB, retrace::map<GLint>> &location_map);
+void
+trackResourceName(GLuint program,  GLenum programInterface,
+                  GLint index, const std::string &traced_name);
 
 extern const retrace::Entry gl_callbacks[];
 extern const retrace::Entry cgl_callbacks[];

--- a/retrace/glretrace.py
+++ b/retrace/glretrace.py
@@ -206,6 +206,11 @@ class GlRetracer(Retracer):
 
 
     def invokeFunction(self, function):
+        if function.name == "glGetActiveUniformBlockName":
+            print('    std::vector<GLchar> name_buf(bufSize);')
+            print('    uniformBlockName = name_buf.data();')
+            print('    const auto traced_name = (const GLchar *)((call.arg(4)).toString());')
+            print('    glretrace::mapUniformBlockName(program, (call.arg(1)).toSInt(), traced_name, _uniformBlock_map);')
         if function.name == "glGetProgramResourceName":
             print('    std::vector<GLchar> name_buf(bufSize);')
             print('    name = name_buf.data();')

--- a/retrace/glretrace.py
+++ b/retrace/glretrace.py
@@ -206,6 +206,13 @@ class GlRetracer(Retracer):
 
 
     def invokeFunction(self, function):
+        if function.name == "glGetProgramResourceName":
+            print('    std::vector<GLchar> name_buf(bufSize);')
+            print('    name = name_buf.data();')
+            print('    const auto traced_name = (const GLchar *)((call.arg(5)).toString());')
+            print('    glretrace::trackResourceName(program, programInterface, index, traced_name);')
+        if function.name == "glGetProgramResourceiv":
+            print('    glretrace::mapResourceLocation(program, programInterface, index, call.arg(4).toArray(), call.arg(7).toArray(), _location_map);')
         # Infer the drawable size from GL calls
         if function.name == "glViewport":
             print('    glretrace::updateDrawable(x + width, y + height);')

--- a/retrace/glretrace_main.cpp
+++ b/retrace/glretrace_main.cpp
@@ -996,3 +996,24 @@ glretrace::trackResourceName(GLuint program, GLenum programInterface,
         uniform_vec.resize(index + 1);
     uniform_vec[index] = traced_name;
 }
+
+void
+glretrace::mapUniformBlockName(GLuint program,
+                               GLint index,
+                               const std::string &traced_name,
+                               std::map<GLuint, retrace::map<GLuint>> &uniformBlock_map) {
+    GLint num_blocks=0;
+    glGetProgramiv(program, GL_ACTIVE_UNIFORM_BLOCKS, &num_blocks);
+    for (int i = 0; i < num_blocks; ++i) {
+        GLint buf_len;
+        glGetActiveUniformBlockiv(program, i, GL_UNIFORM_BLOCK_NAME_LENGTH, &buf_len);
+        std::vector<char> name_buf(buf_len+1);
+        GLint length;
+        glGetActiveUniformBlockName(program, i, name_buf.size(), &length, name_buf.data());
+        name_buf[length] = '\0';
+        if (traced_name == name_buf.data()) {
+            uniformBlock_map[program][index] = i;
+            return;
+        }
+    }
+}

--- a/specs/glapi.py
+++ b/specs/glapi.py
@@ -1667,7 +1667,7 @@ glapi.addFunctions([
     GlFunction(Void, "glGetActiveUniformName", [(GLprogram, "program"), (GLuint, "uniformIndex"), (GLsizei, "bufSize"), Out(Pointer(GLsizei), "length"), OutGlString(GLchar, "length", "uniformName")], sideeffects=False),
     GlFunction(GLuniformBlock, "glGetUniformBlockIndex", [(GLprogram, "program"), (GLstringConst, "uniformBlockName")]),
     GlFunction(Void, "glGetActiveUniformBlockiv", [(GLprogram, "program"), (GLuniformBlock, "uniformBlockIndex"), (GLenum, "pname"), Out(OpaqueArray(GLint, "_glGetActiveUniformBlockiv_size(pname)"), "params")], sideeffects=False),
-    GlFunction(Void, "glGetActiveUniformBlockName", [(GLprogram, "program"), (GLuniformBlock, "uniformBlockIndex"), (GLsizei, "bufSize"), Out(Pointer(GLsizei), "length"), OutGlString(GLchar, "length", "uniformBlockName")], sideeffects=False),
+    GlFunction(Void, "glGetActiveUniformBlockName", [(GLprogram, "program"), (GLuniformBlock, "uniformBlockIndex"), (GLsizei, "bufSize"), Out(Pointer(GLsizei), "length"), OutGlString(GLchar, "length", "uniformBlockName")]),
     GlFunction(Void, "glUniformBlockBinding", [(GLprogram, "program"), (GLuniformBlock, "uniformBlockIndex"), (GLuint, "uniformBlockBinding")]),
 
     # GL_ARB_vertex_array_object

--- a/specs/glapi.py
+++ b/specs/glapi.py
@@ -1389,8 +1389,8 @@ glapi.addFunctions([
     # GL_ARB_program_interface_query
     GlFunction(Void, "glGetProgramInterfaceiv", [(GLprogram, "program"), (GLenum, "programInterface"), (GLenum, "pname"), Out(Array(GLint, "_gl_param_size(pname)"), "params")], sideeffects=False),
     GlFunction(GLuint, "glGetProgramResourceIndex", [(GLprogram, "program"), (GLenum, "programInterface"), (GLstringConst, "name")], sideeffects=False),
-    GlFunction(Void, "glGetProgramResourceName", [(GLprogram, "program"), (GLenum, "programInterface"), (GLuint, "index"), (GLsizei, "bufSize"), Out(Pointer(GLsizei), "length"), OutGlString(GLchar, "length", "name")], sideeffects=False),
-    GlFunction(Void, "glGetProgramResourceiv", [(GLprogram, "program"), (GLenum, "programInterface"), (GLuint, "index"), (GLsizei, "propCount"), (Array(Const(GLenum), "propCount"), "props"), (GLsizei, "bufSize"), Out(Pointer(GLsizei), "length"), Out(Array(GLint, "bufSize"), "params")], sideeffects=False),
+    GlFunction(Void, "glGetProgramResourceName", [(GLprogram, "program"), (GLenum, "programInterface"), (GLuint, "index"), (GLsizei, "bufSize"), Out(Pointer(GLsizei), "length"), OutGlString(GLchar, "length", "name")]),
+    GlFunction(Void, "glGetProgramResourceiv", [(GLprogram, "program"), (GLenum, "programInterface"), (GLuint, "index"), (GLsizei, "propCount"), (Array(Const(GLenum), "propCount"), "props"), (GLsizei, "bufSize"), Out(Pointer(GLsizei), "length"), Out(Array(GLint, "bufSize"), "params")]),
     GlFunction(GLlocation, "glGetProgramResourceLocation", [(GLprogram, "program"), (GLenum, "programInterface"), (GLstringConst, "name")]),
     GlFunction(GLint, "glGetProgramResourceLocationIndex", [(GLprogram, "program"), (GLenum, "programInterface"), (GLstringConst, "name")], sideeffects=False),
 


### PR DESCRIPTION
These patches enable Linux/Windows retrace for GFXBench AztecRuins and Bioshock Infinite.

I'm happy to re-write if there is a better way to do the code generation.