### PR TITLE
gltrim: some more fixes and handling of additional calls

### DIFF
--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -776,6 +776,11 @@ bool TextureObjectMap::setTargetType(unsigned id, unsigned target)
     if (!id)
         return true;
     auto tex = getById(id);
+    if (!tex) {
+        tex = std::make_shared<UsedObject>(id);
+        addObject(id, tex);
+    }
+
     unsigned old_target = tex->extraInfo("target");
     if (!old_target)
         tex->setExtraInfo("target", target);

--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -485,6 +485,8 @@ BufferObjectMap::getBindpoint(unsigned target, unsigned index) const
         return bt_tf  + bt_last * index;
     case GL_UNIFORM_BUFFER:
         return bt_uniform + bt_last * index;
+    case GL_PARAMETER_BUFFER:
+        return bt_parameter;
     }
     std::cerr << "Unknown buffer binding target=" << target << "\n";
     assert(0);

--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -995,14 +995,7 @@ FramebufferObjectMap::FramebufferObjectMap()
 unsigned
 FramebufferObjectMap::getBindpointFromCall(const trace::Call& call) const
 {
-    switch (call.arg(0).toUInt()) {
-    case GL_FRAMEBUFFER:
-    case GL_DRAW_FRAMEBUFFER:
-        return GL_DRAW_FRAMEBUFFER;
-    case GL_READ_FRAMEBUFFER:
-        return GL_READ_FRAMEBUFFER;
-    }
-    return 0;
+    return call.arg(0).toUInt();
 }
 
 UsedObject::Pointer
@@ -1016,8 +1009,9 @@ FramebufferObjectMap::bindTarget(unsigned id, unsigned bindpoint)
     }
 
     if (bindpoint == GL_FRAMEBUFFER ||
-        bindpoint == GL_READ_FRAMEBUFFER)
+        bindpoint == GL_READ_FRAMEBUFFER) {
         obj = bind(GL_READ_FRAMEBUFFER, id);
+    }
 
     return obj;
 }
@@ -1037,7 +1031,12 @@ void
 FramebufferObjectMap::oglReadBuffer(const trace::Call& call)
 {
     auto fbo = boundTo(GL_READ_FRAMEBUFFER);
-    assert(call.arg(0).toUInt() != GL_BACK || fbo->id() == 0);
+    if (call.arg(0).toUInt() == GL_BACK && fbo->id() != 0) {
+        std::cerr << "\nFBO " << fbo->id()
+                  << " bound, but trying to bind GL_BACK as readbuffer in call "
+                  << call.no << "\n";
+        assert(0);
+    }
     callOnObjectBoundTo(call, GL_READ_FRAMEBUFFER);
 }
 

--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -148,6 +148,7 @@ public:
         bt_texture,
         bt_tf,
         bt_uniform,
+        bt_parameter,
         bt_names_access,
         bt_last,
     };

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -486,10 +486,6 @@ void FrameTrimmeImpl::registerLegacyCalls()
     MAP(glGenLists, oglGenLists);
     MAP(glNewList, oglNewList);
 
-    MAP(glPushClientAttr, todo);
-    MAP(glPopClientAttr, todo);
-
-
     // shader calls
     MAP_OBJ(glGenPrograms, m_legacy_programs,
                DependecyObjectWithDefaultBindPointMap::generate);
@@ -504,6 +500,11 @@ void FrameTrimmeImpl::registerLegacyCalls()
                LegacyProgrambjectMap::callOnBoundObject);
     MAP_OBJ(glProgramEnvParameter, m_legacy_programs,
                LegacyProgrambjectMap::callOnBoundObject);
+
+    MAP_OBJ(glNamedProgramLocalParameter, m_legacy_programs,
+               LegacyProgrambjectMap::callOnNamedObject);
+    MAP_OBJ(glNamedProgramEnvParameter, m_legacy_programs,
+               LegacyProgrambjectMap::callOnNamedObject);
 
     // Matrix manipulation
     MAP_OBJ(glLoadIdentity, m_matrix_states, AllMatrisStates::loadIdentity);
@@ -750,6 +751,8 @@ FrameTrimmeImpl::registerStateCalls()
         "glPolygonMode",
         "glPolygonOffset",
         "glPolygonStipple",
+        "glPopAttrib",
+        "glPopClientAttrib",
         "glProvokingVertex",
         "glPrimitiveBoundingBox",
         "glSampleCoverage",
@@ -766,6 +769,7 @@ FrameTrimmeImpl::registerStateCalls()
     /* These are state functions with an extra parameter */
 
     const std::vector<const char *> state_calls_1  = {
+        "glActiveStencilFace",
         "glClipPlane",
         "glColorMaskIndexedEXT",
         "glColorMaterial",
@@ -773,9 +777,13 @@ FrameTrimmeImpl::registerStateCalls()
         "glHint",
         "glLight",
         "glPixelTransfer",
+        "glPushAttrib",
+        "glPushClientAttrib",
+        "glRenderMode",
         "glStencilOpSeparate",
         "glStencilFuncSeparate",
         "glVertexAttribDivisor",
+        "glMultiTexCoord",
     };
 
     /* These are state functions with an extra parameter */

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -1284,18 +1284,15 @@ FrameTrimmeImpl::oglBindVertexArray(const trace::Call& call)
 {
     auto vao = m_vertex_arrays.bind(call, 0);
     global_state.current_vao = vao;
-    if (vao)
+    if (vao) {
         vao->addCall(trace2call(call));
-    else
-        m_vertex_arrays.addCall(trace2call(call));
-
-    if (global_state.emit_dependencies)
-        vao->emitCallsTo(*global_state.out_list);
-    else {
+        if (global_state.emit_dependencies)
+            vao->emitCallsTo(*global_state.out_list);
         auto fb = m_fbo.boundTo(GL_DRAW_FRAMEBUFFER);
         if (fb->id())
             fb->addDependency(vao);
-    }
+    } else
+        m_vertex_arrays.addCall(trace2call(call));
 }
 
 }


### PR DESCRIPTION

- glRenderMode,
- glPushAttrib, glPopAttrib, glClientPushAttrib, glPopClientAttrib
- glNamedProgramLocalParameter
- glNamedProgramEnvParameter
- glActiveStencilFace
- glMultiTexCoord
- OpenGL 2.1 allows a texture to be created with the bind call so add the texture object on bind if it doesn't exist
- avoid segfault when the vertex array is unbound
