### PR TITLE
 glretrace: Add possibility to check for a lost context

### DIFF
--- a/helpers/glfeatures.cpp
+++ b/helpers/glfeatures.cpp
@@ -375,6 +375,8 @@ Features::load(const Profile & profile, const Extensions & ext)
                             ext.has("GL_NV_primitive_restart");
 
         unpack_subimage = 1;
+
+        support_reset_notification = ext.has("GL_ARB_robustness");
     } else {
         texture_3d = 1;
 
@@ -398,6 +400,8 @@ Features::load(const Profile & profile, const Extensions & ext)
         primitive_restart = 0;
 
         unpack_subimage = ext.has("GL_EXT_unpack_subimage");
+        support_reset_notification = profile.versionGreaterOrEqual(3, 2) ||
+                ext.has("GL_EXT_robustness");
     }
 }
 

--- a/helpers/glfeatures.hpp
+++ b/helpers/glfeatures.hpp
@@ -53,6 +53,7 @@ struct Profile {
     unsigned api:1;
     unsigned core:1;
     unsigned forwardCompatible:1;
+    bool notifyLostContext:1;
 
     inline
     Profile(
@@ -68,6 +69,7 @@ struct Profile {
         samples = 1;
         core = _core;
         forwardCompatible = _forwardCompatible;
+        notifyLostContext = false;
     }
 
     inline bool

--- a/helpers/glfeatures.hpp
+++ b/helpers/glfeatures.hpp
@@ -166,6 +166,7 @@ struct Features
     unsigned query_buffer_object:1;
     unsigned primitive_restart:1;
     unsigned unpack_subimage:1;
+    unsigned support_reset_notification:1;
 
     Features(void);
 

--- a/retrace/glretrace_egl.cpp
+++ b/retrace/glretrace_egl.cpp
@@ -268,6 +268,8 @@ static void retrace_eglCreateContext(trace::Call &call) {
         break;
     }
 
+    if (retrace::notifyLostContext)
+        profile.notifyLostContext = true;
 
     Context *context = glretrace::createContext(share_context, profile);
     assert(context);
@@ -332,6 +334,14 @@ static void retrace_eglSwapBuffers(trace::Call &call) {
         // Wait for presentation to finish
         glFinish();
         std::cout << "rendering_finished " << glretrace::getCurrentTime() << std::endl;
+    }
+
+    if (retrace::notifyLostContext &&
+        glretrace::getCurrentContext()->features().support_reset_notification) {
+        if (glGetGraphicsResetStatusEXT() != GL_NO_ERROR) {
+            std::cout << "Context was lost aborting rendering" << std::endl;
+            exit(-2);
+        }
     }
 }
 

--- a/retrace/glretrace_glx.cpp
+++ b/retrace/glretrace_glx.cpp
@@ -159,6 +159,16 @@ static void retrace_glXSwapBuffers(trace::Call &call) {
         glFlush();
     }
 
+    if (retrace::notifyLostContext &&
+        glretrace::getCurrentContext()->features().support_reset_notification) {
+        if (glGetGraphicsResetStatus() != GL_NO_ERROR) {
+            std::cerr << "Context was lost, aborting rendering." << std::endl;
+            exit(-2);
+        }
+    }
+
+
+
     if (retrace::profilingFrameTimes) {
         // Wait for presentation to finish
         glFinish();

--- a/retrace/glws_egl_xlib.cpp
+++ b/retrace/glws_egl_xlib.cpp
@@ -44,7 +44,7 @@ namespace glws {
 static EGLDisplay eglDisplay = EGL_NO_DISPLAY;
 static char const *eglExtensions = NULL;
 static bool has_EGL_KHR_create_context = false;
-
+static bool has_EXT_create_context_robustness = false;
 
 static EGLenum
 translateAPI(glfeatures::Profile profile)
@@ -302,6 +302,7 @@ init(void) {
 
     eglExtensions = eglQueryString(eglDisplay, EGL_EXTENSIONS);
     has_EGL_KHR_create_context = checkExtension("EGL_KHR_create_context", eglExtensions);
+    has_EXT_create_context_robustness = checkExtension("EXT_create_context_robustness", eglExtensions);
 }
 
 void
@@ -480,6 +481,10 @@ createContext(const Visual *_visual, Context *shareContext, bool debug)
         assert(0);
         return NULL;
     }
+
+    if (profile.notifyLostContext && has_EXT_create_context_robustness)
+        attribs.add(EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT,
+                    EGL_LOSE_CONTEXT_ON_RESET_EXT);
 
     if (debug) {
         contextFlags |= EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR;

--- a/retrace/glws_glx.cpp
+++ b/retrace/glws_glx.cpp
@@ -44,7 +44,7 @@ static bool has_GLX_EXT_create_context_es2_profile = false;
 static bool has_GLX_EXT_swap_control = false;
 static bool has_GLX_MESA_swap_control = false;
 static bool has_GLX_OML_swap_method = false;
-
+static bool has_GLX_ARB_robustness = false;
 
 class GlxVisual : public Visual
 {
@@ -245,6 +245,7 @@ init(void) {
     CHECK_EXTENSION(GLX_EXT_swap_control);
     CHECK_EXTENSION(GLX_MESA_swap_control);
     CHECK_EXTENSION(GLX_OML_swap_method);
+    CHECK_EXTENSION(GLX_ARB_robustness);
 
 #undef CHECK_EXTENSION
 }
@@ -386,6 +387,10 @@ createContext(const Visual *_visual, Context *shareContext, bool debug)
         }
         if (contextFlags) {
             attribs.add(GLX_CONTEXT_FLAGS_ARB, contextFlags);
+        }
+        if (profile.notifyLostContext && has_GLX_ARB_robustness) {
+            attribs.add(GLX_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB,
+                        GLX_LOSE_CONTEXT_ON_RESET_ARB);
         }
         attribs.end();
 

--- a/retrace/glws_waffle.cpp
+++ b/retrace/glws_waffle.cpp
@@ -217,6 +217,9 @@ createVisual(bool doubleBuffer, unsigned samples, Profile profile) {
         if (profile.forwardCompatible) {
             config_attrib_list.add(WAFFLE_CONTEXT_FORWARD_COMPATIBLE, true);
         }
+        if (profile.notifyLostContext) {
+            config_attrib_list.add(WAFFLE_CONTEXT_LOSE_CONTEXT_ON_RESET, true);
+        }
     }
     config_attrib_list.add(WAFFLE_RED_SIZE, 8);
     config_attrib_list.add(WAFFLE_GREEN_SIZE, 8);

--- a/retrace/retrace.hpp
+++ b/retrace/retrace.hpp
@@ -124,6 +124,12 @@ extern int verbosity;
 extern int debug;
 
 /**
+ * Create robust context and check for lost context
+ */
+extern bool notifyLostContext;
+
+
+/**
  * Call no markers.
  */
 extern bool markers;

--- a/retrace/retrace_main.cpp
+++ b/retrace/retrace_main.cpp
@@ -93,6 +93,7 @@ bool forceWindowed = true;
 bool dumpingState = false;
 bool dumpingSnapshots = false;
 bool watchdogEnabled = false;
+bool notifyLostContext = false;
 
 bool ignoreCalls = false;
 trace::CallSet callsToIgnore;
@@ -818,6 +819,7 @@ usage(const char *argv0) {
         "      --no-context-check  don't check that the actual GL context version matches the requested version\n"
         "      --min-cpu-time=NANOSECONDS  ignore calls with less than this CPU time when profiling (default is 1000)\n"
         "      --ignore-calls=CALLSET    ignore calls in CALLSET\n"
+        "      --notify-lost-context enable context lost notify\n"
         "      --version           display version information and exit\n"
     ;
 }
@@ -859,6 +861,7 @@ enum {
     QUERY_HANDLING_OPT,
     QUERY_CHECK_TOLARANCE_OPT,
     IGNORE_CALLS_OPT,
+    NOTIFY_LOST_CONTEXT_OPT,
     VERSION_OPT,
 };
 
@@ -913,6 +916,7 @@ longOptions[] = {
     {"no-context-check", no_argument, 0, NO_CONTEXT_CHECK},
     {"min-cpu-time", required_argument, 0, MIN_CPU_TIME_OPT},
     {"ignore-calls", required_argument, 0, IGNORE_CALLS_OPT},
+    {"notify-lost-context", no_argument, 0, NOTIFY_LOST_CONTEXT_OPT},
     {"version", no_argument, 0, VERSION_OPT},
     {0, 0, 0, 0}
 };
@@ -1394,6 +1398,9 @@ int main(int argc, char **argv)
         case VERSION_OPT:
             std::cout << "apitrace " << APITRACE_VERSION << std::endl;
             return 0;
+        case NOTIFY_LOST_CONTEXT_OPT:
+            retrace::notifyLostContext = true;
+            break;
         default:
             std::cerr << "error: unknown option " << opt << "\n";
             usage(argv[0]);


### PR DESCRIPTION
Add a command line option to create an EGL context that supports
lost context notification, and check with each rendered frame whether
the context was lost. In that case abort replaying and return an error
code -2.

Closes: https://github.com/apitrace/apitrace/issues/787

Signed-off-by: Gert Wollny <gert.wollny@collabora.com>