### PR TITLE
retrace: when waffle_context_create fails, report GL context version

### DIFF
--- a/retrace/glws_waffle.cpp
+++ b/retrace/glws_waffle.cpp
@@ -266,7 +266,7 @@ createContext(const Visual *visual, Context *shareContext,
 
     context = waffle_context_create(waffleVisual->config, share_context);
     if (!context) {
-        std::cerr << "error: waffle_context_create failed\n";
+        std::cerr << "error: failed to create " << waffleVisual->profile << " context.\n";
         exit(1);
         return NULL;
     }


### PR DESCRIPTION
Synchronize error report with non-waffle version and make it a bit useful.

Signed-off-by: David Heidelberg <david.heidelberg@collabora.com>