### PR TITLE
glretrace: use samples value recorded in trace to set MSAA samples

### DIFF
--- a/helpers/glfeatures.hpp
+++ b/helpers/glfeatures.hpp
@@ -49,6 +49,7 @@ enum Api {
 struct Profile {
     unsigned major:8;
     unsigned minor:8;
+    unsigned samples:8;
     unsigned api:1;
     unsigned core:1;
     unsigned forwardCompatible:1;
@@ -64,6 +65,7 @@ struct Profile {
         api = _api;
         major = _major;
         minor = _minor;
+        samples = 1;
         core = _core;
         forwardCompatible = _forwardCompatible;
     }

--- a/retrace/glretrace.hpp
+++ b/retrace/glretrace.hpp
@@ -132,6 +132,9 @@ getCurrentContext(void) {
 int
 parseAttrib(const trace::Value *attribs, int param, int default_ = 0, int terminator = 0);
 
+void
+setSamples(trace::Call& call, int samples);
+
 glfeatures::Profile
 parseContextAttribList(const trace::Value *attribs);
 

--- a/retrace/glretrace_egl.cpp
+++ b/retrace/glretrace_egl.cpp
@@ -146,6 +146,9 @@ static void retrace_eglChooseConfig(trace::Call &call) {
         }
     }
 
+    if (parseAttrib(attrib_array, EGL_SAMPLE_BUFFERS))
+        profile.samples = parseAttrib(attrib_array, EGL_SAMPLES);
+
     unsigned num_config = num_config_ptr->values[0]->toUInt();
     for (unsigned i = 0; i < num_config; ++i) {
         unsigned long long orig_config = config_array->values[i]->toUIntPtr();

--- a/retrace/glretrace_wgl.cpp
+++ b/retrace/glretrace_wgl.cpp
@@ -36,10 +36,12 @@ using namespace glretrace;
 
 typedef std::map<unsigned long long, glws::Drawable *> DrawableMap;
 typedef std::map<unsigned long long, Context *> ContextMap;
+typedef std::map<unsigned long long, int> FBConfigMap;
+
 static DrawableMap drawable_map;
 static DrawableMap pbuffer_map;
 static ContextMap context_map;
-
+static FBConfigMap fbconfig_map;
 
 static glws::Drawable *
 getDrawable(unsigned long long hdc) {
@@ -226,6 +228,8 @@ static void retrace_wglSwapLayerBuffers(trace::Call &call) {
 #define WGL_AUX7_ARB                        0x208E
 #define WGL_AUX8_ARB                        0x208F
 #define WGL_AUX9_ARB                        0x2090
+#define WGL_SAMPLE_BUFFERS_ARB              0x2041
+#define WGL_SAMPLES_ARB                     0x2042
 
 static void retrace_wglCreatePbufferARB(trace::Call &call) {
     unsigned long long orig_pbuffer = call.ret->toUIntPtr();
@@ -308,6 +312,10 @@ static void retrace_wglCreateContextAttribsARB(trace::Call &call) {
 
     const trace::Value * attribList = &call.arg(2);
     glfeatures::Profile profile = parseContextAttribList(attribList);
+
+    auto it = fbconfig_map.find(call.arg(0).toUInt());
+    if (it != fbconfig_map.end())
+        profile.samples = it->second;
 
     Context *context = glretrace::createContext(share_context, profile);
     context_map[orig_context] = context;
@@ -452,14 +460,23 @@ static void retrace_wglUseFontOutlinesAW(trace::Call &call)
     }
 }
 
+static void retrace_wglChoosePixelFormat(trace::Call &call) {
+    auto attrib_list = call.arg(1).toArray();
+    if (!parseAttrib(attrib_list, WGL_SAMPLE_BUFFERS_ARB))
+        return;
 
+    int samples = parseAttrib(attrib_list, WGL_SAMPLES_ARB);
+
+    if (samples > 0)
+        fbconfig_map[call.arg(0).toUInt()] = samples;
+}
 
 const retrace::Entry glretrace::wgl_callbacks[] = {
     {"glAddSwapHintRectWIN", &retrace::ignore},
     {"wglBindTexImageARB", &retrace_wglBindTexImageARB},
-    {"wglChoosePixelFormat", &retrace::ignore},
-    {"wglChoosePixelFormatARB", &retrace::ignore},
-    {"wglChoosePixelFormatEXT", &retrace::ignore},
+    {"wglChoosePixelFormat", &retrace_wglChoosePixelFormat},
+    {"wglChoosePixelFormatARB", &retrace_wglChoosePixelFormat},
+    {"wglChoosePixelFormatEXT", &retrace_wglChoosePixelFormat},
     {"wglCreateContext", &retrace_wglCreateContext},
     {"wglCreateContextAttribsARB", &retrace_wglCreateContextAttribsARB},
     {"wglCreateLayerContext", &retrace_wglCreateLayerContext},


### PR DESCRIPTION
Check the calls that configure the framebuffer format and use the
requested samples value unless this value was set from the command
line.

WIP: currently calling the framebuffer config twice with different samples values will result in ignoring the second value if the first one was != 1. 

Related: #690 

@jrfonseca could you skim over it to see whether this makes any sense? 