### PR TITLE
Various gltrim fixes

### DIFF
--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -125,6 +125,7 @@ void DependecyObjectMap::destroy(const trace::Call& call)
 {
     auto c = trace2call(call);
     const auto ids = (call.arg(1)).toArray();
+    assert(ids);
     for (auto& v : ids->values) {
         assert(m_objects[v->toUInt()]->id() == v->toUInt());
         auto obj_it = m_objects.find(v->toUInt());

--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -301,7 +301,7 @@ DependecyObjectMap::callOnBoundObjectWithDepBoundTo(const trace::Call& call,
     unsigned bindpoint = getBindpointFromCall(call);
     if (!m_bound_object[bindpoint]) {
         std::cerr << "No object bound in call " << call.no << ":" << call.name() << "\n";
-        assert(0);
+        return;
     }
     m_bound_object[bindpoint]->addCall(trace2call(call));
 

--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -635,7 +635,8 @@ VertexAttribObjectMap::bindAVO(const trace::Call& call, BufferObjectMap& buffers
     auto obj = std::make_shared<UsedObject>(next_id);
     addObject(next_id, obj);
     bind(id, next_id);
-    obj->addCall(trace2call(call));
+    auto c = trace2call(call);
+    obj->addCall(c);
 
     auto buf = buffers.boundToTarget(GL_ARRAY_BUFFER);
     if (buf) {
@@ -644,6 +645,10 @@ VertexAttribObjectMap::bindAVO(const trace::Call& call, BufferObjectMap& buffers
             buf->emitCallsTo(*global_state.out_list);
         }
     }
+    if (global_state.current_vao) {
+        global_state.current_vao->addDependency(obj);
+    }
+
     ++next_id;
 }
 

--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -531,7 +531,7 @@ BufferObjectMap::namedMap(const trace::Call& call)
 }
 
 void
-BufferObjectMap::map_range(const trace::Call& call)
+BufferObjectMap::mapRange(const trace::Call& call)
 {
     unsigned target = getBindpointFromCall(call);
     auto buf = boundAtBinding(target);

--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -181,6 +181,7 @@ private:
 
     std::unordered_map<unsigned, unsigned> m_buffer_sizes;
     std::unordered_map<unsigned, std::pair<uint64_t, uint64_t>> m_buffer_mappings;
+    std::unordered_map<unsigned, std::tuple<uint64_t, uint64_t, uint64_t>> m_old_buffer_mappings;
 
 };
 

--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -154,7 +154,7 @@ public:
 
     void data(const trace::Call& call);
     void map(const trace::Call& call);
-    void map_range(const trace::Call& call);
+    void mapRange(const trace::Call& call);
     void unmap(const trace::Call& call);
     void memcopy(const trace::Call& call, CallSet& out_set, bool recording);
     void namedMap(const trace::Call& call);

--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -81,13 +81,12 @@ public:
 
     void
     callOnBoundObjectWithDepBoundTo(const trace::Call& call, DependecyObjectMap& other_objects,
-                                    int bindingpoint, CallSet &out_set, bool recording);
+                                    int bindingpoint);
 
     void callOnNamedObjectWithDep(const trace::Call& call,
                                   DependecyObjectMap& other_objects, int dep_obj_param, bool reverse_dep_too);
-    void callOnNamedObjectWithNamedDep(const trace::Call& call,
-                                       DependecyObjectMap& other_objects,
-                                       int dep_call_param, CallSet& out_set, bool recording);
+    void callOnNamedObjectWithNamedDep(const trace::Call& call, DependecyObjectMap& other_objects,
+                                       int dep_call_param);
 
     UsedObject::Pointer getById(unsigned id) const;
     void addCall(PTraceCall call);
@@ -186,9 +185,9 @@ private:
 class VertexAttribObjectMap: public DependecyObjectWithDefaultBindPointMap {
 public:
     VertexAttribObjectMap();
-    void bindAVO(const trace::Call& call, BufferObjectMap& buffers, CallSet &out_list, bool emit_dependencies);
-    void bindVAOBuf(const trace::Call& call, BufferObjectMap& buffers, CallSet &out_list, bool emit_dependencies);    
-    void vaBinding(const trace::Call& call, BufferObjectMap& buffers, CallSet &out_list, bool emit_dependencies);
+    void bindAVO(const trace::Call& call, BufferObjectMap& buffers);
+    void bindVAOBuf(const trace::Call& call, BufferObjectMap& buffers);
+    void vaBinding(const trace::Call& call, BufferObjectMap& buffers);
 private:
     unsigned next_id;
 };
@@ -248,5 +247,14 @@ private:
     bindTarget(unsigned id, unsigned bindpoint) override;
     unsigned getBindpointFromCall(const trace::Call& call) const override;
 };
+
+struct GlobalState {
+    CallSet *out_list = nullptr;
+    bool emit_dependencies = false;
+    UsedObject::Pointer current_vao;
+};
+
+extern GlobalState global_state;
+
 
 }

--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -152,6 +152,7 @@ public:
         bt_last,
     };
 
+    void bindBuffer(const trace::Call& call);
     void data(const trace::Call& call);
     void map(const trace::Call& call);
     void mapRange(const trace::Call& call);
@@ -163,7 +164,7 @@ public:
 
     void namedData(const trace::Call& call);
 
-    UsedObject::Pointer boundToTarget(unsigned target, unsigned index = 0);
+    UsedObject::Pointer boundToTarget(unsigned target);
 
     void addSSBODependencies(UsedObject::Pointer dep);
 

--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -50,6 +50,7 @@ public:
 
     unsigned extraInfo(const std::string& key) const;
     void setExtraInfo(const std::string& key, unsigned value);
+    void eraseExtraInfo(const std::string& key);
 
 private:
 
@@ -111,7 +112,7 @@ private:
     virtual UsedObject::Pointer bindTarget(unsigned id, unsigned bindpoint);
     virtual unsigned getBindpointFromCall(const trace::Call& call) const = 0;
     virtual unsigned getBindpoint(unsigned target, unsigned index) const;
-    virtual void setTargetType(unsigned id, unsigned target);
+    virtual bool setTargetType(unsigned id, unsigned target);
 
     ObjectMap m_objects;
     ObjectMap m_bound_object;
@@ -205,7 +206,7 @@ public:
 private:
     void emitBoundObjectsExt(CallSet& out_calls) override;
     unsigned getBindpointFromCall(const trace::Call& call) const override;
-    void setTargetType(unsigned id, unsigned target) override;
+    bool setTargetType(unsigned id, unsigned target) override;
     int getBindpointFromTargetAndUnit(unsigned target, unsigned unit) const;
     unsigned m_active_texture;
     std::unordered_map<unsigned, UsedObject::Pointer> m_bound_images;

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -622,12 +622,15 @@ FrameTrimmeImpl::registerProgramCalls()
     MAP_OBJ(glShaderSource, m_shaders, ShaderStateMap::callOnNamedObject);
 
     MAP_OBJ(glBindAttribLocation, m_programs, ProgramObjectMap::callOnNamedObject);
+    MAP_OBJ(glGetActiveAttrib, m_programs, ProgramObjectMap::callOnNamedObject);
     MAP_OBJ(glCreateProgram, m_programs, ProgramObjectMap::create);
     MAP_OBJ(glDeleteProgram, m_programs, ProgramObjectMap::del);
     MAP_OBJ(glDetachShader, m_programs, ProgramObjectMap::callOnNamedObject);
+    MAP_OBJ(glGetAttachedShaders, m_programs, ProgramObjectMap::callOnNamedObject);
 
     MAP_OBJ(glGetAttribLocation, m_programs, ProgramObjectMap::callOnNamedObject);
     MAP_OBJ(glGetUniformLocation, m_programs, ProgramObjectMap::callOnNamedObject);
+    MAP_OBJ(glGetUniformBlockIndex, m_programs, ProgramObjectMap::callOnNamedObject);
     MAP_OBJ(glBindFragDataLocation, m_programs, ProgramObjectMap::callOnNamedObject);
     MAP_OBJ(glLinkProgram, m_programs, ProgramObjectMap::callOnNamedObject);
     MAP_OBJ(glProgramBinary, m_programs, ProgramObjectMap::callOnNamedObject);

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -815,6 +815,7 @@ void FrameTrimmeImpl::registerRequiredCalls()
         "glXChooseVisual",
         "glXCreateContext",
         "glXDestroyContext",
+        "glXGetFBConfigAttrib",
         "glXMakeCurrent",
         "glXMakeContextCurrent",
         "glXChooseFBConfig",

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -575,7 +575,9 @@ FrameTrimmeImpl::registerBufferCalls()
     MAP_OBJ(glNamedBufferData, m_buffers, BufferObjectMap::namedData);
     MAP_OBJ(glNamedBufferStorage, m_buffers, BufferObjectMap::namedData);
     MAP_OBJ(glBufferSubData, m_buffers, BufferObjectMap::callOnBoundObject);
+    MAP_OBJ(glGetBufferSubData, m_buffers, BufferObjectMap::callOnBoundObject);
     MAP_OBJ(glNamedBufferSubData, m_buffers, BufferObjectMap::callOnNamedObject);
+    MAP_OBJ(glGetNamedBufferSubData, m_buffers, BufferObjectMap::callOnNamedObject);
     MAP_OBJ(glCopyBufferSubData, m_buffers, BufferObjectMap::copyBufferSubData);
     MAP_OBJ(glCopyNamedBufferSubData, m_buffers, BufferObjectMap::copyNamedBufferSubData);
 

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -365,7 +365,7 @@ bool
 FrameTrimmeImpl::skipDeleteImpl(unsigned obj_id, DependecyObjectMap& map)
 {
     auto obj = map.getById(obj_id);
-    return !obj->emitted();
+    return !obj || !obj->emitted();
 }
 
 void FrameTrimmeImpl::finalize()

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -658,8 +658,12 @@ void FrameTrimmeImpl::registerTextureCalls()
 
     MAP_OBJ(glCompressedTexImage2D, m_textures, TextureObjectMap::callOnBoundObject);
     MAP_OBJ(glGenerateMipmap, m_textures, TextureObjectMap::callOnBoundObject);
-    MAP_OBJ(glTexImage1D, m_textures, TextureObjectMap::callOnBoundObject);
-    MAP_OBJ(glTexImage2D, m_textures, TextureObjectMap::callOnBoundObject);
+    MAP_OBJ_RV(glTexImage1D, m_textures, TextureObjectMap::callOnBoundObjectWithDepBoundTo,
+               m_buffers, GL_PIXEL_UNPACK_BUFFER);
+    MAP_OBJ_RV(glTexImage2D, m_textures, TextureObjectMap::callOnBoundObjectWithDepBoundTo,
+               m_buffers, GL_PIXEL_UNPACK_BUFFER);
+    MAP_OBJ_RV(glTexImage3D, m_textures, TextureObjectMap::callOnBoundObjectWithDepBoundTo,
+               m_buffers, GL_PIXEL_UNPACK_BUFFER);
     MAP_OBJ(glTexStorage1D, m_textures, TextureObjectMap::callOnBoundObject);
     MAP_OBJ(glTexStorage2D, m_textures, TextureObjectMap::callOnBoundObject);
     MAP_OBJ(glTexStorage3D, m_textures, TextureObjectMap::callOnBoundObject);

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -583,7 +583,7 @@ FrameTrimmeImpl::registerBufferCalls()
     MAP_OBJ(glMapNamedBuffer, m_buffers, BufferObjectMap::namedMap);
     MAP_OBJ(glMapNamedBufferRange, m_buffers, BufferObjectMap::namedMapRange);
     MAP_OBJ(glUnmapNamedBuffer, m_buffers, BufferObjectMap::namedUnmap);
-    MAP_OBJ(glMapBufferRange, m_buffers, BufferObjectMap::map_range);
+    MAP_OBJ(glMapBufferRange, m_buffers, BufferObjectMap::mapRange);
     MAP_OBJ_RR(memcpy, m_buffers, BufferObjectMap::memcopy, m_required_calls, m_recording_frame);
     MAP_OBJ(glFlushMappedBufferRange, m_buffers, BufferObjectMap::callOnBoundObject);
     MAP_OBJ(glFlushMappedNamedBufferRange, m_buffers, BufferObjectMap::callOnNamedObject);

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -565,10 +565,10 @@ FrameTrimmeImpl::registerBufferCalls()
     MAP_OBJ(glDeleteBuffers, m_buffers, BufferObjectMap::destroy);
 
     MAP(glBindBuffer, oglBindBuffer);
-    MAP_RV(glBindBufferRange, oglBind, m_buffers, 2);
+    MAP_OBJ(glBindBufferRange, m_buffers, BufferObjectMap::bindBuffer);
 
     /* This will need a bit more to be handled correctly */
-    MAP_RV(glBindBufferBase, oglBind, m_buffers, 2);
+    MAP_OBJ(glBindBufferBase, m_buffers, BufferObjectMap::bindBuffer);
 
     MAP_OBJ(glBufferData, m_buffers, BufferObjectMap::data);
     MAP_OBJ(glBufferStorage, m_buffers, BufferObjectMap::data);


### PR DESCRIPTION
- keep MSAA info in trace (fixes the gltrim tests that broke when we started to replay with the MSAA info)
- fix buffer bindings, mapping and unmapping 
- fix reading textures from unpack buffers 
- add proper support for BindVertexArray
