### PR TITLE
gui: fix keyboard focus to make hotkeys work in image viewer

### DIFF
--- a/gui/pixelwidget.cpp
+++ b/gui/pixelwidget.cpp
@@ -207,6 +207,9 @@ void PixelWidget::keyPressEvent(QKeyEvent *e)
     case Qt::Key_Control:
         grabKeyboard();
         break;
+    default:
+        QWidget::keyPressEvent(e);
+        break;
     }
 }
 

--- a/gui/pixelwidget.cpp
+++ b/gui/pixelwidget.cpp
@@ -65,6 +65,7 @@ PixelWidget::PixelWidget(QWidget *parent)
 {
     setWindowTitle(QLatin1String("PixelTool"));
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    setFocusPolicy(Qt::StrongFocus);
 
     m_gridSize = 1;
     m_gridActive = 0;


### PR DESCRIPTION
There are zoom hotkeys (+/-), grid hotkeys (g, PgUp, PgDown), etc that don't seem to work when viewing an image of a texture. This change allows PixelWidget to get keyboard focus.