### PR TITLE
More config overrides

### DIFF
--- a/helpers/floating_point_conversion.hpp
+++ b/helpers/floating_point_conversion.hpp
@@ -1,0 +1,106 @@
+
+/* The code for converting fp11 and fp10 values to fp32 is taken from Mesa:
+ *
+ * Copyright (C) 2011 Marek Olšák <maraeo@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef FLOATING_POINT_CONVERSION_H
+#define FLOATING_POINT_CONVERSION_H
+
+#include <stdint.h>
+
+#define UF11_EXPONENT_SHIFT  6
+#define UF10_EXPONENT_SHIFT  5
+#define F32_INFINITY         0x7f800000
+
+inline static float
+uint11ToFLoat(unsigned int val)
+{
+    union {
+       float f;
+       uint32_t ui;
+    } f32;
+
+    int exponent = (val & 0x07c0) >> UF11_EXPONENT_SHIFT;
+    int mantissa = (val & 0x003f);
+
+    f32.f = 0.0;
+
+    if (exponent == 0) {
+       if (mantissa != 0) {
+          const float scale = 1.0 / (1 << 20);
+          f32.f = scale * mantissa;
+       }
+    } else if (exponent == 31) {
+       f32.ui = F32_INFINITY | mantissa;
+    } else {
+       float scale, decimal;
+       exponent -= 15;
+       if (exponent < 0) {
+          scale = 1.0f / (1 << -exponent);
+       } else {
+          scale = (float) (1 << exponent);
+       }
+       decimal = 1.0f + (float) mantissa / 64;
+       f32.f = scale * decimal;
+    }
+
+    return f32.f;
+}
+
+inline static float
+uint10ToFLoat(unsigned int val)
+{
+   union {
+      float f;
+      uint32_t ui;
+   } f32;
+
+   int exponent = (val & 0x03e0) >> UF10_EXPONENT_SHIFT;
+   int mantissa = (val & 0x001f);
+
+   f32.f = 0.0;
+
+   if (exponent == 0) {
+      if (mantissa != 0) {
+         const float scale = 1.0 / (1 << 19);
+         f32.f = scale * mantissa;
+      }
+   } else if (exponent == 31) {
+      f32.ui = F32_INFINITY | mantissa;
+   } else {
+      float scale, decimal;
+      exponent -= 15;
+      if (exponent < 0) {
+         scale = 1.0f / (1 << -exponent);
+      }
+      else {
+         scale = (float) (1 << exponent);
+      }
+      decimal = 1.0f + (float) mantissa / 32;
+      f32.f = scale * decimal;
+   }
+
+   return f32.f;
+}
+
+#endif // FLOATING_POINT_CONVERSION_H

--- a/retrace/glstate_shaders.cpp
+++ b/retrace/glstate_shaders.cpp
@@ -40,7 +40,7 @@
 #include "glstate.hpp"
 #include "glstate_internal.hpp"
 #include "halffloat.hpp"
-
+#include "floating_point_conversion.hpp"
 
 namespace glstate {
 
@@ -373,6 +373,18 @@ dumpAttrib(StateWriter &writer,
                 break;
             case GL_BOOL:
                 writer.writeBool(*u.uivalue);
+                break;
+            case GL_INT_2_10_10_10_REV:
+            case GL_UNSIGNED_INT_2_10_10_10_REV:
+                writer.writeInt(*u.ivalue & 0x3ff);
+                writer.writeInt((*u.ivalue >> 10) & 0x3ff);
+                writer.writeInt((*u.ivalue >> 20) & 0x3ff);
+                writer.writeInt((*u.ivalue >> 30) & 0x3);
+                break;
+            case GL_UNSIGNED_INT_10F_11F_11F_REV:
+                writer.writeFloat(uint11ToFLoat(*u.ivalue & 0x7ff));
+                writer.writeFloat(uint11ToFLoat((*u.ivalue >> 11) & 0x7ff));
+                writer.writeFloat(uint10ToFLoat((*u.ivalue >> 21) & 0x3ff));
                 break;
             default:
                 assert(0);

--- a/wrappers/config.cpp
+++ b/wrappers/config.cpp
@@ -274,6 +274,15 @@ parse_file(FILE *f, configuration *conf)
         else if (matchKeyword(b, "GL_MINOR_VERSION")) {
             conf->versionMinor = intValue(f, b + 17);
         }
+        else if (matchKeyword(b, "GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT")) {
+            conf->ubo_offset_alignment = intValue(f, b + 35);
+        }
+        else if (matchKeyword(b, "GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT")) {
+            conf->tbo_offset_alignment = intValue(f, b + 35);
+        }
+        else if (matchKeyword(b, "GL_STORAGE_BUFFER_OFFSET_ALIGNMENT")) {
+            conf->ssbo_offset_alignment = intValue(f, b + 35);
+        }
         else if (matchKeyword(b, "GL_CONTEXT_PROFILE_MASK")) {
             std::string maskStr = stringValue(f, b + 24);
             conf->profileMask = 0x0;
@@ -350,6 +359,10 @@ readConfigFile(const char *filename)
         os::log("apitrace: config GL_MAJOR_VERSION = %d\n", conf->versionMajor);
         os::log("apitrace: config GL_MINOR_VERSION = %d\n", conf->versionMinor);
         os::log("apitrace: config GL_CONTEXT_PROFILE_MASK = 0x%x\n", conf->profileMask);
+        os::log("apitrace: config GL_CONTEXT_PROFILE_MASK = 0x%x\n", conf->profileMask);
+        os::log("apitrace: config GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT = %d\n", conf->ubo_offset_alignment);
+        os::log("apitrace: config GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT = %d\n", conf->tbo_offset_alignment);
+        os::log("apitrace: config GL_STORAGE_BUFFER_OFFSET_ALIGNMENT = %d\n", conf->ssbo_offset_alignment);
     }
 
     return conf;

--- a/wrappers/config.cpp
+++ b/wrappers/config.cpp
@@ -390,15 +390,15 @@ getConfigString(const configuration *config, GLenum pname)
 
     switch (pname) {
     case GL_VERSION:
-        return (const GLubyte *) config->version.c_str();
+        return !config->version.empty() ? (const GLubyte *) config->version.c_str() : NULL;
     case GL_VENDOR:
-        return (const GLubyte *) config->vendor.c_str();
+        return !config->vendor.empty() ? (const GLubyte *) config->vendor.c_str() : NULL;
     case GL_EXTENSIONS:
-        return (const GLubyte *) config->extensions.c_str();
+        return !config->extensions.empty() ? (const GLubyte *) config->extensions.c_str() : NULL;
     case GL_RENDERER:
-        return (const GLubyte *) config->renderer.c_str();
+        return !config->renderer.empty() ? (const GLubyte *) config->renderer.c_str() : NULL;
     case GL_SHADING_LANGUAGE_VERSION:
-        return (const GLubyte *) config->glslVersion.c_str();
+        return !config->glslVersion.empty() ? (const GLubyte *) config->glslVersion.c_str() : NULL;
     default:
         return NULL;
     }

--- a/wrappers/config.hpp
+++ b/wrappers/config.hpp
@@ -45,6 +45,9 @@ struct configuration
     int maxTextureSize;  // 2D texture size
     int numExtensions;
     char **extensionsList;
+    int ubo_offset_alignment;
+    int tbo_offset_alignment;
+    int ssbo_offset_alignment;
 
     inline
     configuration() :
@@ -53,7 +56,10 @@ struct configuration
         profileMask(0),
         maxTextureSize(0),
         numExtensions(0),
-        extensionsList(0)
+        extensionsList(0),
+        ubo_offset_alignment(0),
+        tbo_offset_alignment(0),
+        ssbo_offset_alignment(0)
     {}
 };
 

--- a/wrappers/glcaps.cpp
+++ b/wrappers/glcaps.cpp
@@ -273,6 +273,18 @@ _glGetIntegerv_override(GLenum pname, GLint *params)
                 params[0] = 4096;
             }
             break;
+        case GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT:
+            if (config->ubo_offset_alignment > params[0])
+                params[0] = config->ubo_offset_alignment;
+            break;
+        case GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT:
+            if (config->tbo_offset_alignment > params[0])
+                params[0] = config->tbo_offset_alignment;
+            break;
+        case GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT:
+            if (config->ssbo_offset_alignment > params[0])
+                params[0] = config->ssbo_offset_alignment;
+            break;
         }
     }
 }


### PR DESCRIPTION
The first patch fixes a bug when an incomplete set of configuration values was given in the config file. In this case we should fall back to the values provided by the driver. 

The second patch adds the possibility to set minimum values for buffer alignment offsets, so that one can prepare a trace on one type of hardware that might set lower limits than some other hardware one wants to replay the traces on. 

