### PR TITLE
retrace: remove redundant comparison for the --driver option values

### DIFF
--- a/retrace/retrace_main.cpp
+++ b/retrace/retrace_main.cpp
@@ -1101,8 +1101,6 @@ int main(int argc, char **argv)
                 driver = DRIVER_INTEGRATED;
             } else if (strcasecmp(optarg, "sw") == 0) {
                 driver = DRIVER_SOFTWARE;
-            } else if (strcasecmp(optarg, "sw") == 0) {
-                driver = DRIVER_SOFTWARE;
             } else if (strcasecmp(optarg, "ref") == 0) {
                 driver = DRIVER_REFERENCE;
             } else if (strcasecmp(optarg, "null") == 0) {


### PR DESCRIPTION
Found upon inspection.

Fixes: 93ac817a ("d3dretrace: Partial support for choosing discrete/integrated GPU.")

Signed-off-by: Andres Gomez <agomez@igalia.com>