### PR TITLE
Gltrim

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "frametrim/tests"]
+	path = frametrim/tests
+	url = https://github.com/apitrace/gltrim-tests.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     dist: bionic
     env:
     - LABEL="ubuntu64"
-    - APT_PACKAGES="gcc g++ libdwarf-dev libprocps-dev qtbase5-dev qtdeclarative5-dev"
+    - APT_PACKAGES="gcc g++ libdwarf-dev libprocps-dev qtbase5-dev qtdeclarative5-dev xvfb"
     - CMAKE_OPTIONS="-DPython3_EXECUTABLE=/usr/bin/python3 -DENABLE_GUI=1"
   - os: linux
     dist: bionic

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,6 +602,7 @@ add_subdirectory (dispatch)
 add_subdirectory (helpers)
 add_subdirectory (wrappers)
 add_subdirectory (retrace)
+add_subdirectory (frametrim)
 
 
 ##############################################################################

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable (apitrace
     cli_leaks.cpp
     cli_dump.cpp
     cli_dump_images.cpp
+    cli_gltrim.cpp
     cli_pager.cpp
     cli_pickle.cpp
     cli_repack.cpp

--- a/cli/cli.hpp
+++ b/cli/cli.hpp
@@ -52,3 +52,4 @@ extern const Command sed_command;
 extern const Command trace_command;
 extern const Command trim_command;
 extern const Command info_command;
+extern const Command gltrim_command;

--- a/cli/cli_gltrim.cpp
+++ b/cli/cli_gltrim.cpp
@@ -1,0 +1,91 @@
+/*********************************************************************
+ *
+ * Copyright 2011 Jose Fonseca
+ * Copyright 2012 Intel Corporation
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *********************************************************************/
+
+#include <string.h>
+#include <limits.h> // for CHAR_MAX
+#include <getopt.h>
+#include <iostream>
+
+#include "os_string.hpp"
+#include "os_process.hpp"
+
+#include "trace_parser.hpp"
+#include "cli_resources.hpp"
+
+#include "cli.hpp"
+
+
+static int
+executeGLTrim(const std::vector<const char *> & opts,
+               const char *traceName) {
+
+    std::vector<const char *> command;
+    os::String glTrimPath = findProgram("gltrim");
+    if (glTrimPath.length()) {
+        command.push_back(glTrimPath);
+    } else {
+        command.push_back("gltrim");
+    }
+
+    command.insert(command.end(), opts.begin(), opts.end());
+
+    if (traceName) {
+        command.push_back(traceName);
+    }
+    command.push_back(NULL);
+
+    return os::execute((char * const *)&command[0]);
+}
+
+static const char *synopsis = "Trim an OpenGL trace to a replayable subset of frames";
+
+static void
+usage(void)
+{
+    std::vector<const char *>opts;
+    opts.push_back("--help");
+    trace::API api = trace::API_GL;
+    executeGLTrim(opts, NULL);
+}
+
+static int
+command(int argc, char *argv[])
+{
+    std::vector<const char *> opts;
+    for (int i = 1; i < argc; ++i) {
+        opts.push_back(argv[i]);
+    }
+    return executeGLTrim(opts, NULL);
+}
+
+const Command gltrim_command = {
+    "gltrim",
+    synopsis,
+    usage,
+    command
+};

--- a/cli/cli_main.cpp
+++ b/cli/cli_main.cpp
@@ -71,6 +71,7 @@ static const Command * commands[] = {
     &diff_images_command,
     &dump_command,
     &dump_images_command,
+    &gltrim_command,
     &leaks_command,
     &pickle_command,
     &sed_command,

--- a/frametrim/CMakeLists.txt
+++ b/frametrim/CMakeLists.txt
@@ -26,6 +26,18 @@ target_link_libraries (gltrim
     glretrace_common
     )
 
- install (TARGETS gltrim RUNTIME DESTINATION bin)
+install (TARGETS gltrim RUNTIME DESTINATION bin)
 
-add_subdirectory (tests)
+option (ENABLE_GLTRIM_TESTS "Enable running the gltrim tests." OFF)
+
+if (${ENABLE_GLTRIM_TESTS})
+   SET(gltrim_test_available "${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt")
+   if (EXISTS "${gltrim_test_available}")
+      add_subdirectory (tests)
+   else()
+      message(FATAL_ERROR
+         " gltrim tests requested but test submodule was not cloned, run\n"
+         "    git submodule update --init --recursive\n"
+         " to obtain test data and then re-run cmake.\n")
+   endif()
+endif()

--- a/frametrim/CMakeLists.txt
+++ b/frametrim/CMakeLists.txt
@@ -1,0 +1,31 @@
+include_directories (
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/cli
+    ${CMAKE_SOURCE_DIR}/lib/highlight
+    ${CMAKE_SOURCE_DIR}/helpers
+    ${CMAKE_SOURCE_DIR}/retrace
+    ${CMAKE_BINARY_DIR}/dispatch
+    ${CMAKE_SOURCE_DIR}/dispatch
+    ${CMAKE_SOURCE_DIR}/lib/image
+    ${CMAKE_SOURCE_DIR}/lib/ubjson
+    ${CMAKE_SOURCE_DIR}/thirdparty/dxerr
+    ${CMAKE_SOURCE_DIR}/thirdparty/mhook/mhook-lib
+)
+
+add_executable(gltrim
+   ft_dependecyobject.cpp
+   ft_frametrimmer.cpp
+   ft_main.cpp
+   ft_matrixstate.cpp
+   ft_tracecall.cpp)
+
+set_target_properties(gltrim PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+
+target_link_libraries (gltrim
+    retrace_common
+    glretrace_common
+    )
+
+ install (TARGETS gltrim RUNTIME DESTINATION bin)
+
+add_subdirectory (tests)

--- a/frametrim/frametrim.markdown
+++ b/frametrim/frametrim.markdown
@@ -1,0 +1,61 @@
+# gltrim thoughts and design notes
+
+## Scope
+
+The program targets at trimming a trace to contain the minimum number
+of calls needed to create the image rendered by the target frame.
+
+## Design notes
+
+The programs scans through the trace and collects calls of the various
+GL objects and the GL state. At the start of the target frame the
+current state is recorded to the output, and all the calls recorded in
+the objects used in the callaset corresponding to the frame.
+
+The calls are collected in a std::set so that duplicate calls are
+eliminated, and then the set is sorted based on call number and written.
+
+The following types of calls need to be considered:
+
+* State calls: These need to be updated whenever they occure, but only the
+  last call before the target framess or setup frames are copied needs to
+  be remembered. Set --keep-all-states to override this behaviour and retain
+  all state calls.
+
+* Programs: The object must be tracked and calls related to attached
+  shaders, uniforms, and attribute arrays
+
+* Textures and buffers: creation and use must be tracked
+  - Texture data may also be created by drawing to a fbo
+  - Buffer data may be changed by compute shaders
+
+* Frame buffer objects:
+  The draw buffer must keep all the state information just like the target
+  frame: An attached texture can be used as data source in the target frame
+  and an attached renderbuffer can be the source of a blit. In both cases,
+  the calls to create the output need to be recorded.
+  - Since an FBO needs to keep track of its attachements, and a
+    texture/renderbuffer needs to keep track of its data source(s)  a circular
+    reference is created, this needs to be handled when writing the calls.
+
+## Currently known problems
+
+* in CIV5 the terrain tiles are not retained and some icons are not drawn
+  correctly, this is probably a texture attachement problem. One can work
+  around this by selecting a series of frames as setup frames. These will
+  all be put into the one setup frame.
+
+* Trimming Alien Isolation doesn't retain all state changes as required.
+  Keeping all state changes may help here.
+
+* Games like SOMA, that combine rendered results from various frames to create
+  a motion blur effect need to keep a sufficient number of frames to re-create
+  that effect. It may not be possible to re-create the frame correctly.
+
+## Notes for future optimization
+
+* buffer calls could be optimized so that buffer calls that upload data
+  that is overwritten before it is used in the target frame are dropped
+
+* useless binding and texture unit calls could be dropped
+

--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -1,0 +1,911 @@
+/*********************************************************************
+ *
+ * Copyright 2020 Collabora Ltd
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *********************************************************************/
+
+#include "ft_dependecyobject.hpp"
+
+#include <cstring>
+
+#include <GL/gl.h>
+#include <GL/glext.h>
+
+namespace frametrim {
+
+UsedObject::UsedObject(unsigned id):
+    m_id(id),
+    m_emitted(true)
+{
+
+}
+
+unsigned
+UsedObject::id() const
+{
+    return m_id;
+}
+
+bool
+UsedObject::emitted() const
+{
+    return m_emitted;
+}
+
+void
+UsedObject::addCall(PTraceCall call)
+{
+    m_calls.push_back(call);
+    m_emitted = false;
+}
+
+void
+UsedObject::setCall(PTraceCall call)
+{
+    m_calls.clear();
+    addCall(call);
+}
+
+void
+UsedObject::addDependency(Pointer dep)
+{
+    m_dependencies.push_back(dep);
+    m_emitted = false;
+}
+
+void UsedObject::setDependency(Pointer dep)
+{
+    m_dependencies.clear();
+    addDependency(dep);
+}
+
+void
+UsedObject::emitCallsTo(CallSet& out_list)
+{
+    if (!m_emitted) {
+        m_emitted = true;
+        for (auto&& n : m_calls)
+            out_list.insert(n);
+
+        for (auto&& o : m_dependencies)
+            o->emitCallsTo(out_list);
+    }
+}
+
+unsigned UsedObject::extraInfo(const std::string& key) const
+{
+    auto v = m_extra_info.find(key);
+    return (v != m_extra_info.end()) ? v->second : 0;
+}
+
+void UsedObject::setExtraInfo(const std::string& key, unsigned value)
+{
+    m_extra_info[key] = value;
+}
+
+void
+DependecyObjectMap::generate(const trace::Call& call)
+{
+    auto c = trace2call(call);
+    const auto ids = (call.arg(1)).toArray();
+    for (auto& v : ids->values) {
+        auto obj = std::make_shared<UsedObject>(v->toUInt());
+        obj->addCall(c);
+        addObject(v->toUInt(), obj);
+    }
+}
+
+void DependecyObjectMap::destroy(const trace::Call& call)
+{
+    auto c = trace2call(call);
+    const auto ids = (call.arg(1)).toArray();
+    for (auto& v : ids->values) {
+        assert(m_objects[v->toUInt()]->id() == v->toUInt());
+        m_objects[v->toUInt()]->addCall(c);
+    }
+}
+
+void DependecyObjectMap::create(const trace::Call& call)
+{
+    auto obj = std::make_shared<UsedObject>(call.ret->toUInt());
+    addObject(call.ret->toUInt(), obj);
+    auto c = trace2call(call);
+    obj->addCall(c);
+}
+
+void DependecyObjectMap::del(const trace::Call& call)
+{
+    auto obj = m_objects[call.arg(0).toUInt()];
+    auto c = trace2call(call);
+    obj->addCall(c);
+}
+
+
+void DependecyObjectMap::addObject(unsigned id, UsedObject::Pointer obj)
+{
+    m_objects[id] = obj;
+}
+
+UsedObject::Pointer
+DependecyObjectMap::bind(const trace::Call& call, unsigned obj_id_param)
+{
+    unsigned id = call.arg(obj_id_param).toUInt();
+    setTargetType(id, call.arg(0).toUInt());
+    int bindpoint = getBindpointFromCall(call);
+    if (bindpoint < 0) {
+        std::cerr << "Unknown bindpoint in call "
+                  << call.no << ":" << call.name() << "\n";
+        assert(0);
+    }
+    return bindTarget(id, bindpoint);
+}
+
+void
+DependecyObjectMap::setTargetType(unsigned id, unsigned target)
+{
+    (void)id;
+    (void)target;
+}
+
+UsedObject::Pointer
+DependecyObjectMap::bindTarget(unsigned id, unsigned bindpoint)
+{
+    if (id) {
+        m_bound_object[bindpoint] = m_objects[id];
+    } else {
+        m_bound_object[bindpoint] = nullptr;
+    }
+    return m_bound_object[bindpoint];
+}
+
+UsedObject::Pointer
+DependecyObjectMap::bind( unsigned bindpoint, unsigned id)
+{
+    return m_bound_object[bindpoint] = m_objects[id];
+}
+
+UsedObject::Pointer
+DependecyObjectMap::boundTo(unsigned target, unsigned index)
+{
+    unsigned bindpoint = getBindpoint(target, index);
+    return boundAtBinding(bindpoint);
+}
+
+DependecyObjectMap::ObjectMap::iterator
+DependecyObjectMap::begin()
+{
+    return m_bound_object.begin();
+}
+
+DependecyObjectMap::ObjectMap::iterator
+DependecyObjectMap::end()
+{
+    return m_bound_object.end();
+}
+
+UsedObject::Pointer DependecyObjectMap::boundAtBinding(unsigned index)
+{
+    return m_bound_object[index];
+}
+
+unsigned DependecyObjectMap::getBindpoint(unsigned target, unsigned index) const
+{
+    (void)index;
+    return target;
+}
+
+void
+DependecyObjectMap::callOnBoundObject(const trace::Call& call)
+{
+    unsigned bindpoint = getBindpointFromCall(call);
+    if (bindpoint == 0xffffffff) {
+        std::cerr << "Unknown bindpoint in call " << call.no
+                  << "(" << call.name() << ")\n";
+    }
+
+    if (!m_bound_object[bindpoint])  {
+        return;
+    }
+
+    m_bound_object[bindpoint]->addCall(trace2call(call));
+}
+
+UsedObject::Pointer
+DependecyObjectMap::bindWithCreate(const trace::Call& call, unsigned obj_id_param)
+{
+    unsigned bindpoint = getBindpointFromCall(call);
+    unsigned id = call.arg(obj_id_param).toUInt();
+    if (!m_objects[id])  {
+        m_objects[id] = std::make_shared<UsedObject>(id);
+    }
+    return bindTarget(id, bindpoint);
+}
+
+void
+DependecyObjectMap::callOnObjectBoundTo(const trace::Call& call, unsigned bindpoint)
+{
+    auto obj = boundTo(bindpoint);
+
+    assert(obj);
+
+    obj->addCall(trace2call(call));
+}
+
+void
+DependecyObjectMap::callOnNamedObject(const trace::Call& call)
+{
+    auto obj = m_objects[call.arg(0).toUInt()];
+    if (!obj) {
+        if (call.arg(0).toUInt()) {
+            std::cerr << "Named object " << call.arg(0).toUInt()
+                      << " doesn't exists in call " << call.no << ": "
+                      << call.name() << "\n";
+            assert(0);
+        }
+    } else
+        obj->addCall(trace2call(call));
+}
+
+UsedObject::Pointer
+DependecyObjectMap::callOnBoundObjectWithDep(const trace::Call& call,
+                                             DependecyObjectMap& other_objects,
+                                             int dep_obj_param,
+                                             bool reverse_dep_too)
+{
+    unsigned bindpoint = getBindpointFromCall(call);
+    if (!m_bound_object[bindpoint]) {
+        std::cerr << "No object bound in call " << call.no << ":" << call.name() << "\n";
+        assert(0);
+    }
+
+    UsedObject::Pointer obj = nullptr;
+    unsigned obj_id = call.arg(dep_obj_param).toUInt();
+    if (obj_id) {
+        obj = other_objects.getById(obj_id);
+        assert(obj);
+        m_bound_object[bindpoint]->addDependency(obj);
+        if (reverse_dep_too)
+            obj->addDependency(m_bound_object[bindpoint]);
+    }
+    m_bound_object[bindpoint]->addCall(trace2call(call));
+    return obj;
+}
+
+void
+DependecyObjectMap::callOnBoundObjectWithDepBoundTo(const trace::Call& call,
+                                                    DependecyObjectMap& other_objects,
+                                                    int bindingpoint, CallSet& out_set, bool recording)
+{
+    unsigned bindpoint = getBindpointFromCall(call);
+    if (!m_bound_object[bindpoint]) {
+        std::cerr << "No object bound in call " << call.no << ":" << call.name() << "\n";
+        assert(0);
+    }
+    m_bound_object[bindpoint]->addCall(trace2call(call));
+
+    UsedObject::Pointer obj = nullptr;
+    auto dep = other_objects.boundTo(bindingpoint);
+    if (dep) {
+        m_bound_object[bindpoint]->addDependency(dep);
+        if (recording)
+            dep->emitCallsTo(out_set);
+    }
+
+}
+
+void
+DependecyObjectMap::callOnNamedObjectWithDep(const trace::Call& call,
+                                             DependecyObjectMap& other_objects,
+                                             int dep_obj_param,
+                                             bool reverse_dep_too)
+{
+    auto obj = m_objects[call.arg(0).toUInt()];
+
+    if (!obj) {
+        if (!call.arg(0).toUInt())
+            return;
+
+        std::cerr << "Call:" << call.no << ":" << call.name()
+                  << " Object " << call.arg(0).toUInt() << "not found\n";
+        assert(0);
+    }
+
+
+
+    unsigned dep_obj_id = call.arg(dep_obj_param).toUInt();
+    if (dep_obj_id) {
+        auto dep_obj = other_objects.getById(dep_obj_id);
+        assert(dep_obj);
+        obj->addDependency(dep_obj);
+        if (reverse_dep_too)
+            dep_obj->addDependency(obj);
+    }
+    obj->addCall(trace2call(call));
+}
+
+void
+DependecyObjectMap::callOnNamedObjectWithNamedDep(const trace::Call& call,
+                                                  DependecyObjectMap& other_objects,
+                                                  int dep_call_param, CallSet& out_set, bool recording)
+{
+    auto obj = getById(call.arg(0).toUInt());
+
+    if (!obj) {
+        std::cerr << "No object bound in call " << call.no << ":" << call.name() << "\n";
+        assert(0);
+    }
+    obj->addCall(trace2call(call));
+
+    auto dep = other_objects.getById(call.arg(dep_call_param).toUInt());
+    if (dep) {
+        obj->addDependency(dep);
+        if (recording)
+            dep->emitCallsTo(out_set);
+    }
+}
+
+
+void DependecyObjectMap::addCall(PTraceCall call)
+{
+    m_calls.push_back(call);
+}
+
+
+UsedObject::Pointer
+DependecyObjectMap::getById(unsigned id) const
+{
+    auto i = m_objects.find(id);
+    return i !=  m_objects.end() ? i->second : nullptr;
+}
+
+void
+DependecyObjectMap::emitBoundObjects(CallSet& out_calls)
+{
+    for (auto&& [key, obj]: m_bound_object) {
+        if (obj)
+            obj->emitCallsTo(out_calls);
+    }
+    for(auto&& c : m_calls)
+        out_calls.insert(c);
+}
+
+void DependecyObjectMap::emitBoundObjectsExt(CallSet& out_calls)
+{
+    (void)out_calls;
+}
+
+unsigned
+DependecyObjectWithSingleBindPointMap::getBindpointFromCall(const trace::Call& call) const
+{
+    (void)call;
+    return 0;
+}
+
+unsigned
+DependecyObjectWithDefaultBindPointMap::getBindpointFromCall(const trace::Call& call) const
+{
+    return call.arg(0).toUInt();
+}
+
+UsedObject::Pointer
+BufferObjectMap::boundToTarget(unsigned target, unsigned index)
+{
+    return boundTo(target, index);
+}
+
+unsigned
+BufferObjectMap::getBindpoint(unsigned target, unsigned index) const
+{
+    switch (target) {
+    case GL_ARRAY_BUFFER:
+        return bt_array;
+    case GL_ATOMIC_COUNTER_BUFFER:
+        return bt_atomic_counter + bt_last* index;
+    case GL_COPY_READ_BUFFER:
+        return bt_copy_read;
+    case GL_COPY_WRITE_BUFFER:
+        return bt_copy_write;
+    case GL_DISPATCH_INDIRECT_BUFFER:
+        return bt_dispatch_indirect;
+    case GL_DRAW_INDIRECT_BUFFER:
+        return bt_draw_indirect;
+    case GL_ELEMENT_ARRAY_BUFFER:
+        return bt_element_array;
+    case GL_PIXEL_PACK_BUFFER:
+        return bt_pixel_pack;
+    case GL_PIXEL_UNPACK_BUFFER:
+        return bt_pixel_unpack;
+    case GL_QUERY_BUFFER:
+        return bt_query;
+    case GL_SHADER_STORAGE_BUFFER:
+        return bt_ssbo + bt_last * index;
+    case GL_TEXTURE_BUFFER:
+        return bt_texture;
+    case GL_TRANSFORM_FEEDBACK_BUFFER:
+        return bt_tf  + bt_last * index;
+    case GL_UNIFORM_BUFFER:
+        return bt_uniform + bt_last * index;
+    }
+    std::cerr << "Unknown buffer binding target=" << target << "\n";
+    assert(0);
+    return 0;
+}
+
+unsigned
+BufferObjectMap::getBindpointFromCall(const trace::Call& call) const
+{
+    unsigned target = call.arg(0).toUInt();
+    unsigned index = 0;
+    if (!strcmp(call.name(), "glBindBufferRange")) {
+        index = call.arg(1).toUInt();
+    }
+    return getBindpoint(target, index);
+}
+
+void
+BufferObjectMap::data(const trace::Call& call)
+{
+    unsigned target = getBindpointFromCall(call);
+    auto buf = boundAtBinding(target);
+    if (buf) {
+        m_buffer_sizes[buf->id()] = call.arg(1).toUInt();
+        buf->addCall(trace2call(call));
+    }
+}
+
+void
+BufferObjectMap::namedData(const trace::Call& call)
+{
+    auto buf = getById(call.arg(0).toUInt());
+    if (buf) {
+        m_buffer_sizes[buf->id()] = call.arg(1).toUInt();
+        buf->addCall(trace2call(call));
+    }
+}
+
+void
+BufferObjectMap::map(const trace::Call& call)
+{
+    unsigned target = getBindpointFromCall(call);
+    auto buf = boundAtBinding(target);
+    if (buf) {
+        m_mapped_buffers[target][buf->id()] = buf;
+        uint64_t begin = call.ret->toUInt();
+        uint64_t end = begin + m_buffer_sizes[buf->id()];
+        m_buffer_mappings[buf->id()] = std::make_pair(begin, end);
+        buf->addCall(trace2call(call));
+    }
+}
+
+void
+BufferObjectMap::map_range(const trace::Call& call)
+{
+    unsigned target = getBindpointFromCall(call);
+    auto buf = boundAtBinding(target);
+    if (buf) {
+        m_mapped_buffers[target][buf->id()] = buf;
+        uint64_t begin = call.ret->toUInt();
+        uint64_t end = begin + call.arg(2).toUInt();
+        m_buffer_mappings[buf->id()] = std::make_pair(begin, end);
+        buf->addCall(trace2call(call));
+    }
+}
+
+void
+BufferObjectMap::unmap(const trace::Call& call)
+{
+    unsigned target = getBindpointFromCall(call);
+    auto buf = boundAtBinding(target);
+    if (buf) {
+        m_mapped_buffers[target].erase(buf->id());
+        m_buffer_mappings[buf->id()] = std::make_pair(0, 0);
+        buf->addCall(trace2call(call));
+    }
+}
+
+void
+BufferObjectMap::memcopy(const trace::Call& call)
+{
+    uint64_t start = call.arg(0).toUInt();
+    unsigned buf_id = 0;
+    for(auto&& [id, range ]: m_buffer_mappings) {
+        if (range.first <= start && start < range.second) {
+            buf_id = id;
+            break;
+        }
+    }
+    if (!buf_id) {
+        std::cerr << "Found no mapping for memcopy to " << start << " in call " << call.no << ": " << call.name() << "\n";
+        assert(0);
+    }
+    auto buf = getById(buf_id);
+    buf->addCall(trace2call(call));
+}
+
+void BufferObjectMap::addSSBODependencies(UsedObject::Pointer dep)
+{
+    for(auto && [key, buf]: *this) {
+        if (buf && ((key % bt_last) == bt_ssbo)) {
+            buf->addDependency(dep);
+            dep->addDependency(buf);
+        }
+    }
+}
+
+VertexAttribObjectMap::VertexAttribObjectMap():next_id(1)
+{
+
+}
+
+void
+VertexAttribObjectMap::bindAVO(const trace::Call& call, BufferObjectMap& buffers,
+                               CallSet &out_list, bool emit_dependencies)
+{
+    unsigned id = call.arg(0).toUInt();
+    auto obj = std::make_shared<UsedObject>(next_id);
+    addObject(next_id, obj);
+    bind(id, next_id);
+    obj->addCall(trace2call(call));
+
+    auto buf = buffers.boundToTarget(GL_ARRAY_BUFFER);
+    if (buf) {
+        obj->addDependency(buf);
+        if (emit_dependencies) {
+            buf->emitCallsTo(out_list);
+        }
+    }
+    ++next_id;
+}
+
+void VertexAttribObjectMap::bindVAOBuf(const trace::Call& call, BufferObjectMap& buffers,
+                                       CallSet &out_list, bool emit_dependencies)
+{
+    unsigned id = call.arg(0).toUInt();
+    auto obj = std::make_shared<UsedObject>(next_id);
+    addObject(next_id, obj);
+    bind(id, next_id);
+    obj->addCall(trace2call(call));
+
+    auto buf = buffers.getById(call.arg(1).toUInt());
+    assert(buf || (call.arg(1).toUInt() == 0));
+    if (buf) {
+        obj->addDependency(buf);
+        if (emit_dependencies) {
+            buf->emitCallsTo(out_list);
+        }
+    }
+    ++next_id;
+}
+
+TextureObjectMap::TextureObjectMap():
+    m_active_texture(0)
+{
+
+}
+
+void
+TextureObjectMap::oglActiveTexture(const trace::Call& call)
+{
+    m_active_texture = call.arg(0).toUInt() - GL_TEXTURE0;
+    addCall(trace2call(call));
+}
+
+enum TexTypes {
+    gl_texture_buffer,
+    gl_texture_1d,
+    gl_texture_2d,
+    gl_texture_3d,
+    gl_texture_cube,
+    gl_texture_1d_array,
+    gl_texture_2d_array,
+    gl_texture_cube_array,
+    gl_texture_2dms,
+    gl_texture_2dms_array,
+    gl_texture_rectangle,
+    gl_texture_last
+};
+
+UsedObject::Pointer
+TextureObjectMap::oglBindMultitex(const trace::Call& call)
+{
+    unsigned unit = call.arg(0).toUInt() - GL_TEXTURE0;
+    unsigned target = call.arg(1).toUInt();
+    unsigned id = call.arg(2).toUInt();
+    setTargetType(id, target);
+    unsigned bindpoint  = getBindpointFromTargetAndUnit(target, unit);
+    return bind(bindpoint, id);
+}
+
+void TextureObjectMap::setTargetType(unsigned id, unsigned target)
+{
+    if (!id)
+        return;
+    auto tex = getById(id);
+    unsigned old_target = tex->extraInfo("target");
+    if (!old_target)
+        tex->setExtraInfo("target", target);
+    else
+        assert(old_target == target);
+}
+
+void TextureObjectMap::copy(const trace::Call& call)
+{
+    unsigned src_id = call.arg(0).toUInt();
+    unsigned dst_id = call.arg(6).toUInt();
+
+    auto src = getById(src_id);
+    auto dst = getById(dst_id);
+    assert(src && dst);
+    dst->addCall(trace2call(call));
+    dst->addDependency(src);
+}
+
+void TextureObjectMap::bindToImageUnit(const trace::Call& call)
+{
+    unsigned unit = call.arg(0).toUInt();
+    unsigned id = call.arg(1).toUInt();
+
+    auto c = trace2call(call);
+    if (id) {
+        auto tex = getById(id);
+        assert(tex);
+        tex->addCall(c);
+        m_bound_images[unit] = tex;
+    } else {
+        addCall(c);
+        m_bound_images[unit] = nullptr;
+    }
+}
+
+void TextureObjectMap::bindFromTextureTarget(unsigned unit, UsedObject::Pointer obj)
+{
+    unsigned target = obj->extraInfo("target");
+    assert(target > 0);
+    unsigned bindpoint = getBindpointFromTargetAndUnit(target, unit);
+    bind(bindpoint, obj->id());
+}
+
+void TextureObjectMap::unbindUnits(unsigned first, unsigned count)
+{
+    for (unsigned i = 0; i < count; ++i) {
+        for (unsigned t = gl_texture_1d; t < gl_texture_last; ++t) {
+            unsigned bindpoint = t + (first + i) * gl_texture_last;
+            bind(bindpoint, 0);
+        }
+    }
+}
+
+unsigned
+TextureObjectMap::getBindpointFromCall(const trace::Call& call) const
+{
+    unsigned target = call.arg(0).toUInt();
+    return getBindpointFromTargetAndUnit(target, m_active_texture);
+}
+
+void TextureObjectMap::emitBoundObjectsExt(CallSet& out_calls)
+{
+    for(auto [unit, tex]: m_bound_images)
+        if (tex)
+            tex->emitCallsTo(out_calls);
+}
+
+void TextureObjectMap::addImageDependencies(UsedObject::Pointer dep)
+{
+    for (auto&& [key, tex]: m_bound_images) {
+        if (tex) {
+            tex->addDependency(dep);
+            dep->addDependency(tex);
+        }
+    }
+}
+
+int
+TextureObjectMap::getBindpointFromTargetAndUnit(unsigned target, unsigned unit) const
+{
+    switch (target) {
+    case GL_TEXTURE_CUBE_MAP_NEGATIVE_X:
+    case GL_TEXTURE_CUBE_MAP_NEGATIVE_Y:
+    case GL_TEXTURE_CUBE_MAP_NEGATIVE_Z:
+    case GL_TEXTURE_CUBE_MAP_POSITIVE_X:
+    case GL_TEXTURE_CUBE_MAP_POSITIVE_Y:
+    case GL_TEXTURE_CUBE_MAP_POSITIVE_Z:
+    case GL_TEXTURE_CUBE_MAP:
+        target = gl_texture_cube;
+        break;
+    case GL_PROXY_TEXTURE_1D:
+    case GL_TEXTURE_1D:
+        target = gl_texture_1d;
+        break;
+    case GL_PROXY_TEXTURE_2D:
+    case GL_TEXTURE_2D:
+        target = gl_texture_2d;
+        break;
+    case GL_PROXY_TEXTURE_3D:
+    case GL_TEXTURE_3D:
+        target = gl_texture_3d;
+        break;
+    case GL_TEXTURE_CUBE_MAP_ARRAY:
+        target = gl_texture_cube_array;
+        break;
+    case GL_TEXTURE_1D_ARRAY:
+        target = gl_texture_1d_array;
+        break;
+    case GL_TEXTURE_2D_ARRAY:
+        target = gl_texture_2d_array;
+        break;
+    case GL_TEXTURE_2D_MULTISAMPLE:
+        target = gl_texture_2dms;
+        break;
+    case GL_TEXTURE_2D_MULTISAMPLE_ARRAY:
+        target = gl_texture_2dms_array;
+        break;
+    case GL_TEXTURE_BUFFER:
+        target = gl_texture_buffer;
+        break;
+    case GL_TEXTURE_RECTANGLE:
+        target = gl_texture_rectangle;
+        break;
+    default:
+        std::cerr << "target=" << target << " not supported\n";
+        return -1;
+        ;
+    }
+    return target + unit * gl_texture_last;
+}
+
+unsigned QueryObjectMap::getBindpointFromCall(const trace::Call& call) const
+{
+    unsigned target = call.arg(0).toUInt();
+    unsigned index = 0;
+    if (!strcmp(call.name(), "glBeginQueryIndexed") ||
+        !strcmp(call.name(), "glEndQueryIndexed")) {
+        index = call.arg(1).toUInt();
+    }
+    return getBindpoint(target, index);
+}
+
+unsigned QueryObjectMap::getBindpoint(unsigned target, unsigned index) const
+{
+    unsigned bindpoint = index * query_last;
+    switch (target) {
+    case GL_SAMPLES_PASSED:
+        bindpoint += query_samples_passed;
+        break;
+    case GL_ANY_SAMPLES_PASSED:
+        bindpoint += query_any_samples_passed;
+        break;
+    case GL_ANY_SAMPLES_PASSED_CONSERVATIVE:
+        bindpoint += query_primitives_generated;
+        break;
+    case GL_PRIMITIVES_GENERATED:
+        bindpoint += query_transform_feedback;
+        break;
+    case GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN:
+        bindpoint += query_tf_primitives_written;
+        break;
+    case GL_TIME_ELAPSED:
+        bindpoint += query_time_elapses;
+        break;
+    case GL_TIMESTAMP:
+        bindpoint += query_timestamp;
+        break;
+    default:
+        std::cerr << "Unknown query target "<< target << " in " << __func__ << "\n";
+        bindpoint = 0xffffffff;
+    }
+    return bindpoint;
+}
+
+void QueryObjectMap::oglEndQuery(const trace::Call& call)
+{
+    unsigned target = call.arg(0).toUInt();
+    endWithTargetIndex(target, 0, call);
+}
+
+void QueryObjectMap::oglEndQueryIndexed(const trace::Call& call)
+{
+    unsigned target = call.arg(0).toUInt();
+    unsigned index = call.arg(1).toUInt();
+    endWithTargetIndex(target, index, call);
+}
+
+void QueryObjectMap::endWithTargetIndex(unsigned target, unsigned index, const trace::Call& call)
+{
+    auto obj = boundTo(target, index);
+    if (obj)
+        obj->addCall(trace2call(call));
+
+    bind(getBindpoint(target, index), 0);
+}
+
+
+FramebufferObjectMap::FramebufferObjectMap()
+{
+    auto default_fb = std::make_shared<UsedObject>(0);
+    addObject(0, default_fb);
+    bind(GL_DRAW_FRAMEBUFFER, 0);
+    bind(GL_READ_FRAMEBUFFER, 0);
+}
+
+unsigned
+FramebufferObjectMap::getBindpointFromCall(const trace::Call& call) const
+{
+    switch (call.arg(0).toUInt()) {
+    case GL_FRAMEBUFFER:
+    case GL_DRAW_FRAMEBUFFER:
+        return GL_DRAW_FRAMEBUFFER;
+    case GL_READ_FRAMEBUFFER:
+        return GL_READ_FRAMEBUFFER;
+    }
+    return 0;
+}
+
+UsedObject::Pointer
+FramebufferObjectMap::bindTarget(unsigned id, unsigned bindpoint)
+{
+    UsedObject::Pointer obj = nullptr;
+    if (bindpoint == GL_FRAMEBUFFER ||
+        bindpoint == GL_DRAW_FRAMEBUFFER) {
+        bind(GL_FRAMEBUFFER, id);
+        obj = bind(GL_DRAW_FRAMEBUFFER, id);
+    }
+
+    if (bindpoint == GL_FRAMEBUFFER ||
+        bindpoint == GL_READ_FRAMEBUFFER)
+        obj = bind(GL_READ_FRAMEBUFFER, id);
+
+    return obj;
+}
+
+void
+FramebufferObjectMap::oglBlit(const trace::Call& call)
+{
+    auto dest = boundTo(GL_DRAW_FRAMEBUFFER);
+    auto src = boundTo(GL_READ_FRAMEBUFFER);
+    assert(dest);
+    assert(src);
+    dest->addDependency(src);
+    dest->addCall(trace2call(call));
+}
+
+void
+FramebufferObjectMap::oglReadBuffer(const trace::Call& call)
+{
+    auto fbo = boundTo(GL_READ_FRAMEBUFFER);
+    assert(call.arg(0).toUInt() != GL_BACK || fbo->id() == 0);
+    callOnObjectBoundTo(call, GL_READ_FRAMEBUFFER);
+}
+
+void FramebufferObjectMap::oglDrawFromBuffer(const trace::Call& call, BufferObjectMap& buffers)
+{
+    auto fbo = boundTo(GL_DRAW_FRAMEBUFFER);
+    if (fbo->id()) {
+        auto buf = buffers.boundToTarget(GL_ELEMENT_ARRAY_BUFFER);
+        if (buf)
+            fbo->addDependency(buf);
+        fbo->addCall(trace2call(call));
+    }
+}
+
+}

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -1,0 +1,1175 @@
+/*********************************************************************
+ *
+ * Copyright 2020 Collabora Ltd
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *********************************************************************/
+
+#include "ft_frametrimmer.hpp"
+#include "ft_tracecall.hpp"
+#include "ft_matrixstate.hpp"
+#include "ft_dependecyobject.hpp"
+
+
+#include "trace_model.hpp"
+
+
+#include <unordered_set>
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <iostream>
+#include <memory>
+#include <set>
+
+#include <GL/gl.h>
+#include <GL/glext.h>
+
+namespace frametrim {
+
+using std::bind;
+using std::placeholders::_1;
+using std::make_shared;
+
+
+using ft_callback = std::function<void(const trace::Call&)>;
+
+struct string_part_less {
+    bool operator () (const char *lhs, const char *rhs) const
+    {
+        int len = std::min(strlen(lhs), strlen(rhs));
+        return strncmp(lhs, rhs, len) < 0;
+    }
+};
+
+struct FrameTrimmeImpl {
+
+    using ObjectMap = std::unordered_map<unsigned, UsedObject::Pointer>;
+
+    FrameTrimmeImpl(bool keep_all_states);
+    void call(const trace::Call& call, Frametype frametype);
+    void startTargetFrame();
+    void endTargetFrame();
+
+    std::vector<unsigned> getSortedCallIds();
+
+    static unsigned equalChars(const char *l, const char *r);
+
+    PTraceCall recordStateCall(const trace::Call& call, unsigned no_param_sel);
+
+    void registerStateCalls();
+    void registerLegacyCalls();
+    void registerRequiredCalls();
+    void registerFramebufferCalls();
+    void registerBufferCalls();
+    void registerProgramCalls();
+    void registerVaCalls();
+    void registerTextureCalls();
+    void registerQueryCalls();
+    void registerDrawCalls();
+    void registerIgnoreHistoryCalls();
+
+
+    void recordRequiredCall(const trace::Call& call);
+
+    void updateCallTable(const std::vector<const char*>& names,
+                           ft_callback cb);
+
+    void oglBegin(const trace::Call& call);
+    void oglEnd(const trace::Call& call);
+    void oglVertex(const trace::Call& call);
+    void oglEndList(const trace::Call& call);
+    void oglGenLists(const trace::Call& call);
+    void oglNewList(const trace::Call& call);
+    void oglCallList(const trace::Call& call);
+    void oglDeleteLists(const trace::Call& call);
+    void oglBind(const trace::Call& call, DependecyObjectMap& map, unsigned bind_param);
+    void oglDraw(const trace::Call& call);
+    void oglBindFbo(const trace::Call& call, DependecyObjectMap& map,
+                       unsigned bind_param);
+    void oglBindTextures(const trace::Call& call);
+    void bindWithCreate(const trace::Call& call, DependecyObjectMap& map,
+                        unsigned bind_param);
+    void oglWaitSync(const trace::Call& call);
+    void callOnBoundObjWithDep(const trace::Call& call, DependecyObjectMap& map,
+                               unsigned obj_id_param, DependecyObjectMap &dep_map, bool reverse_dep_too);
+
+    void oglBindMultitex(const trace::Call& call);
+    void oglDispatchCompute(const trace::Call& call);
+
+    void todo(const trace::Call& call);
+    void ignoreHistory(const trace::Call& call);
+
+    bool skipDeleteObj(const trace::Call& call);
+    bool skipDeleteImpl(unsigned obj_id, DependecyObjectMap& map);
+    void finalize();
+
+    using CallTable = std::multimap<const char *, ft_callback, string_part_less>;
+    CallTable m_call_table;
+
+    CallSet m_required_calls;
+    std::set<std::string> m_unhandled_calls;
+
+    std::unordered_map<unsigned, UsedObject::Pointer> m_display_lists;
+    UsedObject::Pointer m_active_display_list;
+
+    AllMatrisStates m_matrix_states;
+
+    using LegacyProgrambjectMap = DependecyObjectWithDefaultBindPointMap;
+    using ProgramObjectMap = DependecyObjectWithSingleBindPointMap;
+    using ProgramPipelineObjectMap = DependecyObjectWithSingleBindPointMap;
+    using SamplerObjectMap = DependecyObjectWithDefaultBindPointMap;
+    using SyncObjectMap = DependecyObjectWithSingleBindPointMap;
+    using ShaderStateMap = DependecyObjectWithDefaultBindPointMap;
+    using RenderObjectMap = DependecyObjectWithSingleBindPointMap;
+    using VertexArrayMap = DependecyObjectWithDefaultBindPointMap;
+
+    LegacyProgrambjectMap m_legacy_programs;
+    ProgramObjectMap m_programs;
+    ProgramPipelineObjectMap m_program_pipelines;
+    TextureObjectMap m_textures;
+    FramebufferObjectMap m_fbo;
+    BufferObjectMap m_buffers;
+    ShaderStateMap m_shaders;
+    RenderObjectMap m_renderbuffers;
+    SamplerObjectMap m_samplers;
+    SyncObjectMap m_sync_objects;
+    VertexArrayMap m_vertex_arrays;
+    VertexAttribObjectMap m_vertex_attrib_pointers;
+    VertexAttribObjectMap m_vertex_buffer_pointers;
+    QueryObjectMap m_queries;
+
+    std::map<std::string, PTraceCall> m_state_calls;
+    std::map<unsigned, PTraceCall> m_enables;
+
+    bool m_recording_frame;
+
+    PTraceCall m_last_swap;
+    bool m_keep_all_state_calls;
+};
+
+FrameTrimmer::FrameTrimmer(bool keep_all_states)
+{
+    impl = new FrameTrimmeImpl(keep_all_states);
+}
+
+FrameTrimmer::~FrameTrimmer()
+{
+    delete impl;
+}
+
+void
+FrameTrimmer::call(const trace::Call& call, Frametype target_frame_type)
+{
+    impl->call(call, target_frame_type);
+}
+
+std::vector<unsigned>
+FrameTrimmer::getSortedCallIds()
+{
+    return impl->getSortedCallIds();
+}
+
+void FrameTrimmer::finalize()
+{
+    impl->finalize();
+}
+
+FrameTrimmeImpl::FrameTrimmeImpl(bool keep_all_states):
+    m_recording_frame(false),
+    m_keep_all_state_calls(keep_all_states)
+{
+    registerStateCalls();
+    registerLegacyCalls();
+    registerRequiredCalls();
+    registerFramebufferCalls();
+    registerBufferCalls();
+    registerProgramCalls();
+    registerVaCalls();
+    registerTextureCalls();
+    registerQueryCalls();
+    registerDrawCalls();
+    registerIgnoreHistoryCalls();
+}
+
+void
+FrameTrimmeImpl::call(const trace::Call& call, Frametype frametype)
+{
+    const char *call_name = call.name();
+
+    if (!m_recording_frame && (frametype != ft_none))
+        startTargetFrame();
+    if (m_recording_frame && (frametype == ft_none))
+        endTargetFrame();
+
+
+
+    auto cb_range = m_call_table.equal_range(call.name());
+    if (cb_range.first != m_call_table.end() &&
+            std::distance(cb_range.first, cb_range.second) > 0) {
+
+        CallTable::const_iterator cb = cb_range.first;
+        CallTable::const_iterator i = cb_range.first;
+        ++i;
+
+        unsigned max_equal = equalChars(cb->first, call_name);
+
+        while (i != cb_range.second && i != m_call_table.end()) {
+            auto n = equalChars(i->first, call_name);
+            if (n > max_equal) {
+                max_equal = n;
+                cb = i;
+            }
+            ++i;
+        }
+
+        cb->second(call);
+    } else {
+        /* This should be some debug output only, because we might
+         * not handle some calls deliberately */
+        if (m_unhandled_calls.find(call_name) == m_unhandled_calls.end()) {
+            std::cerr << "Call " << call.no
+                      << " " << call_name << " not handled\n";
+            m_unhandled_calls.insert(call_name);
+        }
+    }
+
+    auto c = trace2call(call);
+
+    if (frametype == ft_none) {
+        if (call.flags & trace::CALL_FLAG_END_FRAME)
+            m_last_swap = c;
+    } else {
+        /* Skip delete calls for objects that have never been emitted */
+        if (skipDeleteObj(call))
+            return;
+
+        if (!(call.flags & trace::CALL_FLAG_END_FRAME)) {
+            m_required_calls.insert(c);
+        } else {
+            if (frametype == ft_retain_frame) {
+                m_required_calls.insert(c);
+                if (m_last_swap) {
+                    m_required_calls.insert(m_last_swap);
+                    m_last_swap = nullptr;
+                }
+            } else
+                m_last_swap = c;
+        }
+    }
+}
+
+void FrameTrimmeImpl::startTargetFrame()
+{
+    std::cerr << "Start recording\n";
+
+    m_recording_frame = true;
+
+    m_matrix_states.emitStateTo(m_required_calls);
+
+    for (auto&& [name, call] : m_state_calls)
+        m_required_calls.insert(call);
+
+    for (auto&& [id, call]: m_enables)
+        m_required_calls.insert(call);
+
+    m_programs.emitBoundObjects(m_required_calls);
+    m_program_pipelines.emitBoundObjects(m_required_calls);
+    m_textures.emitBoundObjects(m_required_calls);
+    m_fbo.emitBoundObjects(m_required_calls);
+    m_buffers.emitBoundObjects(m_required_calls);
+    m_shaders.emitBoundObjects(m_required_calls);
+    m_renderbuffers.emitBoundObjects(m_required_calls);
+    m_samplers.emitBoundObjects(m_required_calls);
+    m_sync_objects.emitBoundObjects(m_required_calls);
+    m_vertex_arrays.emitBoundObjects(m_required_calls);
+    m_vertex_attrib_pointers.emitBoundObjects(m_required_calls);
+    m_vertex_buffer_pointers.emitBoundObjects(m_required_calls);
+    m_legacy_programs.emitBoundObjects(m_required_calls);
+    m_queries.emitBoundObjects(m_required_calls);
+}
+
+bool
+FrameTrimmeImpl::skipDeleteObj(const trace::Call& call)
+{
+    if (!strcmp(call.name(), "glDeleteProgram"))
+        return skipDeleteImpl(call.arg(0).toUInt(), m_programs);
+
+    if (!strcmp(call.name(), "glDeleteProgramPipelines"))
+        return skipDeleteImpl(call.arg(0).toUInt(), m_program_pipelines);
+
+    if (!strcmp(call.name(), "glDeleteSync"))
+        return skipDeleteImpl(call.arg(0).toUInt(), m_sync_objects);
+
+    DependecyObjectMap *map = nullptr;
+    if (!strcmp(call.name(), "glDeleteBuffers"))
+        map = &m_buffers;
+
+    if (!strcmp(call.name(), "glDeleteTextures"))
+        map = &m_textures;
+
+    if (!strcmp(call.name(), "glDeleteFramebuffers"))
+        map = &m_fbo;
+
+    if (!strcmp(call.name(), "glDeleteRenderbuffers"))
+        map = &m_renderbuffers;
+
+    if (!strcmp(call.name(), "glDeleteQueries"))
+        map = &m_queries;
+
+    if (map) {
+        const auto ids = (call.arg(1)).toArray();
+        for (auto& v : ids->values) {
+            if (!skipDeleteImpl(v->toUInt(), *map))
+                return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+bool
+FrameTrimmeImpl::skipDeleteImpl(unsigned obj_id, DependecyObjectMap& map)
+{
+    auto obj = map.getById(obj_id);
+    return !obj->emitted();
+}
+
+void FrameTrimmeImpl::finalize()
+{
+    if (m_last_swap)
+        m_required_calls.insert(m_last_swap);
+}
+
+void FrameTrimmeImpl::endTargetFrame()
+{
+    std::cerr << "End recording\n";
+    m_recording_frame = false;
+}
+
+std::vector<unsigned>
+FrameTrimmeImpl::getSortedCallIds()
+{
+    std::unordered_set<unsigned> make_sure_its_singular;
+
+    for(auto&& c: m_required_calls)
+        make_sure_its_singular.insert(c->callNo());
+
+    std::vector<unsigned> sorted_calls(
+                make_sure_its_singular.begin(),
+                make_sure_its_singular.end());
+    std::sort(sorted_calls.begin(), sorted_calls.end());
+    return sorted_calls;
+}
+
+unsigned
+FrameTrimmeImpl::equalChars(const char *l, const char *r)
+{
+    unsigned retval = 0;
+    while (*l && *r && *l == *r) {
+        ++retval;
+        ++l; ++r;
+    }
+    if (!*l && !*r)
+        ++retval;
+
+    return retval;
+}
+
+// Map callbacks to call methods of FrameTRimImpl
+// Additional data is passed by reference (R) or vy value (V)
+
+#define MAP(name, call) m_call_table.insert(std::make_pair(#name, bind(&FrameTrimmeImpl:: call, this, _1)))
+
+#define MAP_RV(name, call, data, param1) \
+    m_call_table.insert(std::make_pair(#name, bind(&FrameTrimmeImpl:: call, this, _1, \
+                        std::ref(data), param1)))
+
+#define MAP_RVRV(name, call, data1, param1, data2, param2) \
+    m_call_table.insert(std::make_pair(#name, bind(&FrameTrimmeImpl:: call, this, _1, \
+                        std::ref(data1), param1, std::ref(data2), param2)))
+
+// Map callbacks to call methods of object map "obj"
+
+#define MAP_OBJ(name, obj, call) \
+    m_call_table.insert(std::make_pair(#name, bind(&call, &obj, _1)))
+
+#define MAP_OBJ_V(name, obj, call, data) \
+    m_call_table.insert(std::make_pair(#name, bind(&call, &obj, _1, data)))
+
+#define MAP_OBJ_RVV(name, obj, call, data, param1, param2) \
+    m_call_table.insert(std::make_pair(#name, bind(&call, &obj, _1, \
+                        std::ref(data), param1, param2)))
+
+#define MAP_OBJ_RVRR(name, obj, call, data1, param, data2, data3) \
+    m_call_table.insert(std::make_pair(#name, bind(&call, &obj, _1, \
+                        std::ref(data1), param, std::ref(data2), std::ref(data3))))
+
+#define MAP_OBJ_RRR(name, obj, call, data1, data2, data3) \
+    m_call_table.insert(std::make_pair(#name, bind(&call, &obj, _1, \
+                        std::ref(data1), std::ref(data2), std::ref(data3))))
+
+void FrameTrimmeImpl::registerLegacyCalls()
+{
+    // draw calls
+    MAP(glBegin, oglBegin);
+    MAP(glColor2, oglVertex);
+    MAP(glColor3, oglVertex);
+    MAP(glColor4, oglVertex);
+    MAP(glEnd, oglEnd);
+    MAP(glNormal, oglVertex);
+    MAP(glRect, oglVertex);
+    MAP(glTexCoord2, oglVertex);
+    MAP(glTexCoord3, oglVertex);
+    MAP(glTexCoord4, oglVertex);
+    MAP(glVertex3, oglVertex);
+    MAP(glVertex4, oglVertex);
+    MAP(glVertex2, oglVertex);
+    MAP(glVertex3, oglVertex);
+    MAP(glVertex4, oglVertex);
+
+    // display lists
+    MAP(glCallList, oglCallList);
+    MAP(glDeleteLists, oglDeleteLists);
+    MAP(glEndList, oglEndList);
+    MAP(glGenLists, oglGenLists);
+    MAP(glNewList, oglNewList);
+
+    MAP(glPushClientAttr, todo);
+    MAP(glPopClientAttr, todo);
+
+
+    // shader calls
+    MAP_OBJ(glGenPrograms, m_legacy_programs,
+               DependecyObjectWithDefaultBindPointMap::generate);
+    MAP_RV(glBindProgram, bindWithCreate, m_legacy_programs, 1);
+
+    MAP_OBJ(glDeletePrograms, m_legacy_programs,
+               LegacyProgrambjectMap::destroy);
+
+    MAP_OBJ(glProgramString, m_legacy_programs,
+               LegacyProgrambjectMap::callOnBoundObject);
+    MAP_OBJ(glProgramLocalParameter, m_legacy_programs,
+               LegacyProgrambjectMap::callOnBoundObject);
+    MAP_OBJ(glProgramEnvParameter, m_legacy_programs,
+               LegacyProgrambjectMap::callOnBoundObject);
+
+    // Matrix manipulation
+    MAP_OBJ(glLoadIdentity, m_matrix_states, AllMatrisStates::loadIdentity);
+    MAP_OBJ(glLoadMatrix, m_matrix_states, AllMatrisStates::loadMatrix);
+    MAP_OBJ(glMatrixMode, m_matrix_states, AllMatrisStates::matrixMode);
+    MAP_OBJ(glMultMatrix, m_matrix_states, AllMatrisStates::matrixOp);
+    MAP_OBJ(glOrtho, m_matrix_states, AllMatrisStates::matrixOp);
+    MAP_OBJ(glRotate, m_matrix_states, AllMatrisStates::matrixOp);
+    MAP_OBJ(glScale, m_matrix_states, AllMatrisStates::matrixOp);
+    MAP_OBJ(glTranslate, m_matrix_states, AllMatrisStates::matrixOp);
+    MAP_OBJ(glPopMatrix, m_matrix_states, AllMatrisStates::popMatrix);
+    MAP_OBJ(glPushMatrix, m_matrix_states, AllMatrisStates::pushMatrix);
+    MAP(glDispatchCompute, oglDispatchCompute);
+}
+
+void FrameTrimmeImpl::registerFramebufferCalls()
+{
+    MAP_RV(glBindRenderbuffer, oglBind, m_renderbuffers, 1);
+    MAP_OBJ(glDeleteRenderbuffers, m_renderbuffers, DependecyObjectWithSingleBindPointMap::destroy);
+    MAP_OBJ(glGenRenderbuffer, m_renderbuffers, DependecyObjectWithSingleBindPointMap::generate);
+    MAP_OBJ(glRenderbufferStorage, m_renderbuffers, DependecyObjectWithSingleBindPointMap::callOnBoundObject);
+
+    MAP_OBJ(glGenFramebuffer, m_fbo, FramebufferObjectMap::generate);
+    MAP_OBJ(glDeleteFramebuffers, m_fbo, FramebufferObjectMap::destroy);
+    MAP_RV(glBindFramebuffer, oglBindFbo, m_fbo, 1);
+    MAP_OBJ_V(glViewport, m_fbo, FramebufferObjectMap::callOnObjectBoundTo, GL_DRAW_FRAMEBUFFER);
+
+    MAP_OBJ(glBlitFramebuffer, m_fbo, FramebufferObjectMap::oglBlit);
+    MAP_RVRV(glFramebufferTexture, callOnBoundObjWithDep, m_fbo, 2, m_textures, true);
+    MAP_RVRV(glFramebufferTexture1D, callOnBoundObjWithDep, m_fbo,
+                            3, m_textures, true);
+    MAP_RVRV(glFramebufferTexture2D, callOnBoundObjWithDep, m_fbo,
+                            3, m_textures, true);
+
+    MAP_OBJ(glReadBuffer, m_fbo, FramebufferObjectMap::oglReadBuffer);
+    MAP_OBJ_V(glDrawBuffer, m_fbo, FramebufferObjectMap::callOnObjectBoundTo, GL_DRAW_FRAMEBUFFER);
+
+    MAP_OBJ_V(glClearBuffer, m_fbo, FramebufferObjectMap::callOnObjectBoundTo, GL_DRAW_FRAMEBUFFER);
+    MAP_OBJ_V(glClearBufferfi, m_fbo, FramebufferObjectMap::callOnObjectBoundTo, GL_DRAW_FRAMEBUFFER);
+    MAP_OBJ_V(glClearBufferfv, m_fbo, FramebufferObjectMap::callOnObjectBoundTo, GL_DRAW_FRAMEBUFFER);
+    MAP_OBJ_V(glClearBufferiv, m_fbo, FramebufferObjectMap::callOnObjectBoundTo, GL_DRAW_FRAMEBUFFER);
+
+/*    MAP_GENOBJ_DATAREF(glFramebufferTexture3D, m_fbo,
+                         FramebufferStateMap::attach_texture3d, m_textures);
+      MAP(glReadBuffer, ReadBuffer); */
+
+    MAP_RVRV(glFramebufferRenderbuffer, callOnBoundObjWithDep,
+             m_fbo, 3, m_renderbuffers, true);
+
+    MAP_OBJ_V(glClear, m_fbo, FramebufferObjectMap::callOnObjectBoundTo, GL_DRAW_FRAMEBUFFER);
+
+}
+
+void
+FrameTrimmeImpl::registerBufferCalls()
+{
+    MAP_OBJ(glGenBuffers, m_buffers, BufferObjectMap::generate);
+    MAP_OBJ(glDeleteBuffers, m_buffers, BufferObjectMap::destroy);
+
+    MAP_RV(glBindBuffer, oglBind, m_buffers, 1);
+    MAP_RV(glBindBufferRange, oglBind, m_buffers, 2);
+
+    /* This will need a bit more to be handled correctly */
+    MAP_RV(glBindBufferBase, oglBind, m_buffers, 2);
+
+    MAP_OBJ(glBufferData, m_buffers, BufferObjectMap::data);
+    MAP_OBJ(glBufferStorage, m_buffers, BufferObjectMap::data);
+    MAP_OBJ(glNamedBufferData, m_buffers, BufferObjectMap::namedData);
+    MAP_OBJ(glNamedBufferStorage, m_buffers, BufferObjectMap::namedData);
+    MAP_OBJ(glBufferSubData, m_buffers, BufferObjectMap::callOnBoundObject);
+
+    MAP_OBJ(glMapBuffer, m_buffers, BufferObjectMap::map);
+    MAP_OBJ(glMapBufferRange, m_buffers, BufferObjectMap::map_range);
+    MAP_OBJ(memcpy, m_buffers, BufferObjectMap::memcopy);
+    MAP_OBJ(glFlushMappedBufferRange, m_buffers, BufferObjectMap::callOnBoundObject);
+    MAP_OBJ(glUnmapBuffer, m_buffers, BufferObjectMap::unmap);
+    MAP_OBJ(glClearBufferData, m_buffers, BufferObjectMap::callOnBoundObject);
+    MAP_OBJ(glInvalidateBufferData, m_buffers, BufferObjectMap::callOnNamedObject);
+}
+
+void FrameTrimmeImpl::registerDrawCalls()
+{
+    MAP(glDrawArrays, oglDraw);
+    MAP(glDrawElements, oglDraw);
+    MAP(glDrawRangeElements, oglDraw);
+    MAP(glDrawRangeElementsBaseVertex, oglDraw);
+}
+
+void
+FrameTrimmeImpl::registerProgramCalls()
+{
+    MAP_OBJ_RVV(glAttachObject, m_programs,
+                   ProgramObjectMap::callOnNamedObjectWithDep, m_shaders, 1, false);
+    MAP_OBJ_RVV(glAttachShader, m_programs,
+                   ProgramObjectMap::callOnNamedObjectWithDep, m_shaders, 1, false);
+
+    MAP_OBJ(glCompileShader, m_shaders, ShaderStateMap::callOnNamedObject);
+    MAP_OBJ(glCreateShader, m_shaders, ShaderStateMap::create);
+    MAP_OBJ(glDeleteShader, m_shaders, ShaderStateMap::del);
+    MAP_OBJ(glShaderSource, m_shaders, ShaderStateMap::callOnNamedObject);
+
+    MAP_OBJ(glBindAttribLocation, m_programs, ProgramObjectMap::callOnNamedObject);
+    MAP_OBJ(glCreateProgram, m_programs, ProgramObjectMap::create);
+    MAP_OBJ(glDeleteProgram, m_programs, ProgramObjectMap::del);
+    MAP_OBJ(glDetachShader, m_programs, ProgramObjectMap::callOnNamedObject);
+
+    MAP_OBJ(glGetAttribLocation, m_programs, ProgramObjectMap::callOnNamedObject);
+    MAP_OBJ(glGetUniformLocation, m_programs, ProgramObjectMap::callOnNamedObject);
+    MAP_OBJ(glBindFragDataLocation, m_programs, ProgramObjectMap::callOnNamedObject);
+    MAP_OBJ(glLinkProgram, m_programs, ProgramObjectMap::callOnNamedObject);
+    MAP_OBJ(glProgramBinary, m_programs, ProgramObjectMap::callOnNamedObject);
+    MAP_OBJ(glProgramUniform, m_programs, ProgramObjectMap::callOnNamedObject);
+
+    MAP_OBJ(glUniform, m_programs, ProgramObjectMap::callOnBoundObject);
+    MAP_OBJ(glUniformBlockBinding, m_programs, ProgramObjectMap::callOnNamedObject);
+    MAP_RV(glUseProgram, oglBind, m_programs, 0);
+    MAP_OBJ(glProgramParameter, m_programs, ProgramObjectMap::callOnNamedObject);
+    MAP_OBJ(glShaderStorageBlockBinding, m_programs, ProgramObjectMap::callOnNamedObject);
+
+    MAP_OBJ(glGenProgramPipelines, m_program_pipelines, ProgramPipelineObjectMap::generate);
+    MAP_OBJ(glDeleteProgramPipelines, m_program_pipelines, ProgramPipelineObjectMap::destroy);
+    MAP_RV(glBindProgramPipelines, oglBind, m_program_pipelines, 0);
+    MAP_OBJ_RVRR(glUseProgramStages, m_program_pipelines, ProgramPipelineObjectMap::callOnNamedObjectWithNamedDep,
+                 m_programs, 2, m_required_calls, m_recording_frame);
+    MAP_OBJ_RVRR(glActiveShaderProgram, m_program_pipelines, ProgramPipelineObjectMap::callOnNamedObjectWithNamedDep,
+                 m_programs, 1, m_required_calls, m_recording_frame);
+}
+
+void FrameTrimmeImpl::registerTextureCalls()
+{
+    MAP_OBJ(glGenTextures, m_textures, TextureObjectMap::generate);
+    MAP_OBJ(glDeleteTextures, m_textures, TextureObjectMap::destroy);
+
+    MAP_OBJ(glActiveTexture, m_textures, TextureObjectMap::oglActiveTexture);
+    MAP_OBJ(glClientActiveTexture, m_textures, TextureObjectMap::oglActiveTexture);
+    MAP_RV(glBindTexture, oglBind, m_textures, 1);
+    MAP(glBindMultiTexture, oglBindMultitex);
+
+    MAP_OBJ(glCompressedTexImage2D, m_textures, TextureObjectMap::callOnBoundObject);
+    MAP_OBJ(glGenerateMipmap, m_textures, TextureObjectMap::callOnBoundObject);
+    MAP_OBJ(glTexImage1D, m_textures, TextureObjectMap::callOnBoundObject);
+    MAP_OBJ(glTexImage2D, m_textures, TextureObjectMap::callOnBoundObject);
+    MAP_OBJ(glTexStorage1D, m_textures, TextureObjectMap::callOnBoundObject);
+    MAP_OBJ(glTexStorage2D, m_textures, TextureObjectMap::callOnBoundObject);
+    MAP_OBJ(glTexStorage3D, m_textures, TextureObjectMap::callOnBoundObject);
+    MAP_OBJ(glTexImage3D, m_textures, TextureObjectMap::callOnBoundObject);
+    MAP_OBJ_RVRR(glTexSubImage1D, m_textures, TextureObjectMap::callOnBoundObjectWithDepBoundTo,
+                    m_buffers, GL_PIXEL_UNPACK_BUFFER, m_required_calls, m_recording_frame);
+    MAP_OBJ_RVRR(glTexSubImage2D, m_textures, TextureObjectMap::callOnBoundObjectWithDepBoundTo,
+                    m_buffers, GL_PIXEL_UNPACK_BUFFER, m_required_calls, m_recording_frame);
+    MAP_OBJ_RVRR(glCompressedTexSubImage2D, m_textures, TextureObjectMap::callOnBoundObjectWithDepBoundTo,
+                  m_buffers, GL_PIXEL_UNPACK_BUFFER, m_required_calls, m_recording_frame);
+    MAP_OBJ_RVRR(glTexSubImage3D, m_textures, TextureObjectMap::callOnBoundObjectWithDepBoundTo,
+                  m_buffers, GL_PIXEL_UNPACK_BUFFER, m_required_calls, m_recording_frame);
+    MAP_OBJ(glTexParameter, m_textures, TextureObjectMap::callOnBoundObject);
+    MAP_OBJ_RVV(glTextureView, m_textures, TextureObjectMap::callOnNamedObjectWithDep,
+                   m_textures, 2, true);
+
+    MAP_OBJ_RVV(glTexBuffer, m_textures, TextureObjectMap::callOnBoundObjectWithDep,
+                   m_buffers, 2, true);
+
+    /* Should add a dependency on the read fbo */
+    MAP_OBJ(glCopyTexSubImage, m_textures, TextureObjectMap::callOnBoundObject);
+
+    MAP_OBJ(glCopyTexImage2D, m_textures, TextureObjectMap::callOnBoundObject);
+
+    MAP_OBJ(glCopyImageSubData, m_textures, TextureObjectMap::copy);
+    MAP_OBJ(glBindImageTexture, m_textures, TextureObjectMap::bindToImageUnit);
+
+    /*
+    MAP_GENOBJ(glCopyTexSubImage2D, m_textures, TextureStateMap::copy_sub_data);
+    */
+    MAP_RV(glBindSampler, oglBind, m_samplers, 1);
+    MAP_OBJ(glGenSamplers, m_samplers, SamplerObjectMap::generate);
+    MAP_OBJ(glDeleteSamplers, m_samplers, SamplerObjectMap::destroy);
+    MAP_OBJ(glSamplerParameter, m_samplers, SamplerObjectMap::callOnNamedObject);
+    MAP(glBindTextures, oglBindTextures);
+
+}
+
+void FrameTrimmeImpl::registerQueryCalls()
+{
+    MAP_OBJ(glGenQueries, m_queries, QueryObjectMap::generate);
+    MAP_OBJ(glDeleteQueries, m_queries, QueryObjectMap::destroy);
+    MAP_RV(glBeginQuery, bindWithCreate, m_queries, 1);
+    MAP_OBJ(glEndQuery, m_queries, QueryObjectMap::oglEndQuery);
+    MAP_OBJ(glEndQueryIndexed, m_queries, QueryObjectMap::oglEndQueryIndexed);
+    MAP_OBJ(glGetQueryObject, m_queries, QueryObjectMap::callOnNamedObject);
+    MAP_OBJ(glGetQueryiv, m_queries, QueryObjectMap::callOnBoundObject);
+}
+
+void
+FrameTrimmeImpl::registerStateCalls()
+{
+    /* These Functions change the state and we only need to remember the last
+     * call before the target frame or an fbo creating a dependency is draw. */
+    const std::vector<const char *> state_calls  = {
+        "glAlphaFunc",
+        "glBlendColor",
+        "glBlendEquation",
+        "glBlendFunc",
+        "glClearColor",
+        "glClearDepth",
+        "glClearStencil",
+        "glColorMask",
+        "glColorPointer",
+        "glCullFace",
+        "glDepthFunc",
+        "glDepthMask",
+        "glDepthRange",
+        "glDepthBounds",
+        "glFlush",
+        "glFrontFace",
+        "glFrustum",
+        "glLineStipple",
+        "glLineWidth",
+        "glPatchParameteri",
+        "glPixelZoom",
+        "glPointSize",
+        "glPolygonMode",
+        "glPolygonOffset",
+        "glPolygonStipple",
+        "glProvokingVertex",
+        "glPrimitiveBoundingBox",
+        "glSampleCoverage",
+        "glShadeModel",
+        "glScissor",
+        "glStencilMask",
+        "glFinish",
+    };
+
+    auto state_call_func = bind(&FrameTrimmeImpl::recordStateCall, this, _1, 0);
+    auto state_call_1_func = bind(&FrameTrimmeImpl::recordStateCall, this, _1, 1);
+    auto keep_state_calls_func = bind(&FrameTrimmeImpl::recordRequiredCall, this, _1);
+
+    /* These are state functions with an extra parameter */
+
+    const std::vector<const char *> state_calls_1  = {
+        "glClipPlane",
+        "glColorMaskIndexedEXT",
+        "glColorMaterial",
+        "glFog",
+        "glHint",
+        "glLight",
+        "glPixelTransfer",
+        "glStencilOpSeparate",
+        "glStencilFuncSeparate",
+        "glVertexAttribDivisor",
+    };
+
+    /* These are state functions with an extra parameter */
+    auto state_call_2_func = bind(&FrameTrimmeImpl::recordStateCall, this, _1, 2);
+    const std::vector<const char *> state_calls_2  = {
+        "glMaterial",
+        "glTexEnv",
+    };
+
+    if (m_keep_all_state_calls) {
+        updateCallTable(state_calls, keep_state_calls_func);
+        updateCallTable(state_calls_1, keep_state_calls_func);
+        updateCallTable(state_calls_2, keep_state_calls_func);
+    } else {
+        updateCallTable(state_calls, state_call_func);
+        updateCallTable(state_calls_1, state_call_1_func);
+        updateCallTable(state_calls_2, state_call_2_func);
+    }
+
+    MAP(glDisable, recordRequiredCall);
+    MAP(glEnable, recordRequiredCall);
+    MAP(glEnablei, recordRequiredCall);
+
+    MAP_OBJ(glFenceSync, m_sync_objects, SyncObjectMap::create);
+    MAP(glWaitSync, oglWaitSync);
+    MAP(glClientWaitSync, oglWaitSync);
+    MAP_OBJ(glDeleteSync, m_sync_objects, SyncObjectMap::callOnNamedObject);
+}
+
+void FrameTrimmeImpl::registerRequiredCalls()
+{
+    /* These function set up the context and are, therefore, required
+     * TODO: figure out what is really required, and whether the can be
+     * tracked like state variables. */
+    auto required_func = bind(&FrameTrimmeImpl::recordRequiredCall, this, _1);
+    const std::vector<const char *> required_calls = {
+        "glXChooseVisual",
+        "glXCreateContext",
+        "glXDestroyContext",
+        "glXMakeCurrent",
+        "glXMakeContextCurrent",
+        "glXChooseFBConfig",
+        "glXQueryExtensionsString",
+        "glXSwapIntervalMESA",
+
+        "eglInitialize",
+        "eglCreatePlatformWindowSurface",
+        "eglBindAPI",
+        "eglCreateContext",
+        "eglMakeCurrent",
+
+        "glPixelStorei", /* Being lazy here, we could track the dependency
+                            in the relevant calls */
+    };
+    updateCallTable(required_calls, required_func);
+}
+
+void FrameTrimmeImpl::registerIgnoreHistoryCalls()
+{
+    /* These functions are ignored outside required recordings
+     * TODO: ignore them also in the copied frames */
+    const std::vector<const char *> ignore_history_calls = {
+        "glCheckFramebufferStatus",
+        "glGetActiveUniform",
+        "glGetBoolean",
+        "glGetError",
+        "glGetFloat",
+        "glGetFramebufferAttachmentParameter",
+        "glGetInfoLog",
+        "glGetInteger",
+        "glGetObjectLabelEXT",
+        "glGetObjectParameter",
+        "glGetProgram",
+        "glGetShader",
+        "glGetString",
+        "glGetTexLevelParameter",
+        "glGetTexParameter",
+        "glGetTexImage",
+        "glGetUniform",
+        "glLabelObjectEXT",
+        "glIsEnabled",
+        "glIsVertexArray",
+        "glReadPixels",
+        "glXGetClientString",
+        "glXGetCurrentContext",
+        "glXGetCurrentDisplay",
+        "glXGetCurrentDrawable",
+        "glXGetFBConfigAttrib",
+        "glXGetFBConfigs",
+        "glXGetProcAddress",
+        "glXGetSwapIntervalMESA",
+        "glXGetVisualFromFBConfig",
+        "glXQueryVersion",
+        "eglGetProcAddress",
+        "eglQueryString",
+        "eglGetError",
+        "eglGetPlatformDisplay",
+        "eglGetConfigs",
+        "eglGetConfigAttrib",
+        "eglQuerySurface",
+     };
+    auto ignore_history_func = bind(&FrameTrimmeImpl::ignoreHistory, this, _1);
+    updateCallTable(ignore_history_calls, ignore_history_func);
+}
+
+
+void
+FrameTrimmeImpl::registerVaCalls()
+{
+    MAP_OBJ(glGenVertexArrays, m_vertex_arrays, VertexArrayMap::generate);
+    MAP_OBJ(glDeleteVertexArrays, m_vertex_arrays, VertexArrayMap::destroy);
+    MAP_RV(glBindVertexArray, oglBind, m_vertex_arrays, 0);
+
+    MAP(glDisableVertexAttribArray, recordRequiredCall);
+    MAP(glEnableVertexAttribArray, recordRequiredCall);
+    MAP_OBJ_RRR(glVertexAttribPointer, m_vertex_attrib_pointers,
+                   VertexAttribObjectMap::bindAVO, m_buffers,
+                   m_required_calls, m_recording_frame);
+
+    MAP_OBJ_RRR(glBindVertexBuffer, m_vertex_buffer_pointers,
+                   VertexAttribObjectMap::bindVAOBuf, m_buffers,
+                   m_required_calls, m_recording_frame);
+
+    MAP(glVertexPointer, recordRequiredCall);
+    MAP(glTexCoordPointer, recordRequiredCall);
+    MAP(glVertexAttrib1, recordRequiredCall);
+    MAP(glVertexAttrib2, recordRequiredCall);
+    MAP(glVertexAttrib3, recordRequiredCall);
+    MAP(glVertexAttrib4, recordRequiredCall);
+    MAP(glVertexAttribI, recordRequiredCall);
+    MAP(glVertexAttribL, recordRequiredCall);
+    MAP(glVertexAttribP1, recordRequiredCall);
+    MAP(glVertexAttribP2, recordRequiredCall);
+    MAP(glVertexAttribP3, recordRequiredCall);
+    MAP(glVertexAttribP4, recordRequiredCall);
+    MAP(glTexGen, recordRequiredCall);
+
+    MAP(glDisableClientState, recordRequiredCall);
+    MAP(glEnableClientState, recordRequiredCall);
+
+}
+
+void
+FrameTrimmeImpl::updateCallTable(const std::vector<const char*>& names,
+                                        ft_callback cb)
+{
+    for (auto& i : names)
+        m_call_table.insert(std::make_pair(i, cb));
+}
+
+PTraceCall
+FrameTrimmeImpl::recordStateCall(const trace::Call& call,
+                                   unsigned no_param_sel)
+{
+    std::stringstream s;
+    s << call.name();
+    for (unsigned i = 0; i < no_param_sel; ++i)
+        s << "_" << call.arg(i).toUInt();
+
+    auto c = std::make_shared<TraceCall>(call, s.str());
+    m_state_calls[s.str()] = c;
+
+    if (m_active_display_list)
+        m_active_display_list->addCall(c);
+
+    return c;
+}
+
+void
+FrameTrimmeImpl::oglBegin(const trace::Call& call)
+{
+    if (m_active_display_list)
+        m_active_display_list->addCall(trace2call(call));
+}
+
+void
+FrameTrimmeImpl::oglEnd(const trace::Call& call)
+{
+    if (m_active_display_list)
+        m_active_display_list->addCall(trace2call(call));
+}
+
+void
+FrameTrimmeImpl::oglVertex(const trace::Call& call)
+{
+    if (m_active_display_list)
+        m_active_display_list->addCall(trace2call(call));
+}
+
+void
+FrameTrimmeImpl::oglEndList(const trace::Call& call)
+{
+    if (!m_recording_frame)
+        m_active_display_list->addCall(trace2call(call));
+
+    m_active_display_list = nullptr;
+}
+
+void
+FrameTrimmeImpl::oglGenLists(const trace::Call& call)
+{
+    unsigned nlists = call.arg(0).toUInt();
+    GLuint origResult = (*call.ret).toUInt();
+    for (unsigned i = 0; i < nlists; ++i)
+        m_display_lists[i + origResult] = std::make_shared<UsedObject>(i + origResult);
+
+    auto c = trace2call(call);
+    if (!m_recording_frame)
+        m_display_lists[origResult]->addCall(c);
+}
+
+void
+FrameTrimmeImpl::oglNewList(const trace::Call& call)
+{
+    assert(!m_active_display_list);
+    auto list  = m_display_lists.find(call.arg(0).toUInt());
+    assert(list != m_display_lists.end());
+    m_active_display_list = list->second;
+
+    if (!m_recording_frame)
+        m_active_display_list->addCall(trace2call(call));
+}
+
+void
+FrameTrimmeImpl::oglCallList(const trace::Call& call)
+{
+    auto list  = m_display_lists.find(call.arg(0).toUInt());
+    assert(list != m_display_lists.end());
+
+    if (m_recording_frame)
+        list->second->emitCallsTo(m_required_calls);
+}
+
+void
+FrameTrimmeImpl::oglDeleteLists(const trace::Call& call)
+{
+    GLint value = call.arg(0).toUInt();
+    GLint value_end = call.arg(1).toUInt() + value;
+    for(int i = value; i < value_end; ++i) {
+        auto list  = m_display_lists.find(call.arg(0).toUInt());
+        assert(list != m_display_lists.end());
+        list->second->addCall(trace2call(call));
+        m_display_lists.erase(list);
+    }
+}
+
+void
+FrameTrimmeImpl::oglBind(const trace::Call& call, DependecyObjectMap& map,
+                      unsigned bind_param)
+{
+    auto bound_obj = map.bind(call, bind_param);
+    if (bound_obj)
+        bound_obj->addCall(trace2call(call));
+    else
+        map.addCall(trace2call(call));
+
+    if (m_recording_frame && bound_obj)
+        bound_obj->emitCallsTo(m_required_calls);
+}
+
+void
+FrameTrimmeImpl::oglBindTextures(const trace::Call& call)
+{
+    unsigned first = call.arg(0).toUInt();
+    unsigned count  = call.arg(1).toUInt();
+
+    const auto ids = (call.arg(2)).toArray();
+    if (ids) {
+        for (unsigned i = 0; i < count; ++i) {
+            auto v = ids->values[i];
+            unsigned id = v->toUInt();
+            if (id) {
+                auto obj = m_textures.getById(id);
+                obj->addCall(trace2call(call));
+                m_textures.bindFromTextureTarget(first + i, obj);
+                if (m_recording_frame)
+                    obj->emitCallsTo(m_required_calls);
+            } else {
+                m_textures.unbindUnits(first + i, 1);
+            }
+        }
+        /* Make all bound textures depend on one-another
+         * so that if this call is issued, then all used
+         * textures are available */
+        for (unsigned i = 0; i < count; ++i) {
+            unsigned id = ids->values[i]->toUInt();
+            if (id) {
+                auto obj = m_textures.getById(id);
+                for (unsigned j = i + 1; j < count; ++j) {
+                    unsigned id2 = ids->values[j]->toUInt();
+                    if (id2) {
+                        auto dep = m_textures.getById(id2);
+                        obj->addDependency(dep);
+                        dep->addDependency(obj);
+                    }
+                }
+            }
+        }
+
+    } else {
+        m_textures.unbindUnits(first, count);
+        m_textures.addCall(trace2call(call));
+    }
+}
+
+void FrameTrimmeImpl::oglDraw(const trace::Call& call)
+{
+    auto fb = m_fbo.boundTo(GL_DRAW_FRAMEBUFFER);
+    auto cur_prog = m_programs.boundTo(0, 0);
+    if (cur_prog) {
+        for(auto && [key, buf]: m_buffers) {
+            if (buf && ((key % BufferObjectMap::bt_last) == BufferObjectMap::bt_uniform))
+                cur_prog->addDependency(buf);
+        }
+        m_buffers.addSSBODependencies(cur_prog);
+        m_textures.addImageDependencies(cur_prog);
+
+        if (fb->id())
+            fb->addDependency(cur_prog);
+
+        if (m_recording_frame)
+            cur_prog->emitCallsTo(m_required_calls);
+    }
+
+    auto buf = m_buffers.boundToTarget(GL_ELEMENT_ARRAY_BUFFER);
+
+    if (fb->id()) {
+        fb->addCall(trace2call(call));
+
+        if (buf)
+           fb->addDependency(buf);
+
+        for(auto&& [key, vbo]: m_vertex_attrib_pointers) {
+            if (vbo)
+                fb->addDependency(vbo);
+
+        }
+        for(auto&& [key, vbo]: m_vertex_buffer_pointers) {
+            if (vbo)
+                fb->addDependency(vbo);
+        }
+    }
+
+    if (m_recording_frame) {
+        for(auto&& [key, vbo]: m_vertex_attrib_pointers) {
+            if (vbo)
+                vbo->emitCallsTo(m_required_calls);
+
+        }
+        for(auto&& [key, vbo]: m_vertex_buffer_pointers) {
+            if (vbo)
+                vbo->emitCallsTo(m_required_calls);
+        }
+        if (buf)
+            buf->emitCallsTo(m_required_calls);
+    }
+}
+
+void
+FrameTrimmeImpl::bindWithCreate(const trace::Call& call, DependecyObjectMap& map,
+                                unsigned bind_param)
+{
+    auto bound_obj = map.bindWithCreate(call, bind_param);
+    if (bound_obj)
+        bound_obj->addCall(trace2call(call));
+    else
+        map.addCall(trace2call(call));
+    if (m_recording_frame && bound_obj)
+        bound_obj->emitCallsTo(m_required_calls);
+}
+
+void FrameTrimmeImpl::oglBindMultitex(const trace::Call& call)
+{
+    auto tex = m_textures.oglBindMultitex(call);
+    if (tex)
+        tex->addCall(trace2call(call));
+    else
+        m_textures.addCall(trace2call(call));
+
+    if (m_recording_frame && tex)
+        tex->emitCallsTo(m_required_calls);
+}
+
+void
+FrameTrimmeImpl::oglWaitSync(const trace::Call& call)
+{
+    auto obj = m_sync_objects.getById(call.arg(0).toUInt());
+    assert(obj);
+    obj->addCall(trace2call(call));
+    if (m_recording_frame)
+        obj->emitCallsTo(m_required_calls);
+}
+
+void
+FrameTrimmeImpl::oglBindFbo(const trace::Call& call, DependecyObjectMap& map,
+                         unsigned bind_param)
+{
+    auto bound_obj = map.bind(call, bind_param);
+    bound_obj->addCall(trace2call(call));
+    if (m_recording_frame && bound_obj->id())
+        bound_obj->emitCallsTo(m_required_calls);
+}
+
+void
+FrameTrimmeImpl::callOnBoundObjWithDep(const trace::Call& call, DependecyObjectMap& map,
+                                        unsigned obj_id_param,
+                                        DependecyObjectMap& dep_map, bool reverse_dep_too)
+{
+    auto dep_obj = map.callOnBoundObjectWithDep(call, dep_map, obj_id_param,
+                                                reverse_dep_too);
+    if (m_recording_frame && dep_obj)
+        dep_obj->emitCallsTo(m_required_calls);
+}
+
+void FrameTrimmeImpl::oglDispatchCompute(const trace::Call& call)
+{
+    auto cur_prog = m_programs.boundTo(0);
+    assert(cur_prog);
+
+    cur_prog->addCall(trace2call(call));
+    // Without knowning how the compute program is actually written
+    // we have to assume that any bound ssbo and any bound image can be
+    // changed by the program, so the program has to depend on all bound
+    // ssbos and images, ane they in turn must depend on the program
+
+    m_buffers.addSSBODependencies(cur_prog);
+    m_textures.addImageDependencies(cur_prog);
+
+    if (m_recording_frame)
+        cur_prog->emitCallsTo(m_required_calls);
+}
+
+void
+FrameTrimmeImpl::todo(const trace::Call& call)
+{
+    std::cerr << "TODO: " << call.name() << "\n";
+}
+
+void
+FrameTrimmeImpl::ignoreHistory(const trace::Call& call)
+{
+    (void)call;
+}
+
+void
+FrameTrimmeImpl::recordRequiredCall(const trace::Call& call)
+{
+    auto c = trace2call(call);
+    m_required_calls.insert(c);
+}
+
+}

--- a/frametrim/ft_frametrimmer.hpp
+++ b/frametrim/ft_frametrimmer.hpp
@@ -1,0 +1,58 @@
+/*********************************************************************
+ *
+ * Copyright 2020 Collabora Ltd
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *********************************************************************/
+
+#pragma once
+
+#include "trace_parser.hpp"
+
+#include <vector>
+
+namespace frametrim {
+
+enum Frametype {
+    ft_none = 0,
+    ft_key_frame = 1,
+    ft_retain_frame = 2
+};
+
+class FrameTrimmer
+{
+public:
+    FrameTrimmer(bool keep_all_states);
+    ~FrameTrimmer();
+
+    void call(const trace::Call& call, Frametype target_frame_type);
+
+    void finalize();
+
+    std::vector<unsigned> getSortedCallIds();
+private:
+    struct FrameTrimmeImpl *impl;
+
+};
+
+}

--- a/frametrim/ft_main.cpp
+++ b/frametrim/ft_main.cpp
@@ -1,0 +1,279 @@
+/*********************************************************************
+ *
+ * Copyright 2020 Collabora Ltd
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *********************************************************************/
+
+#include "ft_frametrimmer.hpp"
+
+#include "os_time.hpp"
+#include "trace_parser.hpp"
+#include "retrace.hpp"
+#include "retrace_swizzle.hpp"
+
+#include "trace_callset.hpp"
+#include "trace_parser.hpp"
+#include "trace_writer.hpp"
+
+#include <limits.h> // for CHAR_MAX
+#include <getopt.h>
+#include <memory>
+#include <queue>
+
+using namespace frametrim;
+
+struct trim_options {
+    /* Frames to be included in trace. */
+    trace::CallSet setupframes;
+
+    /* Frames to keep replayable */
+    trace::CallSet frames;
+
+    unsigned top_frame_call_counts;
+    bool keep_all_states;
+
+    /* Output filename */
+    std::string output;
+};
+
+static const char *synopsis = "Create a new, retracable trace containing only the specified frames.";
+
+static void
+usage(void)
+{
+    std::cout
+            << "usage: frametrim [OPTIONS] TRACE_FILE...\n"
+            << synopsis << "\n"
+                           "\n"
+                           "    -h, --help               Show detailed help for trim options and exit\n"
+                           "    -f, --frames=FRAME       Frame the trace should be reduced to.\n"
+                           "    -s, --setupframes=FRAME  Frame that are kept in the trace but but without the end-of-frame command.\n"
+                           "    -t, --top-calls-per-frame=NUMBER Print NUMBER of frames with the top amount of OpenGL calls\n"
+                           "    -k, --keep-all-states    Keep all state calls in the trace (This may help with textures that are created by using FBO\n"
+                           "    -o, --output=TRACE_FILE  Output trace file\n"
+               ;
+}
+
+enum {
+    FRAMES_OPT = 'f',
+    SETUPFRAMES_OPT = 's'
+};
+
+const static char *
+shortOptions = "t:hko:f:s:x";
+
+bool operator < (std::pair<unsigned, unsigned>& lhs, std::pair<unsigned, unsigned>& rhs)
+{
+    return lhs.first < rhs.first;
+}
+
+const static struct option
+longOptions[] = {
+    {"help", no_argument, 0, 'h'},
+    {"top-calls-per-frame", required_argument, 0, 't'},
+    {"frames", required_argument, 0, 'f'},
+    {"setupframes", required_argument, 0, 's'},
+    {"keep-all-states", no_argument, 0, 'k'},
+    {"output", required_argument, 0, 'o'},
+    {0, 0, 0, 0}
+};
+
+static int trim_to_frame(const char *filename,
+                         const struct trim_options& options)
+{
+
+    trace::Parser p;
+    unsigned frame;
+
+    if (!p.open(filename)) {
+        std::cerr << "error: failed to open " << filename << "\n";
+        return 1;
+    }
+
+    if (options.frames.getLast() < options.setupframes.getLast() &&
+        !options.setupframes.empty()) {
+        std::cerr << "error: last frame to keep ("
+                  << options.frames.getLast()
+                  << ") must be larger than last key frame"
+                  << options.setupframes.getLast() << "\n";
+        return 1;
+    }
+
+    auto out_filename = options.output;
+
+    /* Prepare output file and writer for output. */
+    if (options.output.empty()) {
+        os::String base(filename);
+        base.trimExtension();
+
+        out_filename = std::string(base.str()) + std::string("-trim.trace");
+    }
+
+    FrameTrimmer trimmer(options.keep_all_states);
+
+    frame = 0;
+    uint64_t callid = 0;
+    std::unique_ptr<trace::Call> call(p.parse_call());
+    std::priority_queue<std::pair<unsigned, unsigned>> calls_in_frame;
+
+    unsigned ncalls = 0;
+    unsigned ncalls2 = 0;
+
+    unsigned calls_in_this_frame = 0;
+    while (call) {
+        /* There's no use doing any work past the last call and frame
+        * requested by the user. */
+        if (frame > options.frames.getLast()) {
+            break;
+        }
+
+        Frametype ft = ft_none;
+        if (options.setupframes.contains(frame, call->flags))
+            ft = ft_key_frame;
+        if (options.frames.contains(frame, call->flags))
+            ft = ft_retain_frame;
+
+        trimmer.call(*call, ft);
+
+        if (call->flags & trace::CALL_FLAG_END_FRAME) {
+            if (options.top_frame_call_counts > 0) {
+                ncalls += calls_in_this_frame;
+                ncalls2 += calls_in_this_frame * calls_in_this_frame;
+                calls_in_frame.push(std::make_pair(calls_in_this_frame, frame));
+            }
+            calls_in_this_frame = 0;
+            frame++;
+        }
+
+        callid++;
+        if (!(callid & 0xff))
+            std::cerr << "\rScanning frame:" << frame
+                      << " type:" << ft
+                      << " call:" << call->no;
+
+        call.reset(p.parse_call());
+        ++calls_in_this_frame;
+    }
+    trimmer.finalize();
+    std::cerr << "\nDone scanning frames\n";
+
+    trace::Writer writer;
+    if (!writer.open(out_filename.c_str(), p.getVersion(), p.getProperties())) {
+        std::cerr << "error: failed to create " << out_filename << "\n";
+        return 2;
+    }
+
+    auto call_ids = trimmer.getSortedCallIds();
+    std::cerr << "Write output file\n";
+
+    p.close();
+    p.open(filename);
+    call.reset(p.parse_call());
+
+    auto callid_itr = call_ids.begin();
+
+    std::cerr << "Copying " << call_ids.size() << " calls\n";
+
+    while (call && callid_itr != call_ids.end()) {
+        while (call->no != *callid_itr)
+            call.reset(p.parse_call());
+
+        writer.writeCall(call.get());
+        call.reset(p.parse_call());
+        ++callid_itr;
+    }
+
+    if (options.top_frame_call_counts) {
+        unsigned count = options.top_frame_call_counts;
+        std::cerr << "Calls per frame:\n";
+        while (count-- && !calls_in_frame.empty()) {
+            auto fc = calls_in_frame.top();
+            calls_in_frame.pop();
+            std::cerr << "  Frame[" << fc.second << "] = " << fc.first << "\n";
+        }
+    }
+
+    return 0;
+}
+
+
+int main(int argc, char **argv)
+{
+    struct trim_options options;
+    options.frames = trace::CallSet(trace::FREQUENCY_NONE);
+    options.top_frame_call_counts = false;
+    options.keep_all_states = false;
+
+    int opt;
+    while ((opt = getopt_long(argc, argv, shortOptions, longOptions, nullptr)) != -1) {
+        switch (opt) {
+        case 'h':
+            usage();
+            return 0;
+        case FRAMES_OPT:
+            options.frames.merge(optarg);
+            break;
+        case SETUPFRAMES_OPT:
+            options.setupframes.merge(optarg);
+            break;
+        case 'o':
+            options.output = optarg;
+            break;
+        case 't':
+            options.top_frame_call_counts = atoi(optarg);
+            break;
+        case 'k':
+            options.keep_all_states = true;
+            break;
+        default:
+            std::cerr << "error: unexpected option `" << (char)opt << "`\n";
+            usage();
+            return 1;
+        }
+    }
+
+    if (optind >= argc) {
+        std::cerr << "error: apitrace trim requires a trace file as an argument.\n";
+        usage();
+        return 1;
+    }
+
+    if (argc > optind + 1) {
+        std::cerr << "error: extraneous arguments:";
+        for (int i = optind + 1; i < argc; i++) {
+            std::cerr << " " << argv[i];
+        }
+        std::cerr << "\n";
+        usage();
+        return 1;
+    }
+
+    std::cerr << "gltrim may not retain all information required to recreate\n"
+              << "the target frame(s) as expected, it is advised to check the\n"
+              << "results and add setup frames and additional states if needed.\n"
+                 "For further details see frametrim/frametrim.markdown in the "
+                 "source code.\n";
+
+    return trim_to_frame(argv[optind], options);
+}

--- a/frametrim/ft_matrixstate.cpp
+++ b/frametrim/ft_matrixstate.cpp
@@ -1,0 +1,153 @@
+/*********************************************************************
+ *
+ * Copyright 2020 Collabora Ltd
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *********************************************************************/
+
+#include "ft_matrixstate.hpp"
+
+#include <cstring>
+#include <GL/gl.h>
+
+using std::make_shared;
+
+namespace frametrim {
+
+MatrixState::MatrixState(MatrixState::Pointer parent):
+    UsedObject(0),
+    m_parent(parent)
+{
+
+}
+
+void
+MatrixState::selectMatrixType(const trace::Call& call)
+{
+    m_type_select_call = trace2call(call);
+}
+
+void
+MatrixState::setMatrix(const trace::Call &call)
+{
+    assert(!strcmp(call.name(), "glLoadIdentity") ||
+           !strncmp(call.name(), "glLoadMatrix", 12));
+
+    /* Remember matrix type when doing
+     * glMatrixMode
+     * glPushMatrix
+     * glLoad*
+     */
+    if (!m_type_select_call && m_parent)
+        m_type_select_call = m_parent->m_type_select_call;
+
+    m_parent = nullptr;
+    setCall(trace2call(call));
+    if (m_type_select_call)
+        addCall(m_type_select_call);
+}
+
+AllMatrisStates::AllMatrisStates()
+{
+    m_mv_matrix.push(make_shared<MatrixState>(nullptr));
+    m_current_matrix = m_mv_matrix.top();
+    m_current_matrix_stack = &m_mv_matrix;
+}
+
+void AllMatrisStates::emitStateTo(CallSet& list) const
+{
+    if (!m_mv_matrix.empty())
+        m_mv_matrix.top()->emitCallsTo(list);
+
+    if (!m_proj_matrix.empty())
+        m_proj_matrix.top()->emitCallsTo(list);
+
+    if (!m_texture_matrix.empty())
+        m_texture_matrix.top()->emitCallsTo(list);
+
+    if (!m_color_matrix.empty())
+        m_color_matrix.top()->emitCallsTo(list);
+}
+
+void
+AllMatrisStates::loadIdentity(const trace::Call& call)
+{
+    return m_current_matrix->setMatrix(call);
+}
+
+void
+AllMatrisStates::loadMatrix(const trace::Call& call)
+{
+    return m_current_matrix->setMatrix(call);
+}
+
+void
+AllMatrisStates::matrixMode(const trace::Call& call)
+{
+    switch (call.arg(0).toUInt()) {
+    case GL_MODELVIEW:
+        m_current_matrix_stack = &m_mv_matrix;
+        break;
+    case GL_PROJECTION:
+        m_current_matrix_stack = &m_proj_matrix;
+        break;
+    case GL_TEXTURE:
+        m_current_matrix_stack = &m_texture_matrix;
+        break;
+    case GL_COLOR:
+        m_current_matrix_stack = &m_color_matrix;
+        break;
+    default:
+        assert(0 && "Unknown matrix mode");
+    }
+
+    if (m_current_matrix_stack->empty())
+        m_current_matrix_stack->push(make_shared<MatrixState>(nullptr));
+
+    m_current_matrix = m_current_matrix_stack->top();
+    m_current_matrix->selectMatrixType(call);
+}
+
+void
+AllMatrisStates::popMatrix(const trace::Call& call)
+{
+    m_current_matrix->addCall(trace2call(call));
+    m_current_matrix_stack->pop();
+    assert(!m_current_matrix_stack->empty());
+    m_current_matrix = m_current_matrix_stack->top();
+}
+
+void
+AllMatrisStates::pushMatrix(const trace::Call& call)
+{
+    m_current_matrix = make_shared<MatrixState>(m_current_matrix);
+    m_current_matrix_stack->push(m_current_matrix);
+    m_current_matrix->addCall(trace2call(call));
+}
+
+void AllMatrisStates::matrixOp(const trace::Call& call)
+{
+    m_current_matrix->addCall(trace2call(call));
+}
+
+}

--- a/frametrim/ft_matrixstate.hpp
+++ b/frametrim/ft_matrixstate.hpp
@@ -1,0 +1,75 @@
+/*********************************************************************
+ *
+ * Copyright 2020 Collabora Ltd
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *********************************************************************/
+
+#pragma once
+
+#include "ft_dependecyobject.hpp"
+#include <stack>
+
+namespace frametrim {
+
+class MatrixState : public UsedObject
+{
+public:
+    using Pointer = std::shared_ptr<MatrixState>;
+
+    MatrixState(Pointer parent);
+
+    void selectMatrixType(const trace::Call& call);
+    void setMatrix(const trace::Call& call);
+
+private:
+    Pointer m_parent;
+    PTraceCall m_type_select_call;
+};
+
+using PMatrixState = std::shared_ptr<MatrixState>;
+
+class AllMatrisStates {
+public:
+
+    AllMatrisStates();
+
+    void loadIdentity(const trace::Call& call);
+    void loadMatrix(const trace::Call& call);
+    void matrixMode(const trace::Call& call);
+    void popMatrix(const trace::Call& call);
+    void pushMatrix(const trace::Call& call);
+    void matrixOp(const trace::Call& call);
+    void emitStateTo(CallSet& list) const;
+
+private:
+    std::stack<PMatrixState> m_mv_matrix;
+    std::stack<PMatrixState> m_proj_matrix;
+    std::stack<PMatrixState> m_texture_matrix;
+    std::stack<PMatrixState> m_color_matrix;
+
+    PMatrixState m_current_matrix;
+    std::stack<PMatrixState> *m_current_matrix_stack;
+};
+
+}

--- a/frametrim/ft_tracecall.cpp
+++ b/frametrim/ft_tracecall.cpp
@@ -1,0 +1,139 @@
+/*********************************************************************
+ *
+ * Copyright 2020 Collabora Ltd
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *********************************************************************/
+
+#include "ft_tracecall.hpp"
+
+#include <sstream>
+#include <iostream>
+
+
+namespace trace {
+
+class StreamVisitor : public Visitor
+{
+public:
+    StreamVisitor(std::stringstream& ss): s(ss) {}
+    void visit(Null *) override { s << "(null)";}
+    void visit(Bool *v) override { s << v->value;}
+    void visit(SInt *v) override { s << v->value;}
+    void visit(UInt *v) override { s << v->value;}
+    void visit(Float *v) override { s << v->value;}
+    void visit(Double *v) override { s << v->value;}
+    void visit(String *v) override { s << v->value;}
+    void visit(WString *v) override { s << v->value;}
+    void visit(Enum *v) override { s << v->value;}
+    void visit(Bitmask *v) override { s << v->value;}
+    void visit(Struct *v) override { s << v;}
+    void visit(Array *v) override { s << v;}
+    void visit(Blob *v) override { s << v;}
+    void visit(Pointer *v) override { s << v->value;}
+    void visit(Repr *v) override { s << v;}
+protected:
+    inline void _visit(Value *value) {
+        if (value) {
+            value->visit(*this);
+        }
+    }
+    std::stringstream& s;
+};
+
+}
+
+namespace frametrim {
+
+TraceCall::TraceCall(const trace::Call& call, const std::string& name):
+    m_trace_call_no(call.no),
+    m_name(name)
+{
+    std::stringstream s;
+    s << call.name();
+
+    trace::StreamVisitor sv(s);
+    for(auto&& a: call.args) {
+        s << "_";  a.value->visit(sv);
+    }
+
+    m_name_with_params = s.str();
+}
+
+TraceCall::TraceCall(const trace::Call& call, unsigned nsel):
+    TraceCall(call, nameWithParamsel(call, nsel))
+{
+
+}
+
+TraceCall::TraceCall(const trace::Call& call):
+    TraceCall(call, call.name())
+{
+}
+
+std::string
+TraceCall::nameWithParamsel(const trace::Call &call, unsigned nsel)
+{
+    std::stringstream s;
+    s << call.name();
+
+    trace::StreamVisitor sv(s);
+    for(unsigned i = 0; i < nsel; ++i ) {
+        s << "_";
+        call.args[i].value->visit(sv);
+    }
+    return s.str();
+}
+
+void CallSet::insert(PTraceCall call)
+{
+    if (!call)
+        return;
+    m_calls.insert(call);
+}
+
+void CallSet::clear()
+{
+    m_calls.clear();
+}
+
+bool CallSet::empty() const
+{
+    return m_calls.empty();
+}
+
+CallSet::const_iterator
+CallSet::begin() const
+{
+    return m_calls.begin();
+}
+
+CallSet::const_iterator
+CallSet::end() const
+{
+    return m_calls.end();
+}
+
+
+
+}

--- a/frametrim/ft_tracecall.hpp
+++ b/frametrim/ft_tracecall.hpp
@@ -1,0 +1,101 @@
+/*********************************************************************
+ *
+ * Copyright 2020 Collabora Ltd
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *********************************************************************/
+
+#pragma once
+
+#include "trace_model.hpp"
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <iostream>
+#include <bitset>
+
+namespace frametrim {
+
+enum ECallFlags {
+    tc_required,
+    tc_persistent_mapping,
+    tc_skip_record_in_fbo,
+    tc_last
+};
+
+class CallSet;
+
+class TraceCall {
+public:
+    using Pointer = std::shared_ptr<TraceCall>;
+
+    TraceCall(const trace::Call& call, const std::string& name);
+
+    TraceCall(const trace::Call& call, unsigned nparam_sel);
+
+    TraceCall(const trace::Call& call);
+
+    unsigned callNo() const { return m_trace_call_no;};
+    const std::string& name() const { return m_name;}
+    const std::string& nameWithParams() const { return m_name_with_params;}
+private:
+
+    static std::string nameWithParamsel(const trace::Call& call, unsigned nsel);
+
+    unsigned m_trace_call_no;
+    std::string m_name;
+    std::string m_name_with_params;
+};
+using PTraceCall = TraceCall::Pointer;
+
+using StateCallMap=std::unordered_map<std::string, PTraceCall>;
+
+inline PTraceCall trace2call(const trace::Call& call) {
+    return std::make_shared<TraceCall>(call);
+}
+
+struct CallHash {
+    std::size_t operator () (const PTraceCall& call) const {
+        return std::hash<unsigned>{}(call->callNo());
+    }
+};
+
+class CallSet {
+public:
+    using Pointer = std::shared_ptr<CallSet>;
+
+    using const_iterator = std::unordered_set<PTraceCall, CallHash>::const_iterator;
+
+    void insert(PTraceCall call);
+    void clear();
+    bool empty() const;
+    size_t size() const {return m_calls.size(); }
+    const_iterator begin() const;
+    const_iterator end() const;
+private:
+    std::unordered_set<PTraceCall, CallHash> m_calls;
+};
+using PCallSet = std::shared_ptr<CallSet>;
+
+}

--- a/lib/trace/trace_model.hpp
+++ b/lib/trace/trace_model.hpp
@@ -586,6 +586,12 @@ public:
         return *(args[index].value);
     }
 
+    inline const Value &
+    arg(unsigned index) const {
+        assert(index < args.size());
+        return *(args[index].value);
+    }
+
     Value &
     argByName(const char *argName);
 };


### PR DESCRIPTION
This PR adds support for a new trimming tools *gltrim* that trims OpenGL/GLES traces to a given series of frames. Other then the *trim* command already available, this tools aims at keeping the trimmed trace replayable. The resulting trace consists of one setup frame that contains all calls required to properly replay the frames of interest. 

The tool does not aim to be a solution that works fully automated on all traces, for this OpenGL offers just too many possibilities to let textures and buffers depend on each other. For that it is possible to specifying additional frames that are considered to belong to the setup who's calls are added to the output setup frame (without the frame-end call). Additionally one can force that all simple state calls are kept in the trace. 

The tool has been tested on traces of various games, amongst them *Portal 2*, *Stellaris*, *Alien Isolation*, *Civilization V*, *Unturned*, and *Soma*.  Here for the used traces *Portal 2* and *Stellaris* could be trimmed to a single replayable frame without any problem. For *Alien Isolation* it was required to keep all state changes, *Unturned* needed one additional setup frame, and both  *Civilization V*, and *Soma* required to keep additional frames directly before the target frame because they build output over various frames. 

The pull request is considered to be a draft because not all OpenGL functions are supported yet.  
