### PR TITLE
gltrim: retain objects in the last frame that were created in earlier frames 

### DIFF
--- a/frametrim/ft_dependecyobject.cpp
+++ b/frametrim/ft_dependecyobject.cpp
@@ -109,6 +109,14 @@ void UsedObject::eraseExtraInfo(const std::string& key)
     m_extra_info.erase(key);
 }
 
+bool UsedObject::createdBefore(unsigned callno) const
+{
+    if (m_calls.empty())
+        return false;
+
+    return callno > 0 && m_calls[0]->callNo() < callno;
+}
+
 void
 DependecyObjectMap::generate(const trace::Call& call)
 {
@@ -450,7 +458,6 @@ void DependecyObjectMap::addCall(PTraceCall call)
 {
     m_calls.push_back(call);
 }
-
 
 UsedObject::Pointer
 DependecyObjectMap::getById(unsigned id) const

--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -52,6 +52,8 @@ public:
     void setExtraInfo(const std::string& key, unsigned value);
     void eraseExtraInfo(const std::string& key);
 
+    bool createdBefore(unsigned callno) const;
+
 private:
 
     std::vector<PTraceCall> m_calls;

--- a/frametrim/ft_frametrimmer.hpp
+++ b/frametrim/ft_frametrimmer.hpp
@@ -46,6 +46,7 @@ public:
     FrameTrimmer(bool keep_all_states);
     ~FrameTrimmer();
 
+    void start_last_frame(uint32_t callno);
     void call(const trace::Call& call, Frametype target_frame_type);
 
     void finalize();

--- a/frametrim/ft_main.cpp
+++ b/frametrim/ft_main.cpp
@@ -141,6 +141,8 @@ static int trim_to_frame(const char *filename,
     unsigned ncalls2 = 0;
 
     unsigned calls_in_this_frame = 0;
+    bool start_last_frame = false;
+
     while (call) {
         /* There's no use doing any work past the last call and frame
         * requested by the user. */
@@ -151,8 +153,13 @@ static int trim_to_frame(const char *filename,
         Frametype ft = ft_none;
         if (options.setupframes.contains(frame, call->flags))
             ft = ft_key_frame;
-        if (options.frames.contains(frame, call->flags))
+        if (options.frames.contains(frame, call->flags)) {
             ft = ft_retain_frame;
+            if (!start_last_frame && frame == options.frames.getLast()) {
+                start_last_frame = true;
+                trimmer.start_last_frame(call->no);
+            }
+        }
 
         trimmer.call(*call, ft);
 


### PR DESCRIPTION
In order to be able to loop the last frame we must not destroy objects
that are used in the last frame but not created there. For simplicity
only check whether the object was created in the last frame, and not
emit the delete code if it was not.

Remark: 
This doesn't cover all cases where looping the last frame will fail, e.g. buffer mappings or context creation and destruction may also lead to crashes. 
