### PR TITLE
Gltrim: add handling various function calls and fix used of pipelines 

### DIFF
--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -571,7 +571,7 @@ BufferObjectMap::namedUnmap(const trace::Call& call)
 
 
 void
-BufferObjectMap::memcopy(const trace::Call& call)
+BufferObjectMap::memcopy(const trace::Call& call, CallSet& out_set, bool recording)
 {
     uint64_t start = call.arg(0).toUInt();
     unsigned buf_id = 0;
@@ -587,6 +587,9 @@ BufferObjectMap::memcopy(const trace::Call& call)
     }
     auto buf = getById(buf_id);
     buf->addCall(trace2call(call));
+
+    if (recording)
+        buf->emitCallsTo(out_set);
 }
 
 void BufferObjectMap::addSSBODependencies(UsedObject::Pointer dep)

--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -390,6 +390,14 @@ DependecyObjectMap::emitBoundObjects(CallSet& out_calls)
         out_calls.insert(c);
 }
 
+void DependecyObjectMap::addBoundAsDependencyTo(UsedObject& obj)
+{
+    for (auto&& [key, bound_obj]: m_bound_object) {
+        if (bound_obj)
+            obj.addDependency(bound_obj);
+    }
+}
+
 void DependecyObjectMap::emitBoundObjectsExt(CallSet& out_calls)
 {
     (void)out_calls;

--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -178,7 +178,8 @@ class VertexAttribObjectMap: public DependecyObjectWithDefaultBindPointMap {
 public:
     VertexAttribObjectMap();
     void bindAVO(const trace::Call& call, BufferObjectMap& buffers, CallSet &out_list, bool emit_dependencies);
-    void bindVAOBuf(const trace::Call& call, BufferObjectMap& buffers, CallSet &out_list, bool emit_dependencies);
+    void bindVAOBuf(const trace::Call& call, BufferObjectMap& buffers, CallSet &out_list, bool emit_dependencies);    
+    void vaBinding(const trace::Call& call, BufferObjectMap& buffers, CallSet &out_list, bool emit_dependencies);
 private:
     unsigned next_id;
 };

--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -146,6 +146,7 @@ public:
         bt_texture,
         bt_tf,
         bt_uniform,
+        bt_names_access,
         bt_last,
     };
 
@@ -153,7 +154,10 @@ public:
     void map(const trace::Call& call);
     void map_range(const trace::Call& call);
     void unmap(const trace::Call& call);
-    void memcopy(const trace::Call& call);
+    void memcopy(const trace::Call& call, CallSet& out_set, bool recording);
+    void namedMap(const trace::Call& call);
+    void namedMapRange(const trace::Call& call);
+    void namedUnmap(const trace::Call& call);
 
     void namedData(const trace::Call& call);
 

--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -98,6 +98,8 @@ public:
     ObjectMap::iterator begin();
     ObjectMap::iterator end();
 
+    void addBoundAsDependencyTo(UsedObject& obj);
+
 protected:
 
     UsedObject::Pointer bind(unsigned bindpoint, unsigned id);

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -1054,6 +1054,22 @@ void FrameTrimmeImpl::oglDraw(const trace::Call& call)
             cur_prog->emitCallsTo(m_required_calls);
     }
 
+    auto cur_pipeline = m_program_pipelines.boundTo(0, 0);
+    if (cur_pipeline) {
+        for(auto && [key, buf]: m_buffers) {
+            if (buf && ((key % BufferObjectMap::bt_last) == BufferObjectMap::bt_uniform))
+                cur_pipeline->addDependency(buf);
+        }
+        m_buffers.addSSBODependencies(cur_pipeline);
+        m_textures.addImageDependencies(cur_pipeline);
+
+        if (fb->id())
+            fb->addDependency(cur_pipeline);
+
+        if (m_recording_frame)
+            cur_pipeline->emitCallsTo(m_required_calls);
+    }
+
     auto buf = m_buffers.boundToTarget(GL_ELEMENT_ARRAY_BUFFER);
 
     if (fb->id()) {

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -678,6 +678,7 @@ FrameTrimmeImpl::registerStateCalls()
         "glClearColor",
         "glClearDepth",
         "glClearStencil",
+        "glClipControl",
         "glColorMask",
         "glColorPointer",
         "glCullFace",

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -544,11 +544,15 @@ FrameTrimmeImpl::registerBufferCalls()
     MAP_OBJ(glNamedBufferData, m_buffers, BufferObjectMap::namedData);
     MAP_OBJ(glNamedBufferStorage, m_buffers, BufferObjectMap::namedData);
     MAP_OBJ(glBufferSubData, m_buffers, BufferObjectMap::callOnBoundObject);
-
+    MAP_OBJ(glNamedBufferSubData, m_buffers, BufferObjectMap::callOnNamedObject);
     MAP_OBJ(glMapBuffer, m_buffers, BufferObjectMap::map);
+    MAP_OBJ(glMapNamedBuffer, m_buffers, BufferObjectMap::namedMap);
+    MAP_OBJ(glMapNamedBufferRange, m_buffers, BufferObjectMap::namedMapRange);
+    MAP_OBJ(glUnmapNamedBuffer, m_buffers, BufferObjectMap::namedUnmap);
     MAP_OBJ(glMapBufferRange, m_buffers, BufferObjectMap::map_range);
     MAP_OBJ(memcpy, m_buffers, BufferObjectMap::memcopy);
     MAP_OBJ(glFlushMappedBufferRange, m_buffers, BufferObjectMap::callOnBoundObject);
+    MAP_OBJ(glFlushMappedNamedBufferRange, m_buffers, BufferObjectMap::callOnNamedObject);
     MAP_OBJ(glUnmapBuffer, m_buffers, BufferObjectMap::unmap);
     MAP_OBJ(glClearBufferData, m_buffers, BufferObjectMap::callOnBoundObject);
     MAP_OBJ(glInvalidateBufferData, m_buffers, BufferObjectMap::callOnNamedObject);

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -1074,13 +1074,10 @@ void FrameTrimmeImpl::oglDraw(const trace::Call& call)
             cur_pipeline->emitCallsTo(m_required_calls);
     }
 
-    auto buf = m_buffers.boundToTarget(GL_ELEMENT_ARRAY_BUFFER);
-
     if (fb->id()) {
         fb->addCall(trace2call(call));
 
-        if (buf)
-           fb->addDependency(buf);
+        m_buffers.addBoundAsDependencyTo(*fb);
 
         for(auto&& [key, vbo]: m_vertex_attrib_pointers) {
             if (vbo)
@@ -1103,8 +1100,7 @@ void FrameTrimmeImpl::oglDraw(const trace::Call& call)
             if (vbo)
                 vbo->emitCallsTo(m_required_calls);
         }
-        if (buf)
-            buf->emitCallsTo(m_required_calls);
+        m_buffers.emitBoundObjects(m_required_calls);
     }
 }
 

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -425,6 +425,10 @@ FrameTrimmeImpl::equalChars(const char *l, const char *r)
     m_call_table.insert(std::make_pair(#name, bind(&call, &obj, _1, \
                         std::ref(data1), param, std::ref(data2), std::ref(data3))))
 
+#define MAP_OBJ_RR(name, obj, call, data1, data2) \
+    m_call_table.insert(std::make_pair(#name, bind(&call, &obj, _1, \
+                        std::ref(data1), std::ref(data2))))
+
 #define MAP_OBJ_RRR(name, obj, call, data1, data2, data3) \
     m_call_table.insert(std::make_pair(#name, bind(&call, &obj, _1, \
                         std::ref(data1), std::ref(data2), std::ref(data3))))
@@ -550,7 +554,7 @@ FrameTrimmeImpl::registerBufferCalls()
     MAP_OBJ(glMapNamedBufferRange, m_buffers, BufferObjectMap::namedMapRange);
     MAP_OBJ(glUnmapNamedBuffer, m_buffers, BufferObjectMap::namedUnmap);
     MAP_OBJ(glMapBufferRange, m_buffers, BufferObjectMap::map_range);
-    MAP_OBJ(memcpy, m_buffers, BufferObjectMap::memcopy);
+    MAP_OBJ_RR(memcpy, m_buffers, BufferObjectMap::memcopy, m_required_calls, m_recording_frame);
     MAP_OBJ(glFlushMappedBufferRange, m_buffers, BufferObjectMap::callOnBoundObject);
     MAP_OBJ(glFlushMappedNamedBufferRange, m_buffers, BufferObjectMap::callOnNamedObject);
     MAP_OBJ(glUnmapBuffer, m_buffers, BufferObjectMap::unmap);

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -530,6 +530,7 @@ void
 FrameTrimmeImpl::registerBufferCalls()
 {
     MAP_OBJ(glGenBuffers, m_buffers, BufferObjectMap::generate);
+    MAP_OBJ(glCreateBuffers, m_buffers, BufferObjectMap::generate);
     MAP_OBJ(glDeleteBuffers, m_buffers, BufferObjectMap::destroy);
 
     MAP_RV(glBindBuffer, oglBind, m_buffers, 1);

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -835,6 +835,7 @@ FrameTrimmeImpl::registerVaCalls()
     MAP_OBJ(glGenVertexArrays, m_vertex_arrays, VertexArrayMap::generate);
     MAP_OBJ(glDeleteVertexArrays, m_vertex_arrays, VertexArrayMap::destroy);
     MAP_RV(glBindVertexArray, oglBind, m_vertex_arrays, 0);
+    //MAP_OBJ(glVertexAttribBinding, m_vertex_buffer_pointers, VertexAttribObjectMap::vaBinding);
 
     MAP(glDisableVertexAttribArray, recordRequiredCall);
     MAP(glEnableVertexAttribArray, recordRequiredCall);
@@ -848,6 +849,11 @@ FrameTrimmeImpl::registerVaCalls()
 
     MAP(glVertexPointer, recordRequiredCall);
     MAP(glTexCoordPointer, recordRequiredCall);
+
+    MAP(glVertexAttribBinding, recordRequiredCall);
+    MAP(glVertexAttribFormat, recordRequiredCall);
+    MAP(glVertexBindingDivisor, recordRequiredCall);
+
     MAP(glVertexAttrib1, recordRequiredCall);
     MAP(glVertexAttrib2, recordRequiredCall);
     MAP(glVertexAttrib3, recordRequiredCall);
@@ -859,6 +865,7 @@ FrameTrimmeImpl::registerVaCalls()
     MAP(glVertexAttribP3, recordRequiredCall);
     MAP(glVertexAttribP4, recordRequiredCall);
     MAP(glTexGen, recordRequiredCall);
+    MAP(glTextureBarrier, recordRequiredCall);
 
     MAP(glDisableClientState, recordRequiredCall);
     MAP(glEnableClientState, recordRequiredCall);


### PR DESCRIPTION
Add support for glClipControl. glCreateBuffers, glTextureBarrier,  glVertexAttrib(Binding|Format|Divisor), 
add all bound buffers when drawing as a dependency, and emit buffer that is written to by using memcopy in a preserved frame. These changes make it possible to trim traces obtained from Tomb Raider 2013. 