### PR TITLE
specs/glxapi: Make GLX_SAMPELES and GLX_SAMPLE_BUFFERS accept int

### DIFF
--- a/specs/glxapi.py
+++ b/specs/glxapi.py
@@ -298,8 +298,8 @@ GLXCommonAttribs = [
     ('GLX_TRANSPARENT_GREEN_VALUE', Int),
     ('GLX_TRANSPARENT_BLUE_VALUE', Int),
     ('GLX_TRANSPARENT_ALPHA_VALUE', Int),
-    ('GLX_SAMPLE_BUFFERS', UInt),
-    ('GLX_SAMPLES', UInt),
+    ('GLX_SAMPLE_BUFFERS', Int),
+    ('GLX_SAMPLES', Int),
 ]
 
 GLXVisualAttribs = AttribArray(GLXEnum, GLXCommonAttribs + [


### PR DESCRIPTION
The call to glXChooseFBConfig defines the attrib_list as pointer to int.
Fixes replaying and traces of "Lifeless Planet"


Remark: Maybe all the values should be defined as Int. 