### PR TITLE
glretrace: Ignore eglGetPlatformDisplay*()

### DIFF
--- a/retrace/glretrace_egl.cpp
+++ b/retrace/glretrace_egl.cpp
@@ -291,6 +291,8 @@ static void retrace_eglSwapBuffers(trace::Call &call) {
 const retrace::Entry glretrace::egl_callbacks[] = {
     {"eglGetError", &retrace::ignore},
     {"eglGetDisplay", &retrace::ignore},
+    {"eglGetPlatformDisplay", &retrace::ignore},
+    {"eglGetPlatformDisplayEXT", &retrace::ignore},
     {"eglInitialize", &retrace::ignore},
     {"eglTerminate", &retrace::ignore},
     {"eglQueryString", &retrace::ignore},


### PR DESCRIPTION
Avoids an “unsupported eglGetPlatformDisplayEXT call” warning when replaying a `gtk4-demo` trace from Wayland.

The same ignore was done for `eglGetDisplay()`.

Signed-off-by: Emmanuel Gil Peyrot <linkmauve@linkmauve.fr>