### PR TITLE
Add the new client application 'info'

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable (apitrace
     cli_sed.cpp
     cli_trace.cpp
     cli_trim.cpp
+    cli_info.cpp
     cli_resources.cpp
 )
 

--- a/cli/cli.hpp
+++ b/cli/cli.hpp
@@ -51,3 +51,4 @@ extern const Command retrace_command;
 extern const Command sed_command;
 extern const Command trace_command;
 extern const Command trim_command;
+extern const Command info_command;

--- a/cli/cli_info.cpp
+++ b/cli/cli_info.cpp
@@ -1,0 +1,149 @@
+
+/**************************************************************************
+ *
+ * Copyright 2011 Jose Fonseca
+ * Copyright 2010 VMware, Inc.
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ **************************************************************************/
+
+
+#include <string.h>
+#include <limits.h> // for CHAR_MAX
+#include <getopt.h>
+#ifndef _WIN32
+#include <unistd.h> // for isatty()
+#endif
+
+#include <memory>
+#include <fstream>
+#include <string>
+
+#include "cxx_compat.hpp" // for std::to_string, std::make_unique
+
+#include "cli.hpp"
+#include "cli_pager.hpp"
+
+#include "trace_parser.hpp"
+#include "trace_option.hpp"
+
+static const char *synopsis = "Print given trace file(s) information.";
+
+static void
+usage(void)
+{
+    std::cout
+        << "usage: apitrace info [OPTIONS] TRACE_FILE...\n"
+        << synopsis << "\n"
+        "\n"
+        "    -h, --help        show this help message and exit\n"
+        "    --json            output trace file information in JSON format\n"
+        "\n"
+    ;
+}
+
+enum {
+    JSON_OPT = CHAR_MAX + 1,
+};
+
+const static char *
+shortOptions = "h";
+
+const static struct option
+longOptions[] = {
+    {"help", no_argument, 0, 'h'},
+    {"json", no_argument, 0, JSON_OPT},
+    {0, 0, 0, 0}
+};
+
+static const char*
+getApiName(int api) {
+  if (api < trace::API_UNKNOWN || api >= trace::API_MAX)
+    api = trace::API_UNKNOWN;
+  return trace::API_NAMES[api];
+}
+
+static int
+command(int argc, char *argv[])
+{
+    bool json = false;
+    int opt;
+    while ((opt = getopt_long(argc, argv, shortOptions, longOptions, NULL)) != -1) {
+        switch (opt) {
+        case 'h':
+            usage();
+            return 0;
+        case JSON_OPT:
+            json = true;
+            break;
+        default:
+            std::cerr << "error: unexpected option `" << (char)opt << "`\n";
+            usage();
+            return 1;
+        }
+    }
+
+    for (int i = optind; i < argc; ++i) {
+        unsigned long framesCount = 0;
+        trace::API api = trace::API_UNKNOWN;
+        trace::Parser p;
+
+        if (!p.open(argv[i])) {
+            return 1;
+        }
+
+        trace::Call *call;
+        while ((call = p.parse_call())) {
+            if (api == trace::API_UNKNOWN && p.api != trace::API_UNKNOWN)
+              api = p.api;
+            if (call->flags & trace::CALL_FLAG_END_FRAME)
+              ++framesCount;
+            delete call;
+        }
+
+        if (json) {
+            std::cout <<
+                "{" <<
+                    "\"FileName\":\"" << argv[i] << "\"," <<
+                    "\"ContainerVersion\":" << p.getVersion() << "," <<
+                    "\"API\":\"" << getApiName(api) << "\"," <<
+                    "\"FramesCount\":" << framesCount << "" <<
+                "}" << std::endl;
+        } else {
+            std::cout <<
+                std::endl <<
+                "FileName: " << argv[i] << std::endl <<
+                "ContainerVersion: " << p.getVersion() << std::endl <<
+                "API: " << getApiName(api) << std::endl <<
+                "FramesCount: " << framesCount << std::endl <<
+                std::endl;
+        }
+    }
+
+    return 0;
+}
+
+const Command info_command = {
+    "info",
+    synopsis,
+    usage,
+    command
+};

--- a/cli/cli_main.cpp
+++ b/cli/cli_main.cpp
@@ -78,6 +78,7 @@ static const Command * commands[] = {
     &retrace_command,
     &trace_command,
     &trim_command,
+    &info_command,
     &help_command
 };
 

--- a/lib/trace/trace_api.hpp
+++ b/lib/trace/trace_api.hpp
@@ -49,6 +49,19 @@ enum API {
     API_D3D9,
     API_DXGI, // D3D10.x, D3D11.x
     API_D2D1, // Direct2D
+    API_MAX,
+};
+
+const char* const API_NAMES[API_MAX] = {
+    "Unknown API",
+    "OpenGL + GLX/WGL/CGL",
+    "OpenGL/GLES1/GLES2/VG + EGL",
+    "DirectX",
+    "Direct3D 7",
+    "Direct3D 8",
+    "Direct3D 9",
+    "Direct3D 10.x/11.x",
+    "Direct2D"
 };
 
 


### PR DESCRIPTION
The new 'info' client prints the provided trace file information. The
first version of the client shows the container version, api type and
the total amount of frames in the trace file. The information can be
printed in JSON format.