### PR TITLE
Added glSpecializeShader to glapi.py

### DIFF
--- a/specs/glapi.py
+++ b/specs/glapi.py
@@ -1230,6 +1230,7 @@ glapi.addFunctions([
 
     # GL_ARB_gl_spirv
     GlFunction(Void, "glSpecializeShaderARB", [(GLuint, "shader"), (GLstringConst, "pEntryPoint"), (GLuint, "numSpecializationConstants"), (Array(Const(GLuint), "numSpecializationConstants"), "pConstantIndex"), (Array(Const(GLuint), "numSpecializationConstants"), "pConstantValue")]),
+    GlFunction(Void, "glSpecializeShader", [(GLuint, "shader"), (GLstringConst, "pEntryPoint"), (GLuint, "numSpecializationConstants"), (Array(Const(GLuint), "numSpecializationConstants"), "pConstantIndex"), (Array(Const(GLuint), "numSpecializationConstants"), "pConstantValue")]),
 
     # GL_ARB_gpu_shader_fp64
     GlFunction(Void, "glUniform1d", [(GLlocation, "location"), (GLdouble, "x")]),


### PR DESCRIPTION
Adds support for the non-ARB glSpecializeShader() function.