### PR TITLE
retrace,gui: Add ability to disable specific calls

### DIFF
--- a/gui/apicalldelegate.cpp
+++ b/gui/apicalldelegate.cpp
@@ -28,6 +28,8 @@ void ApiCallDelegate::paint(QPainter *painter,
     Q_ASSERT(index.column() == 0);
 
     if (event) {
+        painter->save();
+
         QPoint offset = option.rect.topLeft();
         QStaticText text = event->staticText();
         QSize textSize = text.size().toSize();
@@ -54,6 +56,9 @@ void ApiCallDelegate::paint(QPainter *painter,
             painter->drawPixmap(option.rect.topLeft(), px);
             offset += QPoint(textSize.height() + 5, 0);
         }
+
+        bool textDisabled = false;
+
         if (event->type() == ApiTraceEvent::Call) {
             ApiTraceCall *call = static_cast<ApiTraceCall*>(event);
             const QImage & thumbnail = call->thumbnail();
@@ -75,9 +80,18 @@ void ApiCallDelegate::paint(QPainter *painter,
                 painter->drawPixmap(offset, px);
                 offset += QPoint(textSize.height() + 5, 0);
             }
+
+            textDisabled = call->ignored();
+        }
+
+        if (!textDisabled) {
+            painter->setPen(option.palette.color(QPalette::Normal, QPalette::Text));
+        } else {
+            painter->setPen(option.palette.color(QPalette::Disabled, QPalette::Text));
         }
 
         painter->drawStaticText(offset, text);
+        painter->restore();
     } else {
         QStyledItemDelegate::paint(painter, option, index);
     }

--- a/gui/apitracecall.cpp
+++ b/gui/apitracecall.cpp
@@ -608,7 +608,8 @@ ApiTraceEvent::ApiTraceEvent()
     : m_type(ApiTraceEvent::None),
       m_binaryDataIndex(-1),
       m_state(0),
-      m_staticText(0)
+      m_staticText(0),
+      m_ignored(false)
 {
 }
 
@@ -616,7 +617,8 @@ ApiTraceEvent::ApiTraceEvent(Type t)
     : m_type(t),
       m_binaryDataIndex(-1),
       m_state(0),
-      m_staticText(0)
+      m_staticText(0),
+      m_ignored(false)
 {
     Q_ASSERT(m_type == t);
 }
@@ -645,6 +647,16 @@ void ApiTraceEvent::setThumbnail(const QImage & thumbnail)
 const QImage & ApiTraceEvent::thumbnail() const
 {
     return m_thumbnail;
+}
+
+void ApiTraceEvent::setIgnored(bool ignored)
+{
+    m_ignored = ignored;
+}
+
+bool ApiTraceEvent::ignored() const
+{
+    return m_ignored;
 }
 
 ApiTraceCall::ApiTraceCall(ApiTraceFrame *parentFrame,

--- a/gui/apitracecall.h
+++ b/gui/apitracecall.h
@@ -222,6 +222,9 @@ public:
     void setThumbnail(const QImage & thumbnail);
     const QImage & thumbnail() const;
 
+    void setIgnored(bool ignored);
+    bool ignored() const;
+
     virtual void missingThumbnail() = 0;
 
 protected:
@@ -232,6 +235,8 @@ protected:
     mutable QStaticText *m_staticText;
 
     QImage m_thumbnail;
+
+    bool m_ignored;
 };
 Q_DECLARE_METATYPE(ApiTraceEvent*);
 

--- a/gui/apitracemodel.cpp
+++ b/gui/apitracemodel.cpp
@@ -9,7 +9,6 @@
 #include <QImage>
 #include <QVariant>
 
-
 ApiTraceModel::ApiTraceModel(QObject *parent)
     : QAbstractItemModel(parent),
       m_trace(0)

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -497,6 +497,73 @@ void MainWindow::trim()
     trimEvent();
 }
 
+void MainWindow::toggleCalls() {
+    QItemSelection selection = m_ui.callView->selectionModel()->selection();
+    if (selection.empty()) {
+        QMessageBox::warning(
+            this, tr("Unknown Event"),
+            tr("To toggle calls select events in the event list."));
+        return;
+    }
+
+    QModelIndexList selectedIndexes = selection.indexes();
+
+    for (const QModelIndex& index : selectedIndexes) {
+        ApiTraceEvent *event =
+            index.data(ApiTraceModel::EventRole).value<ApiTraceEvent*>();
+        if (event->type() == ApiTraceEvent::Call) {
+            event->setIgnored(false);
+        }
+    }
+
+    m_ignoredCalls.merge(selection, QItemSelectionModel::Toggle);
+
+    selectedIndexes = m_ignoredCalls.indexes();
+    for (const QModelIndex& index : selectedIndexes) {
+        ApiTraceEvent *event =
+            index.data(ApiTraceModel::EventRole).value<ApiTraceEvent*>();
+        if (event->type() == ApiTraceEvent::Call){
+            event->setIgnored(true);
+        }
+    }
+
+    QList<RetracerCallRange> callRanges;
+    for (const QItemSelectionRange& range : m_ignoredCalls) {
+        ApiTraceEvent *eventTop =
+            range.topLeft().data(ApiTraceModel::EventRole).value<ApiTraceEvent*>();
+
+        ApiTraceEvent *eventBottom =
+            range.bottomRight().data(ApiTraceModel::EventRole).value<ApiTraceEvent*>();
+
+        if (eventTop->type() == ApiTraceEvent::Call && eventBottom->type() == ApiTraceEvent::Call) {
+            RetracerCallRange callRange;
+            callRange.m_callStartNo = static_cast<ApiTraceCall*>(eventTop)->index();
+            callRange.m_callEndNo = static_cast<ApiTraceCall*>(eventBottom)->index();
+
+            callRanges.push_back(callRange);
+        }
+    }
+
+    m_retracer->setCallsToIgnore(callRanges);
+
+    m_ui.callView->model()->dataChanged(QModelIndex(), QModelIndex());
+}
+
+void MainWindow::enableAllCalls() {
+    const QModelIndexList ignoredCallIndexes = m_ignoredCalls.indexes();
+    for (const QModelIndex& index : ignoredCallIndexes) {
+        ApiTraceEvent *event =
+            index.data(ApiTraceModel::EventRole).value<ApiTraceEvent*>();
+        if (event->type() == ApiTraceEvent::Call){
+            event->setIgnored(false);
+        }
+    }
+
+    m_ignoredCalls.clear();
+    m_retracer->setCallsToIgnore(QList<RetracerCallRange>());
+    m_ui.callView->model()->dataChanged(QModelIndex(), QModelIndex());
+}
+
 static void
 variantToString(const QVariant &var, QString &str)
 {
@@ -1003,6 +1070,8 @@ void MainWindow::initObjects()
     m_ui.callView->header()->swapSections(0, 1);
     m_ui.callView->setColumnWidth(1, 42);
     m_ui.callView->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_ui.callView->setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectItems);
+    m_ui.callView->setSelectionMode(QAbstractItemView::SelectionMode::ExtendedSelection);
 
     m_progressBar = new QProgressBar();
     m_progressBar->setRange(0, 100);
@@ -1118,6 +1187,10 @@ void MainWindow::initConnections()
             this, SLOT(lookupState()));
     connect(m_ui.actionTrim, SIGNAL(triggered()),
             this, SLOT(trim()));
+    connect(m_ui.actionToggleCalls, SIGNAL(triggered()),
+            this, SLOT(toggleCalls()));
+    connect(m_ui.actionEnableAllCalls, SIGNAL(triggered()),
+            this, SLOT(enableAllCalls()));
     connect(m_ui.actionShowThumbnails, SIGNAL(triggered()),
             this, SLOT(showThumbnails()));
     connect(m_ui.actionOptions, SIGNAL(triggered()),
@@ -1209,6 +1282,8 @@ void MainWindow::updateActionsState(bool traceLoaded, bool stopped)
         m_ui.actionLookupState   ->setEnabled(true);
         m_ui.actionShowThumbnails->setEnabled(true);
         m_ui.actionTrim          ->setEnabled(true);
+        m_ui.actionToggleCalls   ->setEnabled(true);
+        m_ui.actionEnableAllCalls->setEnabled(true);
     }
     else {
         /* File */
@@ -1227,6 +1302,8 @@ void MainWindow::updateActionsState(bool traceLoaded, bool stopped)
         m_ui.actionLookupState   ->setEnabled(false);
         m_ui.actionShowThumbnails->setEnabled(false);
         m_ui.actionTrim          ->setEnabled(false);
+        m_ui.actionToggleCalls   ->setEnabled(false);
+        m_ui.actionEnableAllCalls->setEnabled(false);
     }
 }
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -75,6 +75,8 @@ private slots:
     void lookupState();
     void showThumbnails();
     void trim();
+    void toggleCalls();
+    void enableAllCalls();
     void showSettings();
     void leakTrace();
     void leakTraceFinished();
@@ -178,4 +180,6 @@ private:
     ApiTraceEvent *m_nonDefaultsLookupEvent;
 
     ProfileDialog* m_profileDialog;
+
+    QItemSelection m_ignoredCalls;
 };

--- a/gui/retracer.cpp
+++ b/gui/retracer.cpp
@@ -256,6 +256,11 @@ qlonglong Retracer::captureAtCallNumber() const
     return m_captureCall;
 }
 
+void Retracer::setCallsToIgnore(const QList<RetracerCallRange>& callsToIgnore)
+{
+    m_callsToIgnore = callsToIgnore;
+}
+
 bool Retracer::captureState() const
 {
     return m_captureState;
@@ -394,6 +399,15 @@ void Retracer::run()
         if (m_benchmarking) {
             arguments << QLatin1String("-b");
         }
+    }
+
+    if (!m_callsToIgnore.empty()) {
+        arguments << QLatin1String("--ignore-calls");
+        QString callsStr("");
+        for (RetracerCallRange& callRange : m_callsToIgnore) {
+            callsStr += QString("%1-%2,").arg(callRange.m_callStartNo).arg(callRange.m_callEndNo);
+        }
+        arguments << callsStr;
     }
 
     arguments << m_fileName;

--- a/gui/retracer.h
+++ b/gui/retracer.h
@@ -11,6 +11,12 @@ class ApiTraceState;
 
 namespace trace { struct Profile; }
 
+struct RetracerCallRange
+{
+    qlonglong m_callStartNo{0};
+    qlonglong m_callEndNo{0};
+};
+
 class Retracer : public QThread
 {
     Q_OBJECT
@@ -48,6 +54,8 @@ public:
 
     void setCaptureAtCallNumber(qlonglong num);
     qlonglong captureAtCallNumber() const;
+
+    void setCallsToIgnore(const QList<RetracerCallRange>& callsToIgnore);
 
     bool captureState() const;
     void setCaptureState(bool enable);
@@ -91,4 +99,6 @@ private:
     QProcessEnvironment m_processEnvironment;
 
     QList<qlonglong> m_thumbnailsToCapture;
+
+    QList<RetracerCallRange> m_callsToIgnore;
 };

--- a/gui/ui/mainwindow.ui
+++ b/gui/ui/mainwindow.ui
@@ -78,6 +78,8 @@
     <addaction name="actionLookupState"/>
     <addaction name="actionShowThumbnails"/>
     <addaction name="actionTrim"/>
+    <addaction name="actionToggleCalls"/>
+    <addaction name="actionEnableAllCalls"/>
     <addaction name="actionLeakTrace"/>
     <addaction name="separator"/>
     <addaction name="actionOptions"/>
@@ -684,6 +686,19 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+I</string>
+   </property>
+  </action>
+  <action name="actionToggleCalls">
+   <property name="text">
+    <string>Toggle Calls</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+/</string>
+   </property>
+  </action>
+  <action name="actionEnableAllCalls">
+   <property name="text">
+    <string>Enable All Calls</string>
    </property>
   </action>
   <action name="actionOptions">


### PR DESCRIPTION
In retracer calls can be disabled with:
`  --ignore-calls=CALLSET    ignore calls in CALLSET`

In QApiTrace:
-    Call range can be disabled/enabled with "Toggle Calls" ctrl+/
-    All disabled calls could be enabled with "Enable All Calls"

![image](https://user-images.githubusercontent.com/3993671/76853083-56715c00-6855-11ea-927c-79161ea7afb5.png)

![image](https://user-images.githubusercontent.com/3993671/76853279-a6502300-6855-11ea-811a-3827643bb84d.png)

I've been using this for quite some time and it proved to be useful in investigations of hangs, misrenders, and other issues with Mesa.