### PR TITLE
gltrim: handle a few more EGL calls

### DIFF
--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -974,6 +974,8 @@ void FrameTrimmeImpl::registerRequiredCalls()
 
         "eglInitialize",
         "eglCreatePlatformWindowSurface",
+        "eglDestroyContext",
+        "eglDestroySurface",
         "eglBindAPI",
 
         "glPixelStorei", /* Being lazy here, we could track the dependency
@@ -1040,6 +1042,9 @@ void FrameTrimmeImpl::registerIgnoreHistoryCalls()
         "eglGetPlatformDisplay",
         "eglGetConfigs",
         "eglGetConfigAttrib",
+        "eglGetCurrentContext",
+        "eglGetCurrentDisplay",
+        "eglGetCurrentSurface",
         "eglQuerySurface",
      };
     auto ignore_history_func = bind(&FrameTrimmeImpl::ignoreHistory, this, _1);


### PR DESCRIPTION
Just like with the corresponding glX calls ignore
eglGetCurrentContext, eglGetCurrentDisplay, and
eglGetCurrentSurface and keep eglDestroyContext and
eglDestroySurface.

Closes: #808

Signed-off-by: Gert Wollny <gert.wollny@collabora.com>