### PR TITLE
gltrim: allow unordered call IDs when copying calls out of a trace

### DIFF
--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -72,6 +72,7 @@ struct FrameTrimmeImpl {
     void endTargetFrame();
 
     std::vector<unsigned> getSortedCallIds();
+    std::unordered_set<unsigned> getUniqueCallIds();
 
     static unsigned equalChars(const char *l, const char *r);
 
@@ -188,6 +189,12 @@ std::vector<unsigned>
 FrameTrimmer::getSortedCallIds()
 {
     return impl->getSortedCallIds();
+}
+
+std::unordered_set<unsigned>
+FrameTrimmer::getUniqueCallIds()
+{
+    return impl->getUniqueCallIds();
 }
 
 void FrameTrimmer::finalize()
@@ -367,13 +374,19 @@ void FrameTrimmeImpl::endTargetFrame()
     m_recording_frame = false;
 }
 
+std::unordered_set<unsigned>
+FrameTrimmeImpl::getUniqueCallIds()
+{
+    std::unordered_set<unsigned> retval;
+    for(auto&& c: m_required_calls)
+        retval.insert(c->callNo());
+    return retval;
+}
+
 std::vector<unsigned>
 FrameTrimmeImpl::getSortedCallIds()
 {
-    std::unordered_set<unsigned> make_sure_its_singular;
-
-    for(auto&& c: m_required_calls)
-        make_sure_its_singular.insert(c->callNo());
+    auto make_sure_its_singular = getUniqueCallIds();
 
     std::vector<unsigned> sorted_calls(
                 make_sure_its_singular.begin(),

--- a/frametrim/ft_frametrimmer.hpp
+++ b/frametrim/ft_frametrimmer.hpp
@@ -30,6 +30,7 @@
 #include "trace_parser.hpp"
 
 #include <vector>
+#include <unordered_set>
 
 namespace frametrim {
 
@@ -50,6 +51,7 @@ public:
     void finalize();
 
     std::vector<unsigned> getSortedCallIds();
+    std::unordered_set<unsigned> getUniqueCallIds();
 private:
     struct FrameTrimmeImpl *impl;
 

--- a/frametrim/ft_main.cpp
+++ b/frametrim/ft_main.cpp
@@ -184,24 +184,24 @@ static int trim_to_frame(const char *filename,
         return 2;
     }
 
-    auto call_ids = trimmer.getSortedCallIds();
+    auto call_ids = trimmer.getUniqueCallIds();
     std::cerr << "Write output file\n";
 
     p.close();
     p.open(filename);
     call.reset(p.parse_call());
 
-    auto callid_itr = call_ids.begin();
-
     std::cerr << "Copying " << call_ids.size() << " calls\n";
 
-    while (call && callid_itr != call_ids.end()) {
-        while (call->no != *callid_itr)
+    while (1) {
+        while (call && call_ids.find(call->no) == call_ids.end())
             call.reset(p.parse_call());
+
+        if (!call)
+            break;
 
         writer.writeCall(call.get());
         call.reset(p.parse_call());
-        ++callid_itr;
     }
 
     if (options.top_frame_call_counts) {


### PR DESCRIPTION
It seems that call IDs in traces are not necessarily ordered,
so don't rely on an ascending order. 

This fixes trimming a Tom Raider 2013 trace.

@jrfonseca This is a workaround, I guess the real fix would be to make sure that the call IDs are indeed ascending, but I didn't really find the code that is responsible for writing the calls in any order. If you can point me to it, I can try to figure out why the call IDs might be written out of order. 