### PR TITLE
egltrace: implement eglSetDamageRegion/eglSwapBuffersWithDamage on retrace

### DIFF
--- a/retrace/glretrace_egl.cpp
+++ b/retrace/glretrace_egl.cpp
@@ -118,6 +118,23 @@ static void createDrawable(unsigned long long orig_config, unsigned long long or
     drawable_map[orig_surface] = drawable;
 }
 
+static void retrace_eglSetDamageRegionKHR(trace::Call &call)
+{
+    glws::Drawable *drawable = getDrawable(call.arg(1).toUIntPtr());
+    trace::Array *rects_array = call.arg(2).toArray();
+    EGLint nrects = call.arg(3).toUInt();
+
+    if (!drawable)
+        return;
+
+    int *rects = new int[nrects*4];
+    for (size_t i = 0; i < (size_t)nrects*4; i++)
+        rects[i] = rects_array->values[i]->toSInt();
+
+    drawable->setDamageRegion(rects, nrects);
+    delete [] rects;
+}
+
 static void retrace_eglChooseConfig(trace::Call &call) {
     if (!call.ret->toSInt()) {
         return;
@@ -326,7 +343,7 @@ const retrace::Entry glretrace::egl_callbacks[] = {
     {"eglWaitGL", &retrace::ignore},
     {"eglWaitNative", &retrace::ignore},
     {"eglReleaseThread", &retrace::ignore},
-    {"eglSetDamageRegionKHR", &retrace::ignore},
+    {"eglSetDamageRegionKHR", &retrace_eglSetDamageRegionKHR},
     {"eglSwapBuffers", &retrace_eglSwapBuffers},
     {"eglSwapBuffersWithDamageEXT", &retrace_eglSwapBuffers},  // ignores additional params
     {"eglSwapBuffersWithDamageKHR", &retrace_eglSwapBuffers},  // ignores additional params

--- a/retrace/glws.hpp
+++ b/retrace/glws.hpp
@@ -148,6 +148,8 @@ public:
         visible = true;
     }
 
+    virtual void setDamageRegion(int *rects, int nrects) {}
+
     virtual void setName(const char *name) {}
 
     virtual void copySubBuffer(int x, int y, int width, int height);

--- a/retrace/glws.hpp
+++ b/retrace/glws.hpp
@@ -155,6 +155,8 @@ public:
     virtual void copySubBuffer(int x, int y, int width, int height);
 
     virtual void swapBuffers(void) = 0;
+
+    virtual void swapBuffersWithDamage(int *rects, int nrects) {}
 };
 
 

--- a/retrace/glws_egl_xlib.cpp
+++ b/retrace/glws_egl_xlib.cpp
@@ -228,6 +228,15 @@ public:
         eglSwapBuffers(eglDisplay, surface);
         processKeys(window);
     }
+
+    void swapBuffersWithDamage(int *rects, int nrects) override {
+        if (!checkExtension("EGL_KHR_swap_buffers_with_damage", eglExtensions))
+            return;
+
+        bindAPI(api);
+        eglSwapBuffersWithDamageEXT(eglDisplay, surface, rects, nrects);
+        processKeys(window);
+    }
 };
 
 

--- a/retrace/glws_egl_xlib.cpp
+++ b/retrace/glws_egl_xlib.cpp
@@ -130,6 +130,16 @@ public:
     }
 
     void
+    setDamageRegion(int *rects, int nrects) override {
+        if (!checkExtension("EGL_KHR_partial_update", eglExtensions))
+            return;
+
+        EGLint value;
+        eglQuerySurface(eglDisplay, surface, EGL_BUFFER_AGE_KHR, &value);
+        eglSetDamageRegionKHR(eglDisplay, surface, rects, nrects);
+    }
+
+    void
     recreate(void) {
         EGLContext currentContext = eglGetCurrentContext();
         EGLSurface currentDrawSurface = eglGetCurrentSurface(EGL_DRAW);


### PR DESCRIPTION
These seem to be functional, although I'm not sure if this is the correct way to implement it in apitrace. Just let me know if something can be improved.