### PR TITLE
docs: update attachment procedure for trace

### DIFF
--- a/docs/BUGS.markdown
+++ b/docs/BUGS.markdown
@@ -137,7 +137,8 @@ paste the URL into the issue description.
 
 Trace files are only slightly compressed (for performance reasons).  You can
 further reduce their size when attaching/uploading by compressing with
-[XZ](https://tukaani.org/xz/) or [7-Zip](https://www.7-zip.org/).
+`apitrace repack -b`.
+If the hosting service requires archives (for example, Github), you can use gzip on Linux/Mac or zip on Windows, preferably with the weakest compression.
 
 
 # Bugs on tracing #

--- a/docs/BUGS.markdown
+++ b/docs/BUGS.markdown
@@ -125,8 +125,6 @@ issue.
 
 # Attachments #
 
-github issue tracker doesn't support attachments.
-
 Please attach long logs to https://gist.github.com/ and paste the URL into the
 issue description.
 


### PR DESCRIPTION
`apitrace repack -b` seems to be more effective than repacking with xz or lzma.