### PR TITLE
Add some instructions for bundling dependencies

### DIFF
--- a/docs/INSTALL.markdown
+++ b/docs/INSTALL.markdown
@@ -69,6 +69,15 @@ you have a multilib gcc and 32-bits X11 libraries, by doing:
 The `/usr/lib32` refers to the path where the 32-bits shared objects are may
 differ depending on the actual Linux distribution.
 
+## Obtaining vendored dependencies
+
+If your distribution does not provide some of the dependencies, you can obtain them as git submodules instead.
+
+To fetch them, run this command:
+
+```
+git submodule update --init --recursive
+```
 
 # Mac OS X #
 


### PR DESCRIPTION
Building on Fedora requires quite a few bundled dependencies, since the distro repos don't have them.

.gitmodules is quite easy to overlook, so I've added instructions to INSTALL.markdown