### PR TITLE
glapi: Add glSpecializeShaderARB from GL_ARB_gl_spirv

### DIFF
--- a/specs/glapi.py
+++ b/specs/glapi.py
@@ -1228,6 +1228,9 @@ glapi.addFunctions([
     GlFunction(Void, "glGetTextureSubImage", [(GLtexture, "texture"), (GLint, "level"), (GLint, "xoffset"), (GLint, "yoffset"), (GLint, "zoffset"), (GLsizei, "width"), (GLsizei, "height"), (GLsizei, "depth"), (GLenum, "format"), (GLenum, "type"), (GLsizei, "bufSize"), Out(GLpointer, "pixels")]),
     GlFunction(Void, "glGetCompressedTextureSubImage", [(GLtexture, "texture"), (GLint, "level"), (GLint, "xoffset"), (GLint, "yoffset"), (GLint, "zoffset"), (GLsizei, "width"), (GLsizei, "height"), (GLsizei, "depth"), (GLsizei, "bufSize"), Out(GLpointer, "pixels")]),
 
+    # GL_ARB_gl_spirv
+    GlFunction(Void, "glSpecializeShaderARB", [(GLuint, "shader"), (GLstringConst, "pEntryPoint"), (GLuint, "numSpecializationConstants"), (Array(Const(GLuint), "numSpecializationConstants"), "pConstantIndex"), (Array(Const(GLuint), "numSpecializationConstants"), "pConstantValue")]),
+
     # GL_ARB_gpu_shader_fp64
     GlFunction(Void, "glUniform1d", [(GLlocation, "location"), (GLdouble, "x")]),
     GlFunction(Void, "glUniform2d", [(GLlocation, "location"), (GLdouble, "x"), (GLdouble, "y")]),


### PR DESCRIPTION
Thank you so much for maintaining this tool!  It's an absolute godsend for debugging any kind of graphics issue in our engine.

This change makes it possible for apitrace to work with applications that use SPIR-V shaders.  Without this, glLinkProgram would fail and glretrace would crash.

Thanks for your consideration!