### PR TITLE
wrappers: add noexcept specification to DWriteCreateFactory

### DIFF
--- a/specs/dwrite.py
+++ b/specs/dwrite.py
@@ -770,7 +770,7 @@ dwrite.addInterfaces([
     IDWriteFactory
 ])
 dwrite.addFunctions([
-    StdFunction(HRESULT, "DWriteCreateFactory", [(DWRITE_FACTORY_TYPE, "factoryType"), (REFIID, "iid"), Out(Pointer(ObjPointer(IUnknown)), "factory")]),
+    StdFunction(HRESULT, "DWriteCreateFactory", [(DWRITE_FACTORY_TYPE, "factoryType"), (REFIID, "iid"), Out(Pointer(ObjPointer(IUnknown)), "factory")], throw='WIN_NOEXCEPT'),
 ])
 
 

--- a/specs/stdapi.py
+++ b/specs/stdapi.py
@@ -382,7 +382,7 @@ def InOut(type, name):
 
 class Function:
 
-    def __init__(self, type, name, args, call = '', fail = None, sideeffects=True, internal=False, overloaded=False):
+    def __init__(self, type, name, args, call = '', fail = None, sideeffects=True, internal=False, overloaded=False, throw=''):
         self.type = type
         self.name = name
 
@@ -405,6 +405,7 @@ class Function:
         self.sideeffects = sideeffects
         self.internal = internal
         self.overloaded = overloaded
+        self.throw = throw
 
     def prototype(self, name=None):
         if name is not None:
@@ -423,6 +424,8 @@ class Function:
         else:
             s += "void"
         s += ")"
+        if self.throw:
+            s += ' ' + self.throw
         return s
 
     def sigName(self):

--- a/wrappers/d2d1trace.py
+++ b/wrappers/d2d1trace.py
@@ -38,6 +38,10 @@ if __name__ == '__main__':
     print()
     print('#define DWRITE_EXPORT WINAPI')
     print()
+    print('#ifndef WIN_NOEXCEPT')
+    print('#define WIN_NOEXCEPT')
+    print('#endif')
+    print()
     print('#include "d2dimports.hpp"')
     print()
 


### PR DESCRIPTION
The `winnt.h` header seems to have changed recently and there is a `WIN_NOEXCEPT` exception specification added to `DWriteCreateFactory`. It is either defined as `noexcept` or `throw()` depending on the compiler version. If `WIN_NOEXCEPT` is not defined, it means we have an older version of the header, so we define it as empty.