### PR TITLE
Fix a crash in retrace_glXChooseFBConfig.

### DIFF
--- a/retrace/glretrace_glx.cpp
+++ b/retrace/glretrace_glx.cpp
@@ -240,8 +240,10 @@ static void retrace_glXChooseFBConfig(trace::Call &call) {
 
     if (samples > 0) {
         const auto ids = call.ret->toArray();
-        for (auto& v : ids->values)
-            fbconfig_map[v->toUInt()] = samples;
+        if (ids) {
+            for (auto& v : ids->values)
+                fbconfig_map[v->toUInt()] = samples;
+        }
     }
 }
 


### PR DESCRIPTION
Can be seen when retracing KiCAD's 3D viewer with Mesa 21.2.6 software renderer (llvmpipe)