### PR TITLE
Work around Qt6 crash involving LTO

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -97,6 +97,10 @@ add_dependencies(apitrace version)
 
 add_executable (qapitrace ${qapitrace_SRCS} ${qapitrace_UIS_H})
 
+# Turn off Linktime Optimization because it causes issues with Qt signal slot connections.
+# See https://bugreports.qt.io/browse/QTBUG-115731
+set_property(TARGET qapitrace PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
+
 target_link_libraries (qapitrace
     Qt::Widgets
     Qt::Network


### PR DESCRIPTION
If link time optimization is enabled in a Qt 6 build of qapitrace, signals are not properly connected, and a crash occurs.

Somehow an interaction between the `image` library and Qt, along with the `INTERPROCEDURAL_OPTIMIZATION` CMake setting causes this behavior.

Simply disabling link time optimization by setting the `INTERPROCEDURAL_OPTIMIZATION` qapitrace target property to false fixes the issue.