### PR TITLE
Increase precision of image range spinners

### DIFF
--- a/gui/ui/imageviewer.ui
+++ b/gui/ui/imageviewer.ui
@@ -142,7 +142,7 @@
      <item>
       <widget class="QDoubleSpinBox" name="lowerSpinBox">
        <property name="decimals">
-        <number>3</number>
+        <number>5</number>
        </property>
        <property name="minimum">
         <double>-999.999000000000024</double>
@@ -165,7 +165,7 @@
      <item>
       <widget class="QDoubleSpinBox" name="upperSpinBox">
        <property name="decimals">
-        <number>3</number>
+        <number>5</number>
        </property>
        <property name="minimum">
         <double>-999.999000000000024</double>


### PR DESCRIPTION
I needed to be able to restrict the range to 0.9998-1.0 to be able to see something far away in a depth buffer, so made this change locally as three decimal digits didn't let me specify such a small range. Presumably, someone else might want to visualise tiny depth buffer differences, too.