### PR TITLE
implement versioning support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,6 +564,17 @@ endif ()
 
 
 ##############################################################################
+# Versioning
+
+find_package(Git)
+add_custom_target(version
+  ${CMAKE_COMMAND} -D SRC=${CMAKE_SOURCE_DIR}/version.h.in
+		   -D DST=${CMAKE_BINARY_DIR}/version.h
+		   -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
+		   -P ${CMAKE_MODULE_PATH}/GenerateVersion.cmake
+  )
+
+##############################################################################
 # Packaging
 
 install (
@@ -579,16 +590,6 @@ install (
     DESTINATION ${DOC_INSTALL_DIR}
     RENAME LICENSE.txt
 )
-
-set (CPACK_PACKAGE_VERSION "latest")
-# https://www.appveyor.com/docs/environment-variables/
-if (($ENV{APPVEYOR}) AND ($ENV{APPVEYOR_REPO_TAG}))
-    set (CPACK_PACKAGE_VERSION "$ENV{APPVEYOR_REPO_TAG_NAME}")
-endif ()
-# https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
-if ("$ENV{GITHUB_ACTIONS}" STREQUAL "true" AND "$ENV{GITHUB_REF}" MATCHES [[^refs/tags/([^/]*)$]])
-    set (CPACK_PACKAGE_VERSION "${CMAKE_MATCH_1}")
-endif ()
 
 # cpack mistakenly detects Mingw-w64 as win32
 if (MINGW)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -17,6 +17,7 @@ endif ()
 include_directories (
     ${CMAKE_SOURCE_DIR}/lib/highlight
     ${CMAKE_SOURCE_DIR}/thirdparty
+    ${CMAKE_BINARY_DIR}
 )
 
 add_executable (apitrace
@@ -46,6 +47,8 @@ target_link_libraries (apitrace
     getopt
     ${CMAKE_DL_LIBS}
 )
+
+add_dependencies(apitrace version)
 
 if (NOT CMAKE_CROSSCOMPILING)
     # On debug builds tell where the source is so that scripts can be found

--- a/cli/cli.hpp
+++ b/cli/cli.hpp
@@ -52,4 +52,5 @@ extern const Command sed_command;
 extern const Command trace_command;
 extern const Command trim_command;
 extern const Command info_command;
+extern const Command version_command;
 extern const Command gltrim_command;

--- a/cli/cli_main.cpp
+++ b/cli/cli_main.cpp
@@ -36,11 +36,13 @@
 #include <iomanip>
 #include <iostream>
 
+#include "version.h"
 #include "cli.hpp"
 
 #define ARRAY_SIZE(arr) (sizeof (arr) / sizeof (arr[0]))
 
 static const char *help_synopsis = "Print detailed help for the given command.";
+static const char *version_synopsis = "Print apitrace version.";
 
 static void list_commands(void);
 
@@ -55,14 +57,32 @@ help_usage()
     list_commands();
 }
 
+static void
+version_usage()
+{
+    std::cout
+        << "usage: apitrace version\n"
+        "\n";
+}
+
 static int
 do_help_command(int argc, char *argv[]);
+
+static int
+do_version_command(int argc, char *argv[]);
 
 const Command help_command = {
     "help",
     help_synopsis,
     help_usage,
     do_help_command
+};
+
+const Command version_command = {
+    "version",
+    version_synopsis,
+    version_usage,
+    do_version_command
 };
 
 static const Command * commands[] = {
@@ -80,6 +100,7 @@ static const Command * commands[] = {
     &trace_command,
     &trim_command,
     &info_command,
+    &version_command,
     &help_command
 };
 
@@ -160,6 +181,13 @@ do_help_command(int argc, char *argv[])
               << " (see \"apitrace help\").\n";
 
     return 1;
+}
+
+static int
+do_version_command(int argc, char *argv[])
+{
+    std::cout << "apitrace " << APITRACE_VERSION << "\n";
+    return 0;
 }
 
 int

--- a/cmake/GenerateVersion.cmake
+++ b/cmake/GenerateVersion.cmake
@@ -1,0 +1,31 @@
+# https://www.appveyor.com/docs/environment-variables/
+if (($ENV{APPVEYOR}) AND ($ENV{APPVEYOR_REPO_TAG}))
+    set (APITRACE_VERSION "$ENV{APPVEYOR_REPO_TAG_NAME}")
+# https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
+elseif ("$ENV{GITHUB_ACTIONS}" STREQUAL "true" AND "$ENV{GITHUB_REF}" MATCHES [[^refs/tags/([^/]*)$]])
+    set (APITRACE_VERSION "${CMAKE_MATCH_1}")
+# git
+elseif (GIT_EXECUTABLE)
+  get_filename_component(SRC_DIR ${SRC} DIRECTORY)
+  # Generate a git-describe version string from Git repository tags
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --match "*"
+    WORKING_DIRECTORY ${SRC_DIR}
+    OUTPUT_VARIABLE GIT_DESCRIBE_VERSION
+    RESULT_VARIABLE GIT_DESCRIBE_ERROR_CODE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  if (NOT GIT_DESCRIBE_ERROR_CODE)
+    set(APITRACE_VERSION ${GIT_DESCRIBE_VERSION})
+  endif ()
+endif ()
+
+if (NOT DEFINED APITRACE_VERSION)
+  set(APITRACE_VERSION 0.0-unknown)
+  message(WARNING "Failed to determine APITRACE_VERSION. Using default version \"${APITRACE_VERSION}\".")
+endif ()
+
+# propagate version into header and cpack
+configure_file(${SRC} ${DST} @ONLY)
+
+set (CPACK_PACKAGE_VERSION "${APITRACE_VERSION}")

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -95,7 +95,10 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories (
     ${CMAKE_SOURCE_DIR}/lib/image
     ${CMAKE_SOURCE_DIR}/lib/ubjson
+    ${CMAKE_BINARY_DIR}
 )
+
+add_dependencies(apitrace version)
 
 add_executable (qapitrace ${qapitrace_SRCS} ${qapitrace_UIS_H})
 

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -8,6 +8,8 @@
 #include "os_string.hpp"
 #include "os_process.hpp"
 
+#include "version.h"
+
 #include <QApplication>
 #include <QMetaType>
 #include <QVariant>
@@ -22,10 +24,15 @@ Q_DECLARE_METATYPE(ImageHash);
 
 static void usage(void)
 {
-    qWarning("usage: qapitrace [options] [TRACE] [CALLNO]\n"
+    qInfo("usage: qapitrace [options] [TRACE] [CALLNO]\n"
              "Valid options include:\n"
              "    -h, --help            Print this help message\n"
+             "    -v, --version         Print version\n"
              "    --remote-target HOST  Replay trace on remote target HOST\n");
+}
+static void version(void)
+{
+    qInfo("qapitrace %s", APITRACE_VERSION);
 }
 
 int main(int argc, char **argv)
@@ -72,6 +79,10 @@ int main(int argc, char **argv)
         } else if (arg == QLatin1String("-h") ||
                    arg == QLatin1String("--help")) {
             usage();
+            exit(0);
+        } else if (arg == QLatin1String("-v") ||
+                   arg == QLatin1String("--version")) {
+            version();
             exit(0);
         } else {
             usage();

--- a/version.h.in
+++ b/version.h.in
@@ -1,0 +1,2 @@
+#pragma once
+#define APITRACE_VERSION "@APITRACE_VERSION@"


### PR DESCRIPTION
Currently supports:
 - `apitrace version`
 - `qapitrace -v` or `qapitrace --version`

when having installed system and custom apitrace from git, it comes handy.

One thing to discuss is dependency on the git.

References: https://github.com/apitrace/apitrace/issues/493#issuecomment-253976844