### PR TITLE
gui: zoom to fit in image viewer

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -17,6 +17,7 @@ add_gtest (qubjson_test qubjson_test.cpp)
 target_link_libraries (qubjson_test qubjson)
 
 set(qapitrace_SRCS
+   adaptivedoublespinbox.cpp
    apisurface.cpp
    apitrace.cpp
    apicalldelegate.cpp

--- a/gui/adaptivedoublespinbox.cpp
+++ b/gui/adaptivedoublespinbox.cpp
@@ -1,0 +1,29 @@
+#include "adaptivedoublespinbox.h"
+
+#include <cmath>
+
+AdaptiveDoubleSpinBox::AdaptiveDoubleSpinBox(QWidget *parent)
+    : QDoubleSpinBox(parent)
+{
+}
+
+void AdaptiveDoubleSpinBox::stepBy(int steps)
+{
+    const double oldValue = value();
+    const double oldAbsValue = qAbs(oldValue);
+    const double oldStep = std::pow(10, std::floor(std::log10(oldAbsValue)));
+
+    const double newValueWithOldStep = oldValue + steps * oldStep;
+    const double newAbsValueWithOldStep = qAbs(newValueWithOldStep);
+    const double newStep = std::pow(10, std::floor(std::log10(newAbsValueWithOldStep)));
+
+    if (newStep < oldStep) {
+        if (oldAbsValue != oldStep) {
+            setValue(oldStep);
+        } else {
+            setValue(oldValue + steps * (oldStep / 10));
+        }
+    } else {
+        setValue(newValueWithOldStep);
+    }
+}

--- a/gui/adaptivedoublespinbox.h
+++ b/gui/adaptivedoublespinbox.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <QDoubleSpinBox>
+
+class AdaptiveDoubleSpinBox : public QDoubleSpinBox
+{
+    Q_OBJECT
+public:
+    explicit AdaptiveDoubleSpinBox(QWidget *parent = nullptr);
+
+    virtual void stepBy(int steps) override;
+};

--- a/gui/imageviewer.cpp
+++ b/gui/imageviewer.cpp
@@ -57,6 +57,8 @@ ImageViewer::ImageViewer(QWidget *parent, bool opaque, bool alpha)
             this, SLOT(showPixel(int, int)));
     connect(m_pixelWidget, SIGNAL(gridGeometry(const QRect &)),
             this, SLOT(showGrid(const QRect &)));
+
+    m_pixelWidget->setFocus();
 }
 
 ImageViewer::~ImageViewer()

--- a/gui/imageviewer.cpp
+++ b/gui/imageviewer.cpp
@@ -43,6 +43,7 @@ ImageViewer::ImageViewer(QWidget *parent, bool opaque, bool alpha)
     scrollAreaWidgetContents->setPalette(pal);
 
     m_pixelWidget = new PixelWidget(scrollAreaWidgetContents);
+    verticalLayout_2->setAlignment(Qt::AlignCenter);
     verticalLayout_2->addWidget(m_pixelWidget);
 
     rectLabel->hide();

--- a/gui/imageviewer.cpp
+++ b/gui/imageviewer.cpp
@@ -49,14 +49,18 @@ ImageViewer::ImageViewer(QWidget *parent, bool opaque, bool alpha)
     rectLabel->hide();
     pixelLabel->hide();
 
-    connect(m_pixelWidget, SIGNAL(zoomChanged(int)),
-            zoomSpinBox, SLOT(setValue(int)));
-    connect(zoomSpinBox, SIGNAL(valueChanged(int)),
-            m_pixelWidget, SLOT(setZoom(int)));
+    connect(m_pixelWidget, SIGNAL(zoomChanged(double)),
+            zoomSpinBox, SLOT(setValue(double)));
+    connect(zoomSpinBox, SIGNAL(valueChanged(double)),
+            m_pixelWidget, SLOT(setZoom(double)));
     connect(m_pixelWidget, SIGNAL(mousePosition(int, int)),
             this, SLOT(showPixel(int, int)));
     connect(m_pixelWidget, SIGNAL(gridGeometry(const QRect &)),
             this, SLOT(showGrid(const QRect &)));
+    connect(m_pixelWidget, SIGNAL(zoomStepUp()),
+            zoomSpinBox, SLOT(stepUp()));
+    connect(m_pixelWidget, SIGNAL(zoomStepDown()),
+            zoomSpinBox, SLOT(stepDown()));
 
     m_pixelWidget->setFocus();
 }

--- a/gui/imageviewer.h
+++ b/gui/imageviewer.h
@@ -28,9 +28,15 @@ private slots:
     void slotUpdate();
     void showPixel(int, int);
     void showGrid(const QRect &rect);
+    void zoomChangedDirectly();
+    void zoomChangedIndirectly(double zoom);
+    void zoomToFitChanged(int state);
 
 private:
+    void zoomToFit();
+
     image::Image *m_image;
     QImage m_convertedImage;
     PixelWidget *m_pixelWidget;
+    bool m_zoomtoFit;
 };

--- a/gui/pixelwidget.cpp
+++ b/gui/pixelwidget.cpp
@@ -134,10 +134,10 @@ void PixelWidget::paintEvent(QPaintEvent *)
     // Draw the grid on top.
     if (m_gridActive) {
         p.setPen(m_gridActive == 1 ? Qt::black : Qt::white);
-        int incr = m_gridSize * zoomValue();
-        for (int x=0; x<w; x+=incr)
+        double incr = m_gridSize * zoomValue();
+        for (double x=0; x<w; x+=incr)
             p.drawLine(x, 0, x, h);
-        for (int y=0; y<h; y+=incr)
+        for (double y=0; y<h; y+=incr)
             p.drawLine(0, y, w, y);
     }
 
@@ -181,10 +181,10 @@ void PixelWidget::keyPressEvent(QKeyEvent *e)
 {
     switch (e->key()) {
     case Qt::Key_Plus:
-        increaseZoom();
+        emit zoomStepUp();
         break;
     case Qt::Key_Minus:
-        decreaseZoom();
+        emit zoomStepDown();
         break;
     case Qt::Key_PageUp:
         setGridSize(m_gridSize + 1);
@@ -352,7 +352,7 @@ void PixelWidget::startGridSizeVisibleTimer()
     }
 }
 
-void PixelWidget::setZoom(int zoom)
+void PixelWidget::setZoom(double zoom)
 {
     if (zoom > 0 && zoom != m_zoom) {
         QPoint pos = m_lastMousePos;
@@ -361,7 +361,7 @@ void PixelWidget::setZoom(int zoom)
         m_lastMousePos = pos;
         m_dragStart = m_dragCurrent = QPoint();
 
-        if (m_zoom == 1)
+        if (m_zoom <= 1)
             m_gridActive = 0;
         else if (!m_gridActive)
             m_gridActive = 1;

--- a/gui/pixelwidget.cpp
+++ b/gui/pixelwidget.cpp
@@ -352,7 +352,7 @@ void PixelWidget::startGridSizeVisibleTimer()
     }
 }
 
-void PixelWidget::setZoom(double zoom)
+void PixelWidget::setZoom(double zoom, bool forceGrid)
 {
     if (zoom > 0 && zoom != m_zoom) {
         QPoint pos = m_lastMousePos;
@@ -363,7 +363,7 @@ void PixelWidget::setZoom(double zoom)
 
         if (m_zoom <= 1)
             m_gridActive = 0;
-        else if (!m_gridActive)
+        else if (forceGrid)
             m_gridActive = 1;
 
         zoomChanged(m_zoom);

--- a/gui/pixelwidget.h
+++ b/gui/pixelwidget.h
@@ -81,7 +81,7 @@ public:
     QSize sizeHint() const override;
 
 public slots:
-    void setZoom(double zoom);
+    void setZoom(double zoom, bool forceGrid = true);
     void setGridSize(int gridSize);
     void toggleGrid();
     void copyToClipboard();

--- a/gui/pixelwidget.h
+++ b/gui/pixelwidget.h
@@ -61,7 +61,9 @@ public:
     QColor colorAtCurrentPosition() const;
 
 signals:
-    void zoomChanged(int);
+    void zoomChanged(double);
+    void zoomStepUp();
+    void zoomStepDown();
     void mousePosition(int x, int y);
     void gridGeometry(const QRect &rect);
 
@@ -79,15 +81,13 @@ public:
     QSize sizeHint() const override;
 
 public slots:
-    void setZoom(int zoom);
+    void setZoom(double zoom);
     void setGridSize(int gridSize);
     void toggleGrid();
     void copyToClipboard();
     void saveToFile();
     void increaseGridSize() { setGridSize(m_gridSize + 1); }
     void decreaseGridSize() { setGridSize(m_gridSize - 1); }
-    void increaseZoom() { setZoom(m_zoom + 1); }
-    void decreaseZoom() { setZoom(m_zoom - 1); }
 
 private:
     void startGridSizeVisibleTimer();
@@ -97,7 +97,7 @@ private:
     bool m_mouseDown;
 
     int m_gridActive;
-    int m_zoom;
+    double m_zoom;
     int m_gridSize;
 
     int m_displayGridSizeId;

--- a/gui/ui/imageviewer.ui
+++ b/gui/ui/imageviewer.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>825</width>
+    <width>865</width>
     <height>629</height>
    </rect>
   </property>
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>811</width>
-        <height>561</height>
+        <width>845</width>
+        <height>543</height>
        </rect>
       </property>
       <property name="autoFillBackground">
@@ -244,6 +244,16 @@
        </property>
        <property name="value">
         <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="zoomToFitCheckBox">
+       <property name="text">
+        <string>Fit</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/gui/ui/imageviewer.ui
+++ b/gui/ui/imageviewer.ui
@@ -220,27 +220,30 @@
       </widget>
      </item>
      <item>
-      <widget class="QSpinBox" name="zoomSpinBox">
+      <widget class="AdaptiveDoubleSpinBox" name="zoomSpinBox">
        <property name="specialValueText">
+        <string/>
+       </property>
+       <property name="prefix">
         <string/>
        </property>
        <property name="suffix">
         <string>x</string>
        </property>
-       <property name="prefix">
-        <string/>
+       <property name="decimals">
+        <number>3</number>
        </property>
        <property name="minimum">
-        <number>1</number>
+        <double>0.001000000000000</double>
        </property>
        <property name="maximum">
-        <number>15</number>
+        <double>1024.000000000000000</double>
        </property>
        <property name="singleStep">
-        <number>1</number>
+        <double>1.000000000000000</double>
        </property>
        <property name="value">
-        <number>1</number>
+        <double>1.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -248,6 +251,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AdaptiveDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>adaptivedoublespinbox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Center the image, focus PixelWidget at start to make keys work, allow zoom < 1, add a checkbox to auto-fit the image (stops fitting when manually zoomed), save auto-fit option after restart.