### PR TITLE
Fix calculation of vertex attribute count

### DIFF
--- a/retrace/glstate_shaders.cpp
+++ b/retrace/glstate_shaders.cpp
@@ -988,11 +988,11 @@ dumpVertexAttributes(StateWriter &writer, Context &context, GLint program)
         }
 
         attrib.desc = desc;
-        GLsizei attribSize = attrib.desc.arrayStride;
+        GLsizei attribSize = attrib.desc.numCols * attrib.desc.colStride;
 
         if (stride == 0) {
             // tightly packed
-            stride = attribSize;
+            stride = attrib.desc.arrayStride;
         }
 
         attrib.offset = offset;


### PR DESCRIPTION
Current code relies on there being only one attribute per stride, and
gives wrong results when this assumption is broken. This patch fixes
this and closes #751.