### PR TITLE
retrace: Add option to pass a query result check threshold

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -250,6 +250,16 @@ void MainWindow::replayStart()
     dlgUi.coreProfileCB->setChecked(
         m_retracer->isCoreProfile());
 
+    dlgUi.queryHandlingSelector->addItem("Skip");
+    dlgUi.queryHandlingSelector->addItem("Run");
+    dlgUi.queryHandlingSelector->addItem("Run & Check");
+    dlgUi.queryHandlingSelector->setCurrentIndex(
+                m_retracer->queryHandling());
+
+    dlgUi.queryCheckReportThreshold->setValue(
+                m_retracer->queryCheckReportThreshold());
+
+
     if (dlg.exec() == QDialog::Accepted) {
         m_retracer->setDoubleBuffered(
             dlgUi.doubleBufferingCB->isChecked());
@@ -264,6 +274,11 @@ void MainWindow::replayStart()
             dlgUi.coreProfileCB->isChecked());
 
         m_retracer->setProfiling(false, false, false);
+
+        m_retracer->setQueryHandling(
+                    dlgUi.queryHandlingSelector->currentIndex());
+        m_retracer->setQueryCheckReportThreshold(
+                    dlgUi.queryCheckReportThreshold->value());
 
         replayTrace(false, false);
     }

--- a/gui/retracer.cpp
+++ b/gui/retracer.cpp
@@ -139,7 +139,9 @@ Retracer::Retracer(QObject *parent)
       m_captureCall(0),
       m_profileGpu(false),
       m_profileCpu(false),
-      m_profilePixels(false)
+      m_profilePixels(false),
+      m_queryHandling(0),
+      m_queryCheckThreshold(0)
 {
     qRegisterMetaType<QList<ApiTraceError> >();
 }
@@ -271,6 +273,26 @@ void Retracer::setCaptureState(bool enable)
     m_captureState = enable;
 }
 
+int Retracer::queryHandling()
+{
+    return m_queryHandling;
+}
+
+void Retracer::setQueryHandling(int handling)
+{
+    m_queryHandling = handling;
+}
+
+int Retracer::queryCheckReportThreshold()
+{
+    return m_queryCheckThreshold;
+}
+
+void Retracer::setQueryCheckReportThreshold(int value)
+{
+    m_queryCheckThreshold = value;
+}
+
 bool Retracer::captureThumbnails() const
 {
     return m_captureThumbnails;
@@ -399,6 +421,22 @@ void Retracer::run()
         if (m_benchmarking) {
             arguments << QLatin1String("-b");
         }
+    }
+
+    switch (m_queryHandling) {
+    case 1:
+        arguments << QLatin1String("--query-handling");
+        arguments << QLatin1String("run");
+        break;
+    case 2:
+        arguments << QLatin1String("--query-handling");
+        arguments << QLatin1String("check");
+
+        if (m_queryCheckThreshold > 0) {
+            arguments << QLatin1String("--query-tolerance");
+            arguments << QString::number(m_queryCheckThreshold);
+        }
+        break;
     }
 
     if (!m_callsToIgnore.empty()) {

--- a/gui/retracer.h
+++ b/gui/retracer.h
@@ -52,6 +52,8 @@ public:
     bool isMsaaResolve() const;
     void setMsaaResolve(bool resolve);
 
+
+
     void setCaptureAtCallNumber(qlonglong num);
     qlonglong captureAtCallNumber() const;
 
@@ -67,6 +69,12 @@ public:
     void resetThumbnailsToCapture();
 
     QString thumbnailCallSet();
+
+    int queryHandling();
+    void setQueryHandling(int handling);
+
+    int queryCheckReportThreshold();
+    void setQueryCheckReportThreshold(int value);
 
 signals:
     void finished(const QString &output);
@@ -95,6 +103,8 @@ private:
     bool m_profileGpu;
     bool m_profileCpu;
     bool m_profilePixels;
+    int m_queryHandling;
+    int m_queryCheckThreshold;
 
     QProcessEnvironment m_processEnvironment;
 

--- a/gui/ui/retracerdialog.ui
+++ b/gui/ui/retracerdialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>286</width>
-    <height>125</height>
+    <width>314</width>
+    <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,9 +30,12 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
+         <width>20</width>
          <height>20</height>
         </size>
        </property>
@@ -67,9 +70,12 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
+         <width>20</width>
          <height>20</height>
         </size>
        </property>
@@ -104,9 +110,12 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>68</width>
+         <width>20</width>
          <height>20</height>
         </size>
        </property>
@@ -140,13 +149,16 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
-      <spacer name="horizontalSpacer_5">
+      <spacer name="horizontalSpacer_9">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
+         <width>20</width>
          <height>20</height>
         </size>
        </property>
@@ -179,6 +191,93 @@
       </spacer>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Queries</string>
+     </property>
+     <widget class="QWidget" name="gridLayoutWidget">
+      <property name="geometry">
+       <rect>
+        <x>11</x>
+        <y>20</y>
+        <width>281</width>
+        <height>80</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout">
+       <property name="leftMargin">
+        <number>1</number>
+       </property>
+       <property name="topMargin">
+        <number>1</number>
+       </property>
+       <property name="rightMargin">
+        <number>1</number>
+       </property>
+       <property name="bottomMargin">
+        <number>1</number>
+       </property>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="queryHandlingSelector">
+         <property name="statusTip">
+          <string>How to handle calls to get the query result.</string>
+         </property>
+         <property name="currentText">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Handling;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Check threshold:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QSpinBox" name="queryCheckReportThreshold">
+         <property name="toolTip">
+          <string>Thresshold to report differentce between recorded query result and result obtained while executing the query.</string>
+         </property>
+         <property name="maximum">
+          <number>100000</number>
+         </property>
+         <property name="singleStep">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <spacer name="horizontalSpacer_11">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/retrace/glretrace.py
+++ b/retrace/glretrace.py
@@ -211,8 +211,10 @@ class GlRetracer(Retracer):
            print(r'        if (call.arg(1).toUInt() == GL_QUERY_RESULT_AVAILABLE) {')
            print(r'            if (expect == 1 && retval == 0)')
            print(r'                goto wait_for_query_result;')
-           print(r'        } else if (retrace::queryHandling == retrace::QUERY_RUN_AND_CHECK_RESULT && expect != retval) {')
-           print(r'           retrace::warning(call) << "Warning: query returned " << retval << " but trace contained " << expect << "\n";')
+           print(r'        } else if (retrace::queryHandling == retrace::QUERY_RUN_AND_CHECK_RESULT &&')
+           print(r'                   abs(static_cast<int64_t>(expect) - static_cast<int64_t>(retval)) > retrace::queryTolerance) {')
+           print(r'           retrace::warning(call) << "Warning: query returned " << retval << " but trace contained " << expect')
+           print(r'                                  << " (tol = " << retrace::queryTolerance << ")\n";')
            print(r'        }')
            print(r'    }')
 

--- a/retrace/retrace.cpp
+++ b/retrace/retrace.cpp
@@ -44,7 +44,7 @@ trace::DumpFlags dumpFlags = trace::DUMP_FLAG_THREAD_IDS;
 static bool call_dumped = false;
 
 EQueryHandling queryHandling = QUERY_SKIP;
-
+unsigned queryTolerance = 0;
 
 static void dumpCall(trace::Call &call) {
     if (verbosity >= 0 && !call_dumped) {

--- a/retrace/retrace.hpp
+++ b/retrace/retrace.hpp
@@ -106,10 +106,12 @@ public:
 enum EQueryHandling {
     QUERY_SKIP,
     QUERY_RUN,
-    QUERY_RUN_AND_CHECK_RESULT
+    QUERY_RUN_AND_CHECK_RESULT,
 };
 
 extern EQueryHandling queryHandling;
+
+extern unsigned queryTolerance;
 
 /**
  * Output verbosity when retracing files.

--- a/retrace/retrace_main.cpp
+++ b/retrace/retrace_main.cpp
@@ -698,6 +698,7 @@ usage(const char *argv0) {
         "      --pdrawcalls        draw call profiling metrics selection\n"
         "      --list-metrics      list all available metrics for TRACE\n"
         "      --query-handling    How query readbacks should be handled: ('skip', 'run', 'check'), default is 'skip'\n"
+        "      --query-tolerance   Set a tolerance when comparing recorded query results to evaluated ones, a value >0 enables query-handling 'check'\n"
         "      --gen-passes        generate profiling passes and output passes number\n"
         "      --call-nos[=BOOL]   use call numbers in snapshot filenames\n"
         "      --core              use core profile\n"
@@ -765,6 +766,7 @@ enum {
     MARKERS_OPT,
     MIN_CPU_TIME_OPT,
     QUERY_HANDLING_OPT,
+    QUERY_CHECK_TOLARANCE_OPT,
     IGNORE_CALLS_OPT,
 };
 
@@ -797,6 +799,7 @@ longOptions[] = {
     {"pframes", required_argument, 0, PFRAMES_OPT},
     {"pdrawcalls", required_argument, 0, PDRAWCALLS_OPT},
     {"query-handling", required_argument, 0, QUERY_HANDLING_OPT},
+    {"query-tolerance", required_argument, 0, QUERY_CHECK_TOLARANCE_OPT},
     {"list-metrics", no_argument, 0, PLMETRICS_OPT},
     {"gen-passes", no_argument, 0, GENPASS_OPT},
     {"sb", no_argument, 0, SB_OPT},
@@ -1246,6 +1249,11 @@ int main(int argc, char **argv)
                 retrace::queryHandling = retrace::QUERY_RUN;
             else
                 retrace::queryHandling = retrace::QUERY_SKIP;
+            break;
+        case QUERY_CHECK_TOLARANCE_OPT:
+            retrace::queryTolerance = atoi(optarg);
+            if (retrace::queryTolerance > 0)
+                retrace::queryHandling = retrace::QUERY_RUN_AND_CHECK_RESULT;
             break;
         case GENPASS_OPT:
             retrace::debug = 0;


### PR DESCRIPTION
In order to reduce the noise when comparing recorded query values
to evaluated ones while retracing add an option to be able to
specify a threshold for the result difference.
With a threshold > 0 " --query-handling check" will be enabled too.

Related: #715

Signed-off-by: Gert Wollny <gert.wollny@collabora.com>