### PR TITLE
frametrim: fix active texture check compare

### DIFF
--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -810,7 +810,7 @@ TextureObjectMap::oglActiveTexture(const trace::Call& call)
 {
     unsigned active_texture = call.arg(0).toUInt() - GL_TEXTURE0;
 
-    if (active_texture < GL_TEXTURE31 - GL_TEXTURE0) {
+    if (active_texture <= GL_TEXTURE31 - GL_TEXTURE0) {
         m_active_texture = active_texture;
         addCall(trace2call(call));
     } else {


### PR DESCRIPTION
Fixes:
```
26916: glActiveTexture Invalid texture unit 34015 specified, ignoring call
```
Found-by: Gert Wollny <gert.wollny@collabora.com>
Signed-off-by: David Heidelberg <david.heidelberg@collabora.com>