### PR TITLE
glws_glx: Allow pixel buffers in GlxDrawable::swapBuffers

### DIFF
--- a/retrace/glws_glx.cpp
+++ b/retrace/glws_glx.cpp
@@ -150,7 +150,6 @@ public:
     }
 
     void swapBuffers(void) override {
-        assert(!pbuffer);
         if (window &&
             !has_GLX_EXT_swap_control &&
             has_GLX_MESA_swap_control) {


### PR DESCRIPTION
Pixel buffers are allowed to be used in glXSwapBuffers.

glx 1.4 spec, 3.3.5 "Off Screen Rendering", "glXCreatePbuffer":

 "The resulting pbuffer will contain color buffers and ancillary
  buffers as specified by config. It is possible to create
  a pbuffer with back buffers and to swap the front and back
  buffers by calling glXSwapBuffers."

Fixes replaying of Blender traces.