### PR TITLE
Gltrim add copysubdata and indirect draw

### DIFF
--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -602,6 +602,26 @@ void BufferObjectMap::addSSBODependencies(UsedObject::Pointer dep)
     }
 }
 
+void BufferObjectMap::copyBufferSubData(const trace::Call& call)
+{
+    auto src = boundTo(call.arg(0).toUInt());
+    auto dst = boundTo(call.arg(1).toUInt());
+    assert(dst);
+    assert(src);
+    dst->addDependency(src);
+    dst->addCall(trace2call(call));
+}
+
+void BufferObjectMap::copyNamedBufferSubData(const trace::Call& call)
+{
+    auto src = getById(call.arg(0).toUInt());
+    auto dst = getById(call.arg(1).toUInt());
+    assert(dst);
+    assert(src);
+    dst->addDependency(src);
+    dst->addCall(trace2call(call));
+}
+
 VertexAttribObjectMap::VertexAttribObjectMap():next_id(1)
 {
 

--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -167,6 +167,9 @@ public:
 
     void addSSBODependencies(UsedObject::Pointer dep);
 
+    void copyBufferSubData(const trace::Call& call);
+    void copyNamedBufferSubData(const trace::Call& call);
+
 private:
     unsigned getBindpointFromCall(const trace::Call& call) const override;
 

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -549,6 +549,9 @@ FrameTrimmeImpl::registerBufferCalls()
     MAP_OBJ(glNamedBufferStorage, m_buffers, BufferObjectMap::namedData);
     MAP_OBJ(glBufferSubData, m_buffers, BufferObjectMap::callOnBoundObject);
     MAP_OBJ(glNamedBufferSubData, m_buffers, BufferObjectMap::callOnNamedObject);
+    MAP_OBJ(glCopyBufferSubData, m_buffers, BufferObjectMap::copyBufferSubData);
+    MAP_OBJ(glCopyNamedBufferSubData, m_buffers, BufferObjectMap::copyNamedBufferSubData);
+
     MAP_OBJ(glMapBuffer, m_buffers, BufferObjectMap::map);
     MAP_OBJ(glMapNamedBuffer, m_buffers, BufferObjectMap::namedMap);
     MAP_OBJ(glMapNamedBufferRange, m_buffers, BufferObjectMap::namedMapRange);

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -571,6 +571,12 @@ void FrameTrimmeImpl::registerDrawCalls()
     MAP(glDrawElements, oglDraw);
     MAP(glDrawRangeElements, oglDraw);
     MAP(glDrawRangeElementsBaseVertex, oglDraw);
+
+    MAP(glDrawArraysInstanced, oglDraw);
+
+    MAP(glDrawElementsIndirect, oglDraw);
+    MAP(glMultiDrawArraysIndirect, oglDraw);
+    MAP(glMultiDrawElementsIndirect, oglDraw);
 }
 
 void


### PR DESCRIPTION
gltrim: 

* Handle indirect and instanced draw calls
* Handle CopyBufferSubData and CopyNamedBufferSubData
* 
Some of these calls are used with "The Dark Mod"
