### PR TITLE
cli_info: Dump per frame metrics for trace files

### DIFF
--- a/cli/cli_info.cpp
+++ b/cli/cli_info.cpp
@@ -45,7 +45,7 @@
 #include "trace_parser.hpp"
 #include "trace_option.hpp"
 
-static const char *synopsis = "Print given trace file(s) information.";
+static const char *synopsis = "Print given trace file(s) information in JSON format";
 
 static void
 usage(void)
@@ -55,13 +55,13 @@ usage(void)
         << synopsis << "\n"
         "\n"
         "    -h, --help        show this help message and exit\n"
-        "    --json            output trace file information in JSON format\n"
+        "    --dump-frames     dump per frame information\n"
         "\n"
     ;
 }
 
 enum {
-    JSON_OPT = CHAR_MAX + 1,
+    DUMP_FRAMES_OPT = CHAR_MAX + 1,
 };
 
 const static char *
@@ -70,7 +70,7 @@ shortOptions = "h";
 const static struct option
 longOptions[] = {
     {"help", no_argument, 0, 'h'},
-    {"json", no_argument, 0, JSON_OPT},
+    {"dump-frames", no_argument, 0, DUMP_FRAMES_OPT},
     {0, 0, 0, 0}
 };
 
@@ -81,18 +81,24 @@ getApiName(int api) {
   return trace::API_NAMES[api];
 }
 
+struct FrameEntry {
+    size_t firstCallId, lastCallId;
+    size_t totalCalls;
+    size_t sizeInBytes;
+};
+
 static int
 command(int argc, char *argv[])
 {
-    bool json = false;
+    bool flagDumpFrames = false;
     int opt;
     while ((opt = getopt_long(argc, argv, shortOptions, longOptions, NULL)) != -1) {
         switch (opt) {
         case 'h':
             usage();
             return 0;
-        case JSON_OPT:
-            json = true;
+        case DUMP_FRAMES_OPT:
+            flagDumpFrames = true;
             break;
         default:
             std::cerr << "error: unexpected option `" << (char)opt << "`\n";
@@ -100,6 +106,9 @@ command(int argc, char *argv[])
             return 1;
         }
     }
+
+    typedef std::vector<FrameEntry> FrameEntries;
+    FrameEntries frames;
 
     for (int i = optind; i < argc; ++i) {
         unsigned long framesCount = 0;
@@ -111,31 +120,68 @@ command(int argc, char *argv[])
         }
 
         trace::Call *call;
+        size_t callsInFrame = 0;
+        size_t firstCallId = 0;
+        size_t frameBytesOffset = 0;
+        bool endFrame = true;
         while ((call = p.parse_call())) {
+            if (flagDumpFrames) {
+                ++callsInFrame;
+                if (endFrame) {
+                    firstCallId = call->no;
+                    endFrame = false;
+                }
+            }
             if (api == trace::API_UNKNOWN && p.api != trace::API_UNKNOWN)
-              api = p.api;
-            if (call->flags & trace::CALL_FLAG_END_FRAME)
-              ++framesCount;
+                api = p.api;
+            if (call->flags & trace::CALL_FLAG_END_FRAME) {
+                ++framesCount;
+                if (flagDumpFrames) {
+                    size_t curBytesOffset = p.dataBytesRead();
+                    frames.push_back(
+                        FrameEntry {
+                            firstCallId,
+                            call->no,
+                            callsInFrame,
+                            curBytesOffset-frameBytesOffset
+                        }
+                    );
+                    frameBytesOffset = curBytesOffset;
+                    endFrame = true;
+                    callsInFrame = 0;
+                }
+            }
             delete call;
         }
 
-        if (json) {
+        std::cout <<
+            "{" << std::endl <<
+            "  \"FileName\": \"" << argv[i] << "\"," << std::endl <<
+            "  \"ContainerVersion\": " << p.getVersion() << "," << std::endl <<
+            "  \"ContainerType\": \"" << p.containerType() << "\"," << std::endl <<
+            "  \"API\": \"" << getApiName(api) << "\"," << std::endl <<
+            "  \"FramesCount\": " << framesCount << "," << std::endl <<
+            "  \"ActualDataSize\": " << p.dataBytesRead() << "," << std::endl <<
+            "  \"ContainerSize\": " << p.containerSizeInBytes();
+        if (flagDumpFrames) {
+            std::cout << "," << std::endl;
             std::cout <<
-                "{" <<
-                    "\"FileName\":\"" << argv[i] << "\"," <<
-                    "\"ContainerVersion\":" << p.getVersion() << "," <<
-                    "\"API\":\"" << getApiName(api) << "\"," <<
-                    "\"FramesCount\":" << framesCount << "" <<
-                "}" << std::endl;
+                "  \"Frames\": [{" << std::endl;
+            for (auto it = frames.begin(); it != frames.end(); ++it) {
+                std::cout <<
+                    "    \"FirstCallId\": " << it->firstCallId << "," << std::endl <<
+                    "    \"LastCallId\": " << it->lastCallId << "," << std::endl <<
+                    "    \"TotalCalls\": " << it->totalCalls << "," << std::endl <<
+                    "    \"SizeInBytes\": " << it->sizeInBytes << std::endl;
+                if (it != std::prev(frames.end())) {
+                    std::cout << "  }, {" << std::endl;
+                }
+            }
+            std::cout << "  }]" << std::endl;
         } else {
-            std::cout <<
-                std::endl <<
-                "FileName: " << argv[i] << std::endl <<
-                "ContainerVersion: " << p.getVersion() << std::endl <<
-                "API: " << getApiName(api) << std::endl <<
-                "FramesCount: " << framesCount << std::endl <<
-                std::endl;
+            std::cout << std::endl;
         }
+        std::cout << "}" << std::endl;
     }
 
     return 0;

--- a/lib/trace/trace_file.hpp
+++ b/lib/trace/trace_file.hpp
@@ -59,7 +59,16 @@ public:
     void close(void);
     int getc(void);
     bool skip(size_t length);
-    int percentRead(void);
+    int percentRead(void) const;
+
+    // returns the size of (compressed/serialized) data in the container in bytes
+    virtual size_t containerSizeInBytes(void) const = 0;
+    // returns the amount of bytes read from the container
+    virtual size_t containerBytesRead(void) const = 0;
+    // returns the size of uncompressed data read in bytes
+    virtual size_t dataBytesRead(void) const = 0;
+    // returns the name of the continer type as a user friendly string
+    virtual const char* containerType() const = 0;
 
     virtual bool supportsOffsets(void) const;
     virtual File::Offset currentOffset(void) const;
@@ -70,7 +79,6 @@ protected:
     virtual int rawGetc(void) = 0;
     virtual void rawClose(void) = 0;
     virtual bool rawSkip(size_t length) = 0;
-    virtual int rawPercentRead(void) = 0;
 
 protected:
     bool m_isOpened = false;
@@ -99,12 +107,14 @@ inline size_t File::read(void *buffer, size_t length)
     return rawRead(buffer, length);
 }
 
-inline int File::percentRead(void)
+inline int File::percentRead(void) const
 {
-    if (!m_isOpened) {
-        return 0;
+    size_t size = containerSizeInBytes();
+    size_t read = containerBytesRead();
+    if (size) {
+        return static_cast<int>((100*read)/size);
     }
-    return rawPercentRead();
+    return 0;
 }
 
 inline void File::close(void)

--- a/lib/trace/trace_parser.hpp
+++ b/lib/trace/trace_parser.hpp
@@ -151,9 +151,25 @@ public:
         return properties;
     }
 
-    int percentRead()
-    {
+
+    int percentRead() const {
         return file->percentRead();
+    }
+
+    size_t containerSizeInBytes() const {
+        return file->containerSizeInBytes();
+    }
+
+    size_t containerBytesRead() const {
+        return file->containerBytesRead();
+    }
+
+    size_t dataBytesRead() const {
+        return file->dataBytesRead();
+    }
+
+    const char *containerType() const {
+        return file->containerType();
     }
 
     Call *scan_call() {


### PR DESCRIPTION
Added extra information to cli_info output which includes:
* container type (compression method)
* container size (the size of the data in the storage container)
* actual data size (the size of uncompressed data)
* per frame metrics which include the folowing information:
  * first call_id
  * last call_id
  * the total amount of calls in a frame
  * uncompressed frame size

Usage:
`  apitrace info --dump-frames /path/to/file.trace`

An example output:

```
{
  "FileName": "/path/to/file.trace",
  "ContainerVersion": 6,
  "ContainerType": "Snappy",
  "API": "OpenGL + GLX/WGL/CGL",
  "FramesCount": 1789,
  "ActualDataSize": 5272672851,
  "ContainerSize": 1547699157,
  "Frames": [{
    "FirstCallId": 0,
    "LastCallId": 2231,
    "TotalCalls": 2232,
    "SizeInBytes": 1259924
  }, {
    "FirstCallId": 2232,
    "LastCallId": 2251,
    "TotalCalls": 20,
    "SizeInBytes": 449
  }, {
    [...]
  ]}
}
```

This information could be useful to analyze the data distribution in a
trace file, find transition points menu/game/etc, choose better point
for a trace file trimming, and so on.