### PR TITLE
retrace: Print frame times

### DIFF
--- a/docs/USAGE.markdown
+++ b/docs/USAGE.markdown
@@ -394,6 +394,8 @@ section above.
 
 You can perform gpu and cpu profiling with the command line options:
 
+ * `--pframe-times` record frames times, waiting for presentation to finish before starting next frame.
+
  * `--pgpu` record gpu times for frames and draw calls.
 
  * `--pcpu` record cpu times for frames and draw calls.

--- a/retrace/glretrace.hpp
+++ b/retrace/glretrace.hpp
@@ -165,6 +165,9 @@ checkGlError(trace::Call &call);
 void
 insertCallMarker(trace::Call &call, Context *currentContext);
 
+int64_t
+getCurrentTime(void);
+
 void
 mapResourceLocation(GLuint program, GLenum programInterface,
                     GLint index,

--- a/retrace/glretrace_egl.cpp
+++ b/retrace/glretrace_egl.cpp
@@ -280,6 +280,12 @@ static void retrace_eglSwapBuffers(trace::Call &call) {
     } else {
         glFlush();
     }
+
+    if (retrace::profilingFrameTimes) {
+        // Wait for presentation to finish
+        glFinish();
+        std::cout << "rendering_finished " << glretrace::getCurrentTime() << std::endl;
+    }
 }
 
 const retrace::Entry glretrace::egl_callbacks[] = {

--- a/retrace/glretrace_glx.cpp
+++ b/retrace/glretrace_glx.cpp
@@ -149,6 +149,12 @@ static void retrace_glXSwapBuffers(trace::Call &call) {
     } else {
         glFlush();
     }
+
+    if (retrace::profilingFrameTimes) {
+        // Wait for presentation to finish
+        glFinish();
+        std::cout << "rendering_finished " << glretrace::getCurrentTime() << std::endl;
+    }
 }
 
 static void retrace_glXSwapBuffersMscOML(trace::Call &call) {

--- a/retrace/glretrace_main.cpp
+++ b/retrace/glretrace_main.cpp
@@ -182,7 +182,7 @@ insertCallMarker(trace::Call &call, Context *currentContext)
 }
 
 
-static inline int64_t
+int64_t
 getCurrentTime(void) {
     if (retrace::profilingGpuTimes && supportsTimestamp) {
         /* Get the current GL time without stalling */

--- a/retrace/glretrace_wgl.cpp
+++ b/retrace/glretrace_wgl.cpp
@@ -155,6 +155,12 @@ static void retrace_wglSwapBuffers(trace::Call &call) {
     } else {
         glFlush();
     }
+
+    if (retrace::profilingFrameTimes) {
+        // Wait for presentation to finish
+        glFinish();
+        std::cout << "rendering_finished " << glretrace::getCurrentTime() << std::endl;
+    }
 }
 
 static void retrace_wglShareLists(trace::Call &call) {

--- a/retrace/retrace.hpp
+++ b/retrace/retrace.hpp
@@ -158,6 +158,7 @@ extern bool profilingListMetrics;
 extern bool profilingNumPasses;
 
 extern bool profiling;
+extern bool profilingFrameTimes;
 extern bool profilingCpuTimes;
 extern bool profilingGpuTimes;
 extern bool profilingPixelsDrawn;

--- a/retrace/retrace_main.cpp
+++ b/retrace/retrace_main.cpp
@@ -108,6 +108,7 @@ bool profilingListMetrics = false;
 bool profilingNumPasses = false;
 
 bool profiling = false;
+bool profilingFrameTimes = false;
 bool profilingGpuTimes = false;
 bool profilingCpuTimes = false;
 bool profilingPixelsDrawn = false;
@@ -650,6 +651,7 @@ usage(const char *argv0) {
         "  -b, --benchmark         benchmark mode (no error checking or warning messages)\n"
         "  -d, --debug             increase debugging checks\n"
         "      --markers           insert call no markers in the command stream\n"
+        "      --pframe-times      frame times profiling (cpu times per frame)\n"
         "      --pcpu              cpu profiling (cpu times per call)\n"
         "      --pgpu              gpu profiling (gpu times per draw call)\n"
         "      --ppd               pixels drawn profiling (pixels drawn per draw call)\n"
@@ -695,6 +697,7 @@ enum {
     DRIVER_OPT,
     FULLSCREEN_OPT,
     HEADLESS_OPT,
+    PFRAMETIMES_OPT,
     PCPU_OPT,
     PGPU_OPT,
     PPD_OPT,
@@ -738,6 +741,7 @@ longOptions[] = {
     {"help", no_argument, 0, 'h'},
     {"mrt", no_argument, 0, 'm'},
     {"msaa-no-resolve", no_argument, 0, MSAA_NO_RESOLVE_OPT},
+    {"pframe-times", no_argument, 0, PFRAMETIMES_OPT},
     {"pcpu", no_argument, 0, PCPU_OPT},
     {"pgpu", no_argument, 0, PGPU_OPT},
     {"ppd", no_argument, 0, PPD_OPT},
@@ -1110,6 +1114,13 @@ int main(int argc, char **argv)
             break;
         case LOOP_OPT:
             loopCount = trace::intOption(optarg, -1);
+            break;
+        case PFRAMETIMES_OPT:
+            retrace::debug = 0;
+            retrace::profiling = true;
+            retrace::verbosity = -1;
+
+            retrace::profilingFrameTimes = true;
             break;
         case PGPU_OPT:
             retrace::debug = 0;


### PR DESCRIPTION
Hello there,

The commit messages should be explicative enough:

```
When replaying a trace, it could be useful to analyze how much time is
needed to render and present each frame. While developing a GPU driver,
for example, developers could graph the frame time series in order to
detect regressions or improvements of driver performance over time.

The `--pframe-times` option enables profiling for frame times, meaning
that replaying will output a timestamp when a frame has been presented.
```

I guess this is a first draft of something that needs some more work.
At the current state, this option works only on `wgl`, `glx`, and `egl` backends.
Please, tell me what I am missing, and how I could tackle that. 😃 