### PR TITLE
glretrace: Handle glViewport better.

### DIFF
--- a/retrace/glretrace.hpp
+++ b/retrace/glretrace.hpp
@@ -80,6 +80,8 @@ public:
     bool insideBeginEnd = false;
     bool insideList = false;
     bool needsFlush = false;
+    int width;
+    int height;
 
     bool used = false;
 

--- a/retrace/glretrace.py
+++ b/retrace/glretrace.py
@@ -219,6 +219,9 @@ class GlRetracer(Retracer):
            print(r'    }')
 
         # Post-snapshots
+        if self.bind_framebuffer_function_regex.match(function.name):
+            print('    if (!framebuffer && target != GL_READ_FRAMEBUFFER)')
+            print('        glretrace::updateDrawable(-1, -1);')
         if function.name in ('glFlush', 'glFinish'):
             print('    if (!retrace::doubleBuffer) {')
             print('        glretrace::frame_complete(call);')

--- a/retrace/glretrace_ws.cpp
+++ b/retrace/glretrace_ws.cpp
@@ -234,6 +234,14 @@ updateDrawable(int width, int height) {
         return;
     }
 
+    if (width < 0 && height < 0) {
+        width = currentContext->width;
+        height = currentContext->height;
+    } else if (width > 0 && height > 0) {
+        currentContext->width = width;
+        currentContext->height = height;
+    }
+
     if (currentDrawable->pbuffer) {
         return;
     }


### PR DESCRIPTION
If a user call glViewport with non default framebuffer bind first,
and then bind the default framebuffer to draw, the current apitrace
won't show anything on screen and complain glViewport hasn't been
called yet. Fix this by caching the width/height value in current
context.