### PR TITLE
Add support for newer DXGI, misc fixes

### DIFF
--- a/retrace/dxgiretrace.py
+++ b/retrace/dxgiretrace.py
@@ -191,6 +191,22 @@ class D3DRetracer(Retracer):
             print(r'    }')
             return
 
+        if interface.name.startswith('IDXGIFactory') and method.name.startswith('EnumAdapterByLuid'):
+            print(r'    retrace::warning(call) << "ignoring adapter LUID, returning adapter 0\n";')
+            print(r'    if (retrace::driver != retrace::DRIVER_DEFAULT) {')
+            print(r'        _result = d3dretrace::createAdapter(_this, riid, ppvAdapter);')
+            print(r'    } else {')
+            print(r'        if (ppvAdapter)')
+            print(r'            *ppvAdapter = nullptr;')
+            print(r'        IDXGIAdapter1 *_temp_adapter;')
+            print(r'        _result = _this->EnumAdapters1(0, &_temp_adapter);')
+            print(r'        if (SUCCEEDED(_result)) {')
+            print(r'            _result = _temp_adapter->QueryInterface(riid, ppvAdapter);')
+            print(r'            _temp_adapter->Release();')
+            print(r'        }')
+            print(r'    }')
+            return
+
         if interface.name.startswith('IDXGIFactory') and method.name.startswith('EnumAdapterByGpuPreference'):
             print(r'    if (Adapter != 0) {')
             print(r'        retrace::warning(call) << "ignoring non-default adapter " << Adapter << "\n";')

--- a/retrace/dxgiretrace.py
+++ b/retrace/dxgiretrace.py
@@ -191,6 +191,18 @@ class D3DRetracer(Retracer):
             print(r'    }')
             return
 
+        if interface.name.startswith('IDXGIFactory') and method.name.startswith('EnumAdapterByGpuPreference'):
+            print(r'    if (Adapter != 0) {')
+            print(r'        retrace::warning(call) << "ignoring non-default adapter " << Adapter << "\n";')
+            print(r'        Adapter = 0;')
+            print(r'    }')
+            print(r'    if (retrace::driver != retrace::DRIVER_DEFAULT) {')
+            print(r'        _result = d3dretrace::createAdapter(_this, riid, ppvAdapter);')
+            print(r'    } else {')
+            Retracer.doInvokeInterfaceMethod(self, interface, method)
+            print(r'    }')
+            return
+
         if interface.name.startswith('IDXGIFactory') and method.name == 'CreateSoftwareAdapter':
             print(r'    const char *szSoftware = NULL;')
             print(r'    switch (retrace::driver) {')

--- a/retrace/retrace_swizzle.cpp
+++ b/retrace/retrace_swizzle.cpp
@@ -56,9 +56,9 @@ contains(RegionMap::iterator &it, unsigned long long address) {
 
 static inline bool
 intersects(RegionMap::iterator &it, unsigned long long start, unsigned long long size) {
-    unsigned long it_start = it->first;
-    unsigned long it_stop  = it->first + it->second.size;
-    unsigned long stop = start + size;
+    unsigned long long it_start = it->first;
+    unsigned long long it_stop  = it->first + it->second.size;
+    unsigned long long stop = start + size;
     return it_start < stop && start < it_stop;
 }
 

--- a/specs/dxgi.py
+++ b/specs/dxgi.py
@@ -1136,6 +1136,7 @@ DXGI_GPU_PREFERENCE = Enum('DXGI_GPU_PREFERENCE', [
 ])
 
 IDXGIFactory6 = Interface('IDXGIFactory6', IDXGIFactory5)
+IDXGIFactory7 = Interface('IDXGIFactory7', IDXGIFactory6)
 IDXGIAdapter4 = Interface('IDXGIAdapter4', IDXGIAdapter3)
 IDXGIOutput6 = Interface('IDXGIOutput6', IDXGIOutput5)
 
@@ -1152,7 +1153,13 @@ IDXGIFactory6.methods += [
     StdMethod(HRESULT, 'EnumAdapterByGpuPreference', [(UINT, 'Adapter'), (DXGI_GPU_PREFERENCE, 'GpuPreference'), (REFIID, 'riid'), Out(Pointer(ObjPointer(Void)), 'ppvAdapter')]),
 ]
 
+IDXGIFactory7.methods += [
+    StdMethod(HRESULT, 'RegisterAdaptersChangedEvent', [(HANDLE, 'hEvent'), Out(Pointer(DWORD), 'pdwCookie')], sideeffects=False),
+    StdMethod(HRESULT, 'UnregisterAdaptersChangedEvent', [(DWORD, 'dwCookie')], sideeffects=False),
+]
+
 dxgi.addInterfaces([
+    IDXGIFactory7,
     IDXGIFactory6,
     IDXGIAdapter4,
     IDXGIOutput6,


### PR DESCRIPTION
 - Adds support for IDXGIFactory7
 - Fixes non-default adapters in `EnumAdapterByGpuPreference`
 - Handles returning non-default adapters for EnumAdapterByLuid (these are never going to match up)
 - Fix the `intersects` region call on 64-bit