### PR TITLE
Initialise application name

### DIFF
--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -31,6 +31,8 @@ static void usage(void)
 int main(int argc, char **argv)
 {
     QApplication app(argc, argv);
+    QCoreApplication::setOrganizationName("ApiTrace");
+    QCoreApplication::setApplicationName("QApiTrace");
 
     qRegisterMetaType<QList<ApiTraceFrame*> >();
     qRegisterMetaType<QVector<ApiTraceCall*> >();


### PR DESCRIPTION
`QSettings` requires that the application and organisation names are initialised before it can use an implicit settings location. When
QApiTrace uses `QSettings`, it doesn't set an explicit location, so the implicit one must be valid.

Without this, the *Recent Launches* list remains empty, at least on Windows. I've had it work on Ubuntu, though, so presumably something's setting the names automatically there.