### PR TITLE
glstate: Fix out-of-bounds memset of image

### DIFF
--- a/lib/image/image.hpp
+++ b/lib/image/image.hpp
@@ -76,6 +76,10 @@ public:
         delete [] pixels;
     }
 
+    inline unsigned sizeInBytes() const {
+        return width * height * bytesPerPixel;
+    }
+
     // Absolute stride
     inline unsigned
     _stride() const {

--- a/retrace/glstate_images.cpp
+++ b/retrace/glstate_images.cpp
@@ -771,7 +771,7 @@ dumpActiveTextureLevel(StateWriter &writer, Context &context,
         if (retrace::resolveMSAA){
             // For resolved MSAA...
             image = new image::Image(desc.width, desc.height, channels, true, channelType);
-            memset(image->pixels, 0x0, desc.width * desc.height * sizeof(int));
+            memset(image->pixels, 0x0, image->sizeInBytes());
             getTexImageMSAA(target, format, type, desc, image->pixels, true);
         }
         else {
@@ -779,7 +779,7 @@ dumpActiveTextureLevel(StateWriter &writer, Context &context,
             GLuint samples = std::max(desc.samples, 1);
             GLuint total_height = desc.height * samples;
             image = new image::Image(desc.width, total_height, channels, true, channelType);
-            memset(image->pixels, 0x0, desc.width * total_height * sizeof(int));
+            memset(image->pixels, 0x0, image->sizeInBytes());
             getTexImageMSAA(target, format, type, desc, image->pixels, false);
         }
     }


### PR DESCRIPTION
E.g. the crash could be reproduced with this trace: [gl-3.2-layered-rendering-gl-layer-render.trace.zip](https://github.com/apitrace/apitrace/files/5642748/gl-3.2-layered-rendering-gl-layer-render.trace.zip)

