### PR TITLE
retrace: take end of frame shapshots always from back buffer

### DIFF
--- a/retrace/d3dretrace.hpp
+++ b/retrace/d3dretrace.hpp
@@ -56,7 +56,7 @@ public:
     }
 
     image::Image *
-    getSnapshot(int n) {
+    getSnapshot(int n, bool backBuffer) {
         if ((n != 0) || !pLastDevice) {
             return NULL;
         }

--- a/retrace/glretrace_main.cpp
+++ b/retrace/glretrace_main.cpp
@@ -815,11 +815,11 @@ public:
     }
 
     image::Image *
-    getSnapshot(int n) override {
+    getSnapshot(int n, bool backBuffer) override {
         if (!glretrace::getCurrentContext()) {
             return NULL;
         }
-        return glstate::getDrawBufferImage(n);
+        return glstate::getDrawBufferImage(n, backBuffer);
     }
 
     bool

--- a/retrace/glstate.hpp
+++ b/retrace/glstate.hpp
@@ -68,7 +68,7 @@ int
 getDrawBufferImageCount(void);
 
 image::Image *
-getDrawBufferImage(int n);
+getDrawBufferImage(int n, bool backBuffer);
 
 
 } /* namespace glstate */

--- a/retrace/glstate_images.cpp
+++ b/retrace/glstate_images.cpp
@@ -1242,7 +1242,7 @@ getDrawBufferImageCount()
 
 
 image::Image *
-getDrawBufferImage(int n)
+getDrawBufferImage(int n, bool backBuffer)
 {
     Context context;
 
@@ -1265,7 +1265,7 @@ getDrawBufferImage(int n)
         framebuffer_target = GL_FRAMEBUFFER;
     }
     GLint draw_framebuffer = 0;
-    if (context.framebuffer_object) {
+    if (context.framebuffer_object && !backBuffer) {
         glGetIntegerv(framebuffer_binding, &draw_framebuffer);
     }
 
@@ -1289,7 +1289,7 @@ getDrawBufferImage(int n)
 
     GLint draw_buffer = GL_NONE;
     ImageDesc desc;
-    if (draw_framebuffer) {
+    if (draw_framebuffer && !backBuffer) {
         if (context.ARB_draw_buffers) {
             glGetIntegerv(GL_DRAW_BUFFER0 + n, &draw_buffer);
             if (draw_buffer == GL_NONE) {
@@ -1304,7 +1304,7 @@ getDrawBufferImage(int n)
             return NULL;
         }
     } else if (n == 0) {
-        if (context.ES) {
+        if (context.ES || backBuffer) {
             // XXX: Draw buffer is always FRONT for single buffer context, BACK
             // for double buffered contexts. There is no way to know which (as
             // GL_DOUBLEBUFFER state is also unavailable), so always assume

--- a/retrace/retrace.hpp
+++ b/retrace/retrace.hpp
@@ -251,7 +251,7 @@ public:
     getSnapshotCount(void) = 0;
 
     virtual image::Image *
-    getSnapshot(int n) = 0;
+    getSnapshot(int n, bool backBuffer) = 0;
 
     virtual bool
     canDump(void) = 0;


### PR DESCRIPTION
When specifying "--snapshot=frame" it can be assumed that the user
is interested in the renderung output that goes to the screen and
not to some framebuffer attachment that happens to be bound to be
bound to an active framebuffer and set to be the drawbuffer.

Consequently, override the frame capture logic in case the frame-end
call triggers the snapshot to get the backbuffer contents.

Closes: #699