### PR TITLE
retrace: Fix GPU Duration

### DIFF
--- a/retrace/metric_backend_opengl.cpp
+++ b/retrace/metric_backend_opengl.cpp
@@ -320,6 +320,10 @@ void MetricBackend_opengl::processQueries() {
             }
             if (metrics[METRIC_GPU_DURATION].profiled[i]) {
                 if (supportsTimestamp) {
+                    if (!metrics[METRIC_GPU_START].profiled[i]) {
+                        glGetQueryObjecti64v(query[QUERY_GPU_START], GL_QUERY_RESULT,
+                                             &gpuStart);
+                    }
                     glGetQueryObjecti64v(query[QUERY_GPU_DURATION], GL_QUERY_RESULT,
                                          &gpuEnd);
                     gpuEnd -= gpuStart;


### PR DESCRIPTION
By running `eglretrace --pframes "opengl: GPU Duration" test.trace`, we would see a column with GPU time for each frame of the trace, but the actual value is incorrect.

That is because GPU duration relies on GPU start. If that is not enabled with "opengl: GPU Start", we end up using a uninitialized value, resulting in undefined behavior.

With this commit, we make sure GPU start is valid before calculating GPU duration.