### PR TITLE
Gltrim skip while looping

### DIFF
--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -54,6 +54,7 @@ public:
 
     bool createdBefore(unsigned callno) const;
 
+    auto calls() { return m_calls; }
 private:
 
     std::vector<PTraceCall> m_calls;
@@ -106,6 +107,9 @@ public:
     void addBoundAsDependencyTo(UsedObject& obj);
 
     UsedObject::Pointer bind(unsigned bindpoint, unsigned id);
+
+    void unbalancedCreateCallsInLastFrame(uint32_t last_frame_start,
+                                          std::unordered_set<unsigned>& outSet);
 
 protected:
     void addObject(unsigned id, UsedObject::Pointer obj);

--- a/frametrim/ft_frametrimmer.hpp
+++ b/frametrim/ft_frametrimmer.hpp
@@ -49,7 +49,7 @@ public:
     void start_last_frame(uint32_t callno);
     void call(const trace::Call& call, Frametype target_frame_type);
 
-    void finalize();
+    std::unordered_set<unsigned> finalize(int last_frame_start);
 
     std::vector<unsigned> getSortedCallIds();
     std::unordered_set<unsigned> getUniqueCallIds();


### PR DESCRIPTION
This is a series to alleviate the problems reported in https://github.com/apitrace/apitrace/issues/839

With these patches a new call flag is added to tag calls that may be dropped after the first time when the last frame is looping. gltrim will tag these calls, and the a new retrace flag is added `--loop-skip-tagged-calls` to actually skip these calls during replay with the final loop. 

Testing with the trace posted in #839 showed a *significant* impact on performance, so using this  flag in a context where the performance is analyzed may not be a good option. 

The nice thing about this approach is that one can simply re-trim already trimmed traces. 

An alternative would be to either inject  object destroy calls for objects that are created but not deleted in the last frame (This is probably not feasible at all in the retracer, because it would mean that it would have to deal with the different backends)  or to let gltrim scan the whole original trace to add these destroy calls to the last frame. 