### PR TITLE
cli_info: Dump per frame metrics for trace files

### DIFF
--- a/lib/trace/trace_file.hpp
+++ b/lib/trace/trace_file.hpp
@@ -59,7 +59,16 @@ public:
     void close(void);
     int getc(void);
     bool skip(size_t length);
-    int percentRead(void);
+    int percentRead(void) const;
+
+    // returns the size of (compressed/serialized) data in the container in bytes
+    virtual size_t containerSizeInBytes(void) const = 0;
+    // returns the amount of bytes read from the container
+    virtual size_t containerBytesRead(void) const = 0;
+    // returns the size of uncompressed data read in bytes
+    virtual size_t dataBytesRead(void) const = 0;
+    // returns the name of the continer type as a user friendly string
+    virtual const char* containerType() const = 0;
 
     virtual bool supportsOffsets(void) const;
     virtual File::Offset currentOffset(void) const;
@@ -70,7 +79,6 @@ protected:
     virtual int rawGetc(void) = 0;
     virtual void rawClose(void) = 0;
     virtual bool rawSkip(size_t length) = 0;
-    virtual int rawPercentRead(void) = 0;
 
 protected:
     bool m_isOpened = false;
@@ -99,12 +107,14 @@ inline size_t File::read(void *buffer, size_t length)
     return rawRead(buffer, length);
 }
 
-inline int File::percentRead(void)
+inline int File::percentRead(void) const
 {
-    if (!m_isOpened) {
-        return 0;
+    size_t size = containerSizeInBytes();
+    size_t read = containerBytesRead();
+    if (size) {
+        return static_cast<int>(100 * read / size);
     }
-    return rawPercentRead();
+    return 0;
 }
 
 inline void File::close(void)

--- a/lib/trace/trace_parser.hpp
+++ b/lib/trace/trace_parser.hpp
@@ -151,9 +151,25 @@ public:
         return properties;
     }
 
-    int percentRead()
-    {
+
+    int percentRead() const {
         return file->percentRead();
+    }
+
+    size_t containerSizeInBytes() const {
+        return file->containerSizeInBytes();
+    }
+
+    size_t containerBytesRead() const {
+        return file->containerBytesRead();
+    }
+
+    size_t dataBytesRead() const {
+        return file->dataBytesRead();
+    }
+
+    const char *containerType() const {
+        return file->containerType();
     }
 
     Call *scan_call() {


### PR DESCRIPTION
Added extra information to cli_info output which includes:
* container type (compression method)
* container size (the size of the data in the storage container)
* actual data size (the size of uncompressed data)
* per frame metrics which include the folowing information:
  * first call_id
  * last call_id
  * the total amount of calls in a frame
  * uncompressed frame size

An example output:

```
{
  "FileName": "/home/user/game.trace",
  "ContainerVersion": 6,
  "ContainerType": "Snappy",
  "API": "OpenGL + GLX/WGL/CGL",
  "FramesCount": 1789,
  "ActualDataSize": 5272672851,
  "ContainerSize": 1547699157,
  "Frames": [{
    "FirstCallId": 0,
    "LastCallId": 2231,
    "TotalCalls": 2232,
    "SizeInBytes": 1259924
  }, {
    "FirstCallId": 2232,
    "LastCallId": 2251,
    "TotalCalls": 20,
    "SizeInBytes": 449
  }, {
    [...]
  ]}
}
```

This information could be useful to analyze the data distribution in a trace file, find transition points menu/game/etc, choose better point for a trace file trimming, and so on.