### PR TITLE
#850. Add a bit of excessive space in image buffer.

### DIFF
--- a/lib/image/image.hpp
+++ b/lib/image/image.hpp
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <assert.h>
 
 #include <iostream>
 
@@ -45,6 +46,7 @@ enum ChannelType {
 
 
 class Image {
+    static const unsigned GUARD_VALUE = 0xdeadc0de;
 public:
     unsigned width;
     unsigned height;
@@ -68,11 +70,17 @@ public:
         channelType(t),
         bytesPerChannel(t == TYPE_FLOAT ? 4 : 1),
         bytesPerPixel(channels * bytesPerChannel),
-        flipped(f),
-        pixels(new unsigned char[h*w*bytesPerPixel])
-    {}
+        flipped(f)
+    {
+        unsigned contentBytes = sizeInBytes();
+        // Additional space to avoid buffer overflow crash in case of a bug in driver
+        unsigned guardBytes = ((h + w) * 4 + 32) * bytesPerPixel;
+        pixels = new unsigned char[contentBytes + guardBytes];
+        memcpy(pixels + contentBytes, &GUARD_VALUE, 4);
+    }
 
     inline ~Image() {
+        assert(memcmp(pixels + sizeInBytes(), &GUARD_VALUE, 4) == 0);
         delete [] pixels;
     }
 

--- a/lib/image/image.hpp
+++ b/lib/image/image.hpp
@@ -47,7 +47,6 @@ enum ChannelType {
 
 
 class Image {
-    static const unsigned GUARD_VALUE = 0xdeadc0de;
 public:
     unsigned width;
     unsigned height;
@@ -77,10 +76,12 @@ public:
         // Additional space to avoid buffer overflow crash in case of a bug in driver
         unsigned guardBytes = ((h + w) * 4 + 32) * bytesPerPixel;
         pixels = new unsigned char[contentBytes + guardBytes];
+        unsigned GUARD_VALUE = 0xdeadc0de;
         memcpy(pixels + contentBytes, &GUARD_VALUE, 4);
     }
 
     inline ~Image() {
+        unsigned GUARD_VALUE = 0xdeadc0de;
         assert(memcmp(pixels + sizeInBytes(), &GUARD_VALUE, 4) == 0);
         delete [] pixels;
     }

--- a/lib/image/image.hpp
+++ b/lib/image/image.hpp
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <assert.h>
+#include <string.h>
 
 #include <iostream>
 


### PR DESCRIPTION
This is done for a rare case of buggy driver, which writes more bytes than we expect (and specs say). I have a particular problem on reading very low-resolution textures on Windows + AMD RX 550, and the problem totally blocks retracing for me.

Note that we write a 4-byte marker immediately after the image contents and assert that it has not changed in destructor. So if driver is buggy, we can see it in Debug build, but Release build simply proceeds.