### PR TITLE
gui: make image viewer windows maximizable

### DIFF
--- a/gui/imageviewer.cpp
+++ b/gui/imageviewer.cpp
@@ -15,6 +15,7 @@ ImageViewer::ImageViewer(QWidget *parent, bool opaque, bool alpha)
       m_image(0)
 {
     setupUi(this);
+    setWindowFlags(Qt::Window);
     opaqueCheckBox->setChecked(opaque);
     alphaCheckBox->setChecked(alpha);
 


### PR DESCRIPTION
ImageViewer is a dialog window with no maximizing ability (double-click on the header of the window doesn't maximize, there is no maximize button). So making it a proper window.

Side effect with this patch is that the viewer windows can be behind the main window.