### PR TITLE
Fix glMultiDrawArraysIndirect not capturing client buffer

### DIFF
--- a/helpers/glsize.hpp
+++ b/helpers/glsize.hpp
@@ -1267,3 +1267,13 @@ _glGetDebugMessageLog_length(const Char * string, const GLsizei *lengths, GLuint
     return size;
 }
 
+static inline size_t
+_glMultiDrawArraysIndirect_size(GLsizei drawcount, GLsizei stride)
+{
+    if (stride == 0) {
+        return size_t(drawcount) * sizeof(unsigned int) * 4;
+    } else {
+        return size_t(drawcount * stride);
+    }
+}
+

--- a/specs/glapi.py
+++ b/specs/glapi.py
@@ -1327,7 +1327,7 @@ glapi.addFunctions([
     GlFunction(Void, "glBindVertexBuffers", [(GLuint, "first"), (GLsizei, "count"), (Array(Const(GLbuffer), "count"), "buffers"), (Array(Const(GLintptr), "count"), "offsets"), (Array(Const(GLsizei), "count"), "strides")]),
 
     # GL_ARB_multi_draw_indirect
-    GlFunction(Void, "glMultiDrawArraysIndirect", [(GLenum_mode, "mode"), (OpaqueArray(Const(Void), "_glMultiDrawArraysIndirect_size(drawcount, stride)"), "indirect"), (GLsizei, "drawcount"), (GLsizei, "stride")]),
+    GlFunction(Void, "glMultiDrawArraysIndirect", [(GLenum_mode, "mode"), (Blob(Const(Void), "_glMultiDrawArraysIndirect_size(drawcount, stride)"), "indirect"), (GLsizei, "drawcount"), (GLsizei, "stride")]),
     GlFunction(Void, "glMultiDrawElementsIndirect", [(GLenum_mode, "mode"), (GLenum, "type"), (OpaqueArray(Const(Void), "_glMultiDrawElementsIndirect_size(drawcount, stride)"), "indirect"), (GLsizei, "drawcount"), (GLsizei, "stride")]),
 
     # GL_ARB_multisample


### PR DESCRIPTION
I'm not entirely sure why using `Blob` instead of `OpaqueArray` makes this work, but it does.
In case `stride` is zero, it means "the array is tightly packed" [1].

[1] https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_multi_draw_indirect.txt