### PR TITLE
retrace: Add support for spoofing GetModuleFileNameW

### DIFF
--- a/retrace/process_name.cpp
+++ b/retrace/process_name.cpp
@@ -190,14 +190,6 @@ setProcessName(const char *processName)
     if (!bHooked) {
         bHooked = TRUE;
 
-        // XXX: mhook doesn't work reliably on Wine
-        // http://wiki.winehq.org/DeveloperFaq#detect-wine
-        HMODULE hNtDll = GetModuleHandleA("ntdll");
-        if (hNtDll &&
-            GetProcAddress(hNtDll, "wine_get_version") != nullptr) {
-            return;
-        }
-
         LPVOID lpOrigAddress = (LPVOID)GetProcAddress(GetModuleHandleA("kernel32"), "GetModuleFileNameA");
         if (lpOrigAddress) {
             LPVOID lpHookAddress = (LPVOID)&MyGetModuleFileNameA;


### PR DESCRIPTION
We use this in DXVK for app profiles so we need this to be spoofed like this too on retrace.

Signed-off-by: Joshua Ashton <joshua@froggi.es>