### PR TITLE
glretrace: Don't try to get pointer for buffer '0' in DeleteBuffers

### DIFF
--- a/retrace/glretrace.py
+++ b/retrace/glretrace.py
@@ -307,6 +307,8 @@ class GlRetracer(Retracer):
             print(r'    if (currentContext && currentContext->features().ARB_direct_state_access) {')
             print(r'        for (GLsizei i = 0; i < n; ++i) {')
             print(r'            GLvoid *ptr = nullptr;')
+            print(r'            if (!buffers[i])')
+            print(r'                   continue;')
             print(r'            glGetNamedBufferPointerv(buffers[i], GL_BUFFER_MAP_POINTER, &ptr);')
             print(r'            if (ptr) {')
             print(r'                retrace::delRegionByPointer(ptr);')


### PR DESCRIPTION
glDeleteBuffers ignores non-existing buffers names, and especially '0',
but calling glGetNamedBufferPointerv on a non-existing buffer results in
an error 'GL_INVALID_OPERATION'. To avoid this error skip over buffer '0'
when handling the region pointers.

Signed-off-by: Gert Wollny <gert.wollny@collabora.com>