### PR TITLE
Switch to using compile-time signal-slot connections

### DIFF
--- a/gui/apitrace.cpp
+++ b/gui/apitrace.cpp
@@ -13,53 +13,49 @@ ApiTrace::ApiTrace()
 {
     m_loader = new TraceLoader();
 
-    connect(this, SIGNAL(loadTrace(QString)),
-            m_loader, SLOT(loadTrace(QString)));
-    connect(this, SIGNAL(requestFrame(ApiTraceFrame*)),
-            m_loader, SLOT(loadFrame(ApiTraceFrame*)));
-    connect(m_loader, SIGNAL(framesLoaded(const QList<ApiTraceFrame*>)),
-            this, SLOT(addFrames(const QList<ApiTraceFrame*>)));
-    connect(m_loader,
-            SIGNAL(frameContentsLoaded(ApiTraceFrame*,QVector<ApiTraceCall*>, QVector<ApiTraceCall*>,quint64)),
-            this,
-            SLOT(loaderFrameLoaded(ApiTraceFrame*,QVector<ApiTraceCall*>,QVector<ApiTraceCall*>,quint64)));
-    connect(m_loader, SIGNAL(guessedApi(int)),
-            this, SLOT(guessedApi(int)));
-    connect(this, SIGNAL(loaderSearch(ApiTrace::SearchRequest)),
-            m_loader, SLOT(search(ApiTrace::SearchRequest)));
-    connect(m_loader,
-            SIGNAL(searchResult(ApiTrace::SearchRequest,ApiTrace::SearchResult,ApiTraceCall*)),
-            this,
-            SLOT(loaderSearchResult(ApiTrace::SearchRequest,ApiTrace::SearchResult,ApiTraceCall*)));
-    connect(this, SIGNAL(loaderFindFrameStart(ApiTraceFrame*)),
-            m_loader, SLOT(findFrameStart(ApiTraceFrame*)));
-    connect(this, SIGNAL(loaderFindFrameEnd(ApiTraceFrame*)),
-            m_loader, SLOT(findFrameEnd(ApiTraceFrame*)));
-    connect(m_loader, SIGNAL(foundFrameStart(ApiTraceFrame*)),
-            this, SIGNAL(foundFrameStart(ApiTraceFrame*)));
-    connect(m_loader, SIGNAL(foundFrameEnd(ApiTraceFrame*)),
-            this, SIGNAL(foundFrameEnd(ApiTraceFrame*)));
-    connect(this, SIGNAL(loaderFindCallIndex(int)),
-            m_loader, SLOT(findCallIndex(int)));
-    connect(m_loader, SIGNAL(foundCallIndex(ApiTraceCall*)),
-            this, SIGNAL(foundCallIndex(ApiTraceCall*)));
+    connect(this, &ApiTrace::loadTrace,
+            m_loader, &TraceLoader::loadTrace);
+    connect(this, &ApiTrace::requestFrame,
+            m_loader, &TraceLoader::loadFrame);
+    connect(m_loader, &TraceLoader::framesLoaded,
+            this, &ApiTrace::addFrames);
+    connect(m_loader, &TraceLoader::frameContentsLoaded,
+            this, &ApiTrace::loaderFrameLoaded);
+    connect(m_loader, &TraceLoader::guessedApi,
+            this, &ApiTrace::guessedApi);
+    connect(this, &ApiTrace::loaderSearch,
+            m_loader, &TraceLoader::search);
+    connect(m_loader, &TraceLoader::searchResult,
+            this, &ApiTrace::loaderSearchResult);
+    connect(this, &ApiTrace::loaderFindFrameStart,
+            m_loader, &TraceLoader::findFrameStart);
+    connect(this, &ApiTrace::loaderFindFrameEnd,
+            m_loader, &TraceLoader::findFrameEnd);
+    connect(m_loader, &TraceLoader::foundFrameStart,
+            this, &ApiTrace::foundFrameStart);
+    connect(m_loader, &TraceLoader::foundFrameEnd,
+            this, &ApiTrace::foundFrameEnd);
+    connect(this, &ApiTrace::loaderFindCallIndex,
+            m_loader, &TraceLoader::findCallIndex);
+    connect(m_loader, &TraceLoader::foundCallIndex,
+            this, &ApiTrace::foundCallIndex);
 
 
-    connect(m_loader, SIGNAL(parseProblem(const QString&)),
-            this, SIGNAL(problemLoadingTrace(const QString&)));
-    connect(m_loader, SIGNAL(startedParsing()),
-            this, SIGNAL(startedLoadingTrace()));
-    connect(m_loader, SIGNAL(parsed(int)),
-            this, SIGNAL(loaded(int)));
-    connect(m_loader, SIGNAL(finishedParsing()),
-            this, SIGNAL(finishedLoadingTrace()));
+    connect(m_loader, &TraceLoader::parseProblem,
+            this, &ApiTrace::problemLoadingTrace);
+    connect(m_loader, &TraceLoader::startedParsing,
+            this, &ApiTrace::startedLoadingTrace);
+    connect(m_loader, &TraceLoader::parsed,
+            this, &ApiTrace::loaded);
+    connect(m_loader, &TraceLoader::finishedParsing,
+            this, &ApiTrace::finishedLoadingTrace);
 
 
     m_saver = new SaverThread(this);
-    connect(m_saver, SIGNAL(traceSaved()),
-            this, SLOT(slotSaved()));
-    connect(m_saver, SIGNAL(traceSaved()),
-            this, SIGNAL(saved()));
+    connect(m_saver, &SaverThread::traceSaved,
+            this, &ApiTrace::slotSaved);
+    connect(m_saver, &SaverThread::traceSaved,
+            this, &ApiTrace::saved);
 
     m_loaderThread = new QThread();
     m_loader->moveToThread(m_loaderThread);

--- a/gui/apitracecall.cpp
+++ b/gui/apitracecall.cpp
@@ -1097,7 +1097,7 @@ QString ApiTraceCall::searchText() const
         return m_searchText;
 
     QVector<QVariant> argValues = arguments();
-    m_searchText = m_signature->name() + QLatin1String("(");
+    m_searchText = m_signature->name() % QLatin1String("(");
     QStringList argNames = m_signature->argNames();
     for (int i = 0; i < argNames.count(); ++i) {
         m_searchText += argNames[i] +

--- a/gui/apitracemodel.cpp
+++ b/gui/apitracemodel.cpp
@@ -246,20 +246,20 @@ void ApiTraceModel::setApiTrace(ApiTrace *trace)
     if (m_trace)
         disconnect(m_trace);
     m_trace = trace;
-    connect(m_trace, SIGNAL(invalidated()),
-            this, SLOT(invalidateFrames()));
-    connect(m_trace, SIGNAL(framesInvalidated()),
-            this, SLOT(invalidateFrames()));
-    connect(m_trace, SIGNAL(beginAddingFrames(int, int)),
-            this, SLOT(beginAddingFrames(int, int)));
-    connect(m_trace, SIGNAL(endAddingFrames()),
-            this, SLOT(endAddingFrames()));
-    connect(m_trace, SIGNAL(changed(ApiTraceEvent*)),
-            this, SLOT(changed(ApiTraceEvent*)));
-    connect(m_trace, SIGNAL(beginLoadingFrame(ApiTraceFrame*,int)),
-            this, SLOT(beginLoadingFrame(ApiTraceFrame*,int)));
-    connect(m_trace, SIGNAL(endLoadingFrame(ApiTraceFrame*)),
-            this, SLOT(endLoadingFrame(ApiTraceFrame*)));
+    connect(m_trace, &ApiTrace::invalidated,
+            this, &ApiTraceModel::invalidateFrames);
+    connect(m_trace, &ApiTrace::framesInvalidated,
+            this, &ApiTraceModel::invalidateFrames);
+    connect(m_trace, &ApiTrace::beginAddingFrames,
+            this, &ApiTraceModel::beginAddingFrames);
+    connect(m_trace, &ApiTrace::endAddingFrames,
+            this, &ApiTraceModel::endAddingFrames);
+    connect(m_trace, &ApiTrace::changed,
+            this, &ApiTraceModel::changed);
+    connect(m_trace, &ApiTrace::beginLoadingFrame,
+            this, &ApiTraceModel::beginLoadingFrame);
+    connect(m_trace, &ApiTrace::endLoadingFrame,
+            this, &ApiTraceModel::endLoadingFrame);
 
 }
 

--- a/gui/argumentseditor.cpp
+++ b/gui/argumentseditor.cpp
@@ -141,12 +141,12 @@ void ArgumentsEditor::init()
 {
     m_ui.setupUi(this);
 
-    connect(m_ui.selectStringCB, SIGNAL(currentIndexChanged(int)),
-            SLOT(currentSourceChanged(int)));
-    connect(m_ui.glslEdit, SIGNAL(textChanged()),
-            SLOT(sourceChanged()));
-    connect(m_ui.revertButton, SIGNAL(clicked()),
-            SLOT(revert()));
+    connect(m_ui.selectStringCB, &QComboBox::currentIndexChanged,
+            this, &ArgumentsEditor::currentSourceChanged);
+    connect(m_ui.glslEdit, &QPlainTextEdit::textChanged,
+            this, &ArgumentsEditor::sourceChanged);
+    connect(m_ui.revertButton, &QAbstractButton::clicked,
+            this, &ArgumentsEditor::revert);
 
     setArgumentsItemEditorFactory ();
 

--- a/gui/glsledit.cpp
+++ b/gui/glsledit.cpp
@@ -600,9 +600,9 @@ GLSLEdit::GLSLEdit(QWidget *parent)
 
     document()->setDocumentLayout(d_ptr->layout);
 
-    connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(updateCursor()));
-    connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateSidebar()));
-    connect(this, SIGNAL(updateRequest(QRect, int)), this, SLOT(updateSidebar(QRect, int)));
+    connect(this, &QPlainTextEdit::cursorPositionChanged, this, &GLSLEdit::updateCursor);
+    connect(this, &QPlainTextEdit::blockCountChanged, this, qOverload<>(&GLSLEdit::updateSidebar));
+    connect(this, &QPlainTextEdit::updateRequest, this, qOverload<>(&GLSLEdit::updateSidebar));
 
 #if defined(Q_OS_MAC)
     QFont textFont = font();
@@ -1001,7 +1001,7 @@ void GLSLEdit::contextMenuEvent(QContextMenuEvent *e)
 {
     QMenu *menu = createStandardContextMenu();
 
-    menu->addAction(tr("Indent Code"), this, SLOT(indent()));
+    menu->addAction(tr("Indent Code"), this, &GLSLEdit::indent);
 
     menu->exec(e->globalPos());
     delete menu;

--- a/gui/graphing/graphwidget.cpp
+++ b/gui/graphing/graphwidget.cpp
@@ -245,57 +245,57 @@ void GraphWidget::updateScrollbars()
 void GraphWidget::updateConnections()
 {
     if (m_view) {
-        connect(m_view, SIGNAL(selectionChanged()), this, SLOT(updateSelection()), Qt::UniqueConnection);
+        connect(m_view, &GraphView::selectionChanged, this, qOverload<>(&GraphWidget::updateSelection), Qt::UniqueConnection);
 
-        connect(m_view, SIGNAL(horizontalViewChanged(qint64,qint64)), this, SLOT(horizontalViewChange(qint64,qint64)), Qt::UniqueConnection);
-        connect(m_view, SIGNAL(horizontalRangeChanged(qint64,qint64)), this, SLOT(horizontalRangeChange(qint64,qint64)), Qt::UniqueConnection);
+        connect(m_view, &GraphView::horizontalViewChanged, this, &GraphWidget::horizontalViewChange, Qt::UniqueConnection);
+        connect(m_view, &GraphView::horizontalRangeChanged, this, &GraphWidget::horizontalRangeChange, Qt::UniqueConnection);
 
-        connect(m_view, SIGNAL(verticalViewChanged(qint64,qint64)), this, SLOT(verticalViewChange(qint64,qint64)), Qt::UniqueConnection);
-        connect(m_view, SIGNAL(verticalRangeChanged(qint64,qint64)), this, SLOT(verticalRangeChange(qint64,qint64)), Qt::UniqueConnection);
+        connect(m_view, &GraphView::verticalViewChanged, this, &GraphWidget::verticalViewChange, Qt::UniqueConnection);
+        connect(m_view, &GraphView::verticalRangeChanged, this, &GraphWidget::verticalRangeChange, Qt::UniqueConnection);
     }
 
     if (m_axisTop) {
         if (m_view) {
-            connect(m_view, SIGNAL(horizontalViewChanged(qint64,qint64)), m_axisTop, SLOT(setView(qint64,qint64)), Qt::UniqueConnection);
-            connect(m_view, SIGNAL(horizontalRangeChanged(qint64,qint64)), m_axisTop, SLOT(setRange(qint64,qint64)), Qt::UniqueConnection);
+            connect(m_view, &GraphView::horizontalViewChanged, m_axisTop, &GraphAxisWidget::setView, Qt::UniqueConnection);
+            connect(m_view, &GraphView::horizontalRangeChanged, m_axisTop, &GraphAxisWidget::setRange, Qt::UniqueConnection);
         }
 
-        connect(m_axisTop, SIGNAL(selectionChanged()), this, SLOT(updateSelection()), Qt::UniqueConnection);
+        connect(m_axisTop, &GraphAxisWidget::selectionChanged, this, qOverload<>(&GraphWidget::updateSelection), Qt::UniqueConnection);
     }
 
     if (m_axisLeft) {
         if (m_view) {
-            connect(m_view, SIGNAL(verticalViewChanged(qint64,qint64)), m_axisLeft, SLOT(setView(qint64,qint64)), Qt::UniqueConnection);
-            connect(m_view, SIGNAL(verticalRangeChanged(qint64,qint64)), m_axisLeft, SLOT(setRange(qint64,qint64)), Qt::UniqueConnection);
+            connect(m_view, &GraphView::verticalViewChanged, m_axisLeft, &GraphAxisWidget::setView, Qt::UniqueConnection);
+            connect(m_view, &GraphView::verticalRangeChanged, m_axisLeft, &GraphAxisWidget::setRange, Qt::UniqueConnection);
         }
 
-        connect(m_axisLeft, SIGNAL(selectionChanged()), this, SLOT(updateSelection()), Qt::UniqueConnection);
+        connect(m_axisLeft, &GraphAxisWidget::selectionChanged, this, qOverload<>(&GraphWidget::updateSelection), Qt::UniqueConnection);
     }
 
     if (m_axisRight) {
         if (m_view) {
-            connect(m_view, SIGNAL(verticalViewChanged(qint64,qint64)), m_axisRight, SLOT(setView(qint64,qint64)), Qt::UniqueConnection);
-            connect(m_view, SIGNAL(verticalRangeChanged(qint64,qint64)), m_axisRight, SLOT(setRange(qint64,qint64)), Qt::UniqueConnection);
+            connect(m_view, &GraphView::verticalViewChanged, m_axisRight, &GraphAxisWidget::setView, Qt::UniqueConnection);
+            connect(m_view, &GraphView::verticalRangeChanged, m_axisRight, &GraphAxisWidget::setRange, Qt::UniqueConnection);
         }
 
-        connect(m_axisRight, SIGNAL(selectionChanged()), this, SLOT(updateSelection()), Qt::UniqueConnection);
+        connect(m_axisRight, &GraphAxisWidget::selectionChanged, this, qOverload<>(&GraphWidget::updateSelection), Qt::UniqueConnection);
     }
 
     if (m_axisBottom) {
         if (m_view) {
-            connect(m_view, SIGNAL(horizontalViewChanged(qint64,qint64)), m_axisBottom, SLOT(setView(qint64,qint64)), Qt::UniqueConnection);
-            connect(m_view, SIGNAL(horizontalRangeChanged(qint64,qint64)), m_axisBottom, SLOT(setRange(qint64,qint64)), Qt::UniqueConnection);
+            connect(m_view, &GraphView::horizontalViewChanged, m_axisBottom, &GraphAxisWidget::setView, Qt::UniqueConnection);
+            connect(m_view, &GraphView::horizontalRangeChanged, m_axisBottom, &GraphAxisWidget::setRange, Qt::UniqueConnection);
         }
 
-        connect(m_axisBottom, SIGNAL(selectionChanged()), this, SLOT(updateSelection()), Qt::UniqueConnection);
+        connect(m_axisBottom, &GraphAxisWidget::selectionChanged, this, qOverload<>(&GraphWidget::updateSelection), Qt::UniqueConnection);
     }
 
     if (m_horizontalScrollbar) {
-        connect(m_horizontalScrollbar, SIGNAL(actionTriggered(int)), this, SLOT(horizontalScrollAction(int)));
+        connect(m_horizontalScrollbar, &QAbstractSlider::actionTriggered, this, &GraphWidget::horizontalScrollAction);
     }
 
     if (m_verticalScrollbar) {
-        connect(m_verticalScrollbar, SIGNAL(actionTriggered(int)), this, SLOT(verticalScrollAction(int)));
+        connect(m_verticalScrollbar, &QAbstractSlider::actionTriggered, this, &GraphWidget::verticalScrollAction);
     }
 }
 

--- a/gui/graphing/graphwidget.h
+++ b/gui/graphing/graphwidget.h
@@ -70,7 +70,8 @@ protected slots:
     void verticalScrollAction(int action);
 
     /* Update child elements when selection changes */
-    void updateSelection(bool emitSignal = true);
+    void updateSelection(bool emitSignal);
+    void updateSelection() { updateSelection(true); }
 
 signals:
     void selectionChanged(SelectionState state);

--- a/gui/imageviewer.cpp
+++ b/gui/imageviewer.cpp
@@ -20,16 +20,16 @@ ImageViewer::ImageViewer(QWidget *parent, bool opaque, bool alpha)
     opaqueCheckBox->setChecked(opaque);
     alphaCheckBox->setChecked(alpha);
 
-    connect(lowerSpinBox, SIGNAL(valueChanged(double)),
-            SLOT(slotUpdate()));
-    connect(upperSpinBox, SIGNAL(valueChanged(double)),
-            SLOT(slotUpdate()));
-    connect(flipCheckBox, SIGNAL(stateChanged(int)),
-            SLOT(slotUpdate()));
-    connect(opaqueCheckBox, SIGNAL(stateChanged(int)),
-            SLOT(slotUpdate()));
-    connect(alphaCheckBox, SIGNAL(stateChanged(int)),
-            SLOT(slotUpdate()));
+    connect(lowerSpinBox, &QDoubleSpinBox::valueChanged,
+            this, &ImageViewer::slotUpdate);
+    connect(upperSpinBox, &QDoubleSpinBox::valueChanged,
+            this, &ImageViewer::slotUpdate);
+    connect(flipCheckBox, &QCheckBox::stateChanged,
+            this, &ImageViewer::slotUpdate);
+    connect(opaqueCheckBox, &QCheckBox::stateChanged,
+            this, &ImageViewer::slotUpdate);
+    connect(alphaCheckBox, &QCheckBox::stateChanged,
+            this, &ImageViewer::slotUpdate);
 
     QPixmap px(32, 32);
     QPainter p(&px);
@@ -51,26 +51,26 @@ ImageViewer::ImageViewer(QWidget *parent, bool opaque, bool alpha)
     rectLabel->hide();
     pixelLabel->hide();
 
-    connect(m_pixelWidget, SIGNAL(zoomChanged(double)),
-            this, SLOT(zoomChangedIndirectly(double)));
-    connect(zoomSpinBox, SIGNAL(valueChanged(double)),
-            this, SLOT(zoomChangedDirectly()));
-    connect(zoomSpinBox, SIGNAL(valueChanged(double)),
-            m_pixelWidget, SLOT(setZoom(double)));
-    connect(m_pixelWidget, SIGNAL(mousePosition(int, int)),
-            this, SLOT(showPixel(int, int)));
-    connect(m_pixelWidget, SIGNAL(gridGeometry(const QRect &)),
-            this, SLOT(showGrid(const QRect &)));
-    connect(m_pixelWidget, SIGNAL(zoomStepUp()),
-            this, SLOT(zoomChangedDirectly()));
-    connect(m_pixelWidget, SIGNAL(zoomStepUp()),
-            zoomSpinBox, SLOT(stepUp()));
-    connect(m_pixelWidget, SIGNAL(zoomStepDown()),
-            this, SLOT(zoomChangedDirectly()));
-    connect(m_pixelWidget, SIGNAL(zoomStepDown()),
-            zoomSpinBox, SLOT(stepDown()));
-    connect(zoomToFitCheckBox, SIGNAL(stateChanged(int)),
-            this, SLOT(zoomToFitChanged(int)));
+    connect(m_pixelWidget, &PixelWidget::zoomChanged,
+            this, &ImageViewer::zoomChangedIndirectly);
+    connect(zoomSpinBox, &QDoubleSpinBox::valueChanged,
+            this, &ImageViewer::zoomChangedDirectly);
+    connect(zoomSpinBox, &QDoubleSpinBox::valueChanged,
+            m_pixelWidget, qOverload<double>(&PixelWidget::setZoom));
+    connect(m_pixelWidget, &PixelWidget::mousePosition,
+            this, &ImageViewer::showPixel);
+    connect(m_pixelWidget, &PixelWidget::gridGeometry,
+            this, &ImageViewer::showGrid);
+    connect(m_pixelWidget, &PixelWidget::zoomStepUp,
+            this, &ImageViewer::zoomChangedDirectly);
+    connect(m_pixelWidget, &PixelWidget::zoomStepUp,
+            zoomSpinBox, &QAbstractSpinBox::stepUp);
+    connect(m_pixelWidget, &PixelWidget::zoomStepDown,
+            this, &ImageViewer::zoomChangedDirectly);
+    connect(m_pixelWidget, &PixelWidget::zoomStepDown,
+            zoomSpinBox, &QAbstractSpinBox::stepDown);
+    connect(zoomToFitCheckBox, &QCheckBox::stateChanged,
+            this, &ImageViewer::zoomToFitChanged);
 
     const auto zoomToFit = QSettings().value("imageViewerZoomToFit");
     if (!zoomToFit.isNull()) {

--- a/gui/jumpwidget.cpp
+++ b/gui/jumpwidget.cpp
@@ -8,12 +8,12 @@ JumpWidget::JumpWidget(QWidget *parent )
 {
     m_ui.setupUi(this);
 
-    connect(m_ui.jumpButton, SIGNAL(clicked()),
-            SLOT(slotJump()));
-    connect(m_ui.spinBox, SIGNAL(editingFinished()),
-            SLOT(slotJump()));
-    connect(m_ui.cancelButton, SIGNAL(clicked()),
-            SLOT(slotCancel()));
+    connect(m_ui.jumpButton, &QAbstractButton::clicked,
+            this, &JumpWidget::slotJump);
+    connect(m_ui.spinBox, &QAbstractSpinBox::editingFinished,
+            this, &JumpWidget::slotJump);
+    connect(m_ui.cancelButton, &QAbstractButton::clicked,
+            this, &JumpWidget::slotCancel);
 
     installEventFilter(this);
 }

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -973,10 +973,9 @@ void MainWindow::leakTrace()
 {
     LeakTraceThread *t=new LeakTraceThread(m_trace->fileName());
 
-    connect (t,SIGNAL(finished()),this,SLOT(leakTraceFinished()));
-
-    connect (t,SIGNAL(leakTraceErrors(const QList<ApiTraceError> &)),
-            this,SLOT(slotRetraceErrors(const QList<ApiTraceError>&)));
+    connect (t, &QThread::finished, this, &MainWindow::leakTraceFinished);
+    connect (t, &LeakTraceThread::leakTraceErrors,
+            this, &MainWindow::slotRetraceErrors);
 
     t->start();
 }
@@ -1002,13 +1001,11 @@ void MainWindow::showSurfacesMenu(const QPoint &pos)
 
     QAction *act = menu.addAction(tr("View Image"));
     act->setStatusTip(tr("View the currently selected surface"));
-    connect(act, SIGNAL(triggered()),
-            SLOT(showSelectedSurface()));
+    connect(act, &QAction::triggered, this, &MainWindow::showSelectedSurface);
 
     act = menu.addAction(tr("Save Image"));
     act->setStatusTip(tr("Save the currently selected surface"));
-    connect(act, SIGNAL(triggered()),
-            SLOT(saveSelectedSurface()));
+    connect(act, &QAction::triggered, this, &MainWindow::saveSelectedSurface);
 
     menu.exec(tree->viewport()->mapToGlobal(pos));
 }
@@ -1138,151 +1135,145 @@ void MainWindow::initObjects()
 
 void MainWindow::initConnections()
 {
-    connect(m_trace, SIGNAL(problemLoadingTrace(const QString&)),
-            this, SLOT(loadError(const QString&)));
-    connect(m_trace, SIGNAL(startedLoadingTrace()),
-            this, SLOT(startedLoadingTrace()));
-    connect(m_trace, SIGNAL(loaded(int)),
-            this, SLOT(loadProgess(int)));
-    connect(m_trace, SIGNAL(finishedLoadingTrace()),
-            this, SLOT(finishedLoadingTrace()));
-    connect(m_trace, SIGNAL(startedSaving()),
-            this, SLOT(slotStartedSaving()));
-    connect(m_trace, SIGNAL(saved()),
-            this, SLOT(slotSaved()));
-    connect(m_trace, SIGNAL(changed(ApiTraceEvent*)),
-            this, SLOT(slotTraceChanged(ApiTraceEvent*)));
-    connect(m_trace, SIGNAL(findResult(ApiTrace::SearchRequest,ApiTrace::SearchResult,ApiTraceCall*)),
-            this, SLOT(slotSearchResult(ApiTrace::SearchRequest,ApiTrace::SearchResult,ApiTraceCall*)));
-    connect(m_trace, SIGNAL(foundFrameStart(ApiTraceFrame*)),
-            this, SLOT(slotFoundFrameStart(ApiTraceFrame*)));
-    connect(m_trace, SIGNAL(foundFrameEnd(ApiTraceFrame*)),
-            this, SLOT(slotFoundFrameEnd(ApiTraceFrame*)));
-    connect(m_trace, SIGNAL(foundCallIndex(ApiTraceCall*)),
-            this, SLOT(slotJumpToResult(ApiTraceCall*)));
+    connect(m_trace, &ApiTrace::problemLoadingTrace,
+            this, &MainWindow::loadError);
+    connect(m_trace, &ApiTrace::startedLoadingTrace,
+            this, &MainWindow::startedLoadingTrace);
+    connect(m_trace, &ApiTrace::loaded,
+            this, &MainWindow::loadProgess);
+    connect(m_trace, &ApiTrace::finishedLoadingTrace,
+            this, &MainWindow::finishedLoadingTrace);
+    connect(m_trace, &ApiTrace::startedSaving,
+            this, &MainWindow::slotStartedSaving);
+    connect(m_trace, &ApiTrace::saved,
+            this, &MainWindow::slotSaved);
+    connect(m_trace, &ApiTrace::changed,
+            this, &MainWindow::slotTraceChanged);
+    connect(m_trace, &ApiTrace::findResult,
+            this, &MainWindow::slotSearchResult);
+    connect(m_trace, &ApiTrace::foundFrameStart,
+            this, &MainWindow::slotFoundFrameStart);
+    connect(m_trace, &ApiTrace::foundFrameEnd,
+            this, &MainWindow::slotFoundFrameEnd);
+    connect(m_trace, &ApiTrace::foundCallIndex,
+            this, &MainWindow::slotJumpToResult);
 
-    connect(m_retracer, SIGNAL(finished(const QString&)),
-            this, SLOT(replayFinished(const QString&)));
-    connect(m_retracer, SIGNAL(error(const QString&)),
-            this, SLOT(replayError(const QString&)));
-    connect(m_retracer, SIGNAL(foundState(ApiTraceState*)),
-            this, SLOT(replayStateFound(ApiTraceState*)));
-    connect(m_retracer, SIGNAL(foundProfile(trace::Profile*)),
-            this, SLOT(replayProfileFound(trace::Profile*)));
-    connect(m_retracer, SIGNAL(foundThumbnails(const ImageHash&)),
-            this, SLOT(replayThumbnailsFound(const ImageHash&)));
-    connect(m_retracer, SIGNAL(retraceErrors(const QList<ApiTraceError>&)),
-            this, SLOT(slotRetraceErrors(const QList<ApiTraceError>&)));
+    connect(m_retracer, &Retracer::finished,
+            this, &MainWindow::replayFinished);
+    connect(m_retracer, &Retracer::error,
+            this, &MainWindow::replayError);
+    connect(m_retracer, &Retracer::foundState,
+            this, &MainWindow::replayStateFound);
+    connect(m_retracer, &Retracer::foundProfile,
+            this, &MainWindow::replayProfileFound);
+    connect(m_retracer, qOverload<const ImageHash&>(&Retracer::foundThumbnails),
+            this, &MainWindow::replayThumbnailsFound);
+    connect(m_retracer, &Retracer::retraceErrors,
+            this, &MainWindow::slotRetraceErrors);
 
-    connect(m_ui.vertexInterpretButton, SIGNAL(clicked()),
-            m_vdataInterpreter, SLOT(interpretData()));
-    connect(m_ui.bufferExportButton, SIGNAL(clicked()),
-            this, SLOT(exportBufferData()));
-    connect(m_ui.vertexTypeCB, SIGNAL(currentTextChanged(const QString&)),
-            m_vdataInterpreter, SLOT(setTypeFromString(const QString&)));
-    connect(m_ui.vertexStrideSB, SIGNAL(valueChanged(int)),
-            m_vdataInterpreter, SLOT(setStride(int)));
-    connect(m_ui.vertexComponentsSB, SIGNAL(valueChanged(int)),
-            m_vdataInterpreter, SLOT(setComponents(int)));
-    connect(m_ui.startingOffsetSB, SIGNAL(valueChanged(int)),
-            m_vdataInterpreter, SLOT(setStartingOffset(int)));
+    connect(m_ui.vertexInterpretButton, &QAbstractButton::clicked,
+            m_vdataInterpreter, &VertexDataInterpreter::interpretData);
+    connect(m_ui.bufferExportButton, &QAbstractButton::clicked,
+            this, &MainWindow::exportBufferData);
+    connect(m_ui.vertexTypeCB, &QComboBox::currentTextChanged,
+            m_vdataInterpreter, &VertexDataInterpreter::setTypeFromString);
+    connect(m_ui.vertexStrideSB, &QSpinBox::valueChanged,
+            m_vdataInterpreter, &VertexDataInterpreter::setStride);
+    connect(m_ui.vertexComponentsSB, &QSpinBox::valueChanged,
+            m_vdataInterpreter, &VertexDataInterpreter::setComponents);
+    connect(m_ui.startingOffsetSB, &QSpinBox::valueChanged,
+            m_vdataInterpreter, &VertexDataInterpreter::setStartingOffset);
 
 
-    connect(m_ui.actionNew, SIGNAL(triggered()),
-            this, SLOT(createTrace()));
-    connect(m_ui.actionOpen, SIGNAL(triggered()),
-            this, SLOT(openTrace()));
-    connect(m_ui.actionSave, SIGNAL(triggered()),
-            this, SLOT(saveTrace()));
-    connect(m_ui.actionQuit, SIGNAL(triggered()),
-            this, SLOT(close()));
+    connect(m_ui.actionNew, &QAction::triggered,
+            this, qOverload<>(&MainWindow::createTrace));
+    connect(m_ui.actionOpen, &QAction::triggered,
+            this, &MainWindow::openTrace);
+    connect(m_ui.actionSave, &QAction::triggered,
+            this, &MainWindow::saveTrace);
+    connect(m_ui.actionQuit, &QAction::triggered,
+            this, &QWidget::close);
 
-    connect(m_ui.actionFind, SIGNAL(triggered()),
-            this, SLOT(slotSearch()));
-    connect(m_ui.actionGo, SIGNAL(triggered()),
-            this, SLOT(slotGoTo()));
-    connect(m_ui.actionGoFrameStart, SIGNAL(triggered()),
-            this, SLOT(slotGoFrameStart()));
-    connect(m_ui.actionGoFrameEnd, SIGNAL(triggered()),
-            this, SLOT(slotGoFrameEnd()));
+    connect(m_ui.actionFind, &QAction::triggered,
+            this, &MainWindow::slotSearch);
+    connect(m_ui.actionGo, &QAction::triggered,
+            this, &MainWindow::slotGoTo);
+    connect(m_ui.actionGoFrameStart, &QAction::triggered,
+            this, &MainWindow::slotGoFrameStart);
+    connect(m_ui.actionGoFrameEnd, &QAction::triggered,
+            this, &MainWindow::slotGoFrameEnd);
 
-    connect(m_ui.actionReplay, SIGNAL(triggered()),
-            this, SLOT(replayStart()));
-    connect(m_ui.actionProfile, SIGNAL(triggered()),
-            this, SLOT(replayProfile()));
-    connect(m_ui.actionStop, SIGNAL(triggered()),
-            this, SLOT(replayStop()));
-    connect(m_ui.actionLookupState, SIGNAL(triggered()),
-            this, SLOT(lookupState()));
-    connect(m_ui.actionTrim, SIGNAL(triggered()),
-            this, SLOT(trim()));
-    connect(m_ui.actionToggleCalls, SIGNAL(triggered()),
-            this, SLOT(toggleCalls()));
-    connect(m_ui.actionEnableAllCalls, SIGNAL(triggered()),
-            this, SLOT(enableAllCalls()));
-    connect(m_ui.actionShowThumbnails, SIGNAL(triggered()),
-            this, SLOT(showThumbnails()));
-    connect(m_ui.actionOptions, SIGNAL(triggered()),
-            this, SLOT(showSettings()));
-    connect(m_ui.actionLeakTrace,SIGNAL(triggered()),
-            this, SLOT(leakTrace()));
+    connect(m_ui.actionReplay, &QAction::triggered,
+            this, &MainWindow::replayStart);
+    connect(m_ui.actionProfile, &QAction::triggered,
+            this, &MainWindow::replayProfile);
+    connect(m_ui.actionStop, &QAction::triggered,
+            this, &MainWindow::replayStop);
+    connect(m_ui.actionLookupState, &QAction::triggered,
+            this, &MainWindow::lookupState);
+    connect(m_ui.actionTrim, &QAction::triggered,
+            this, &MainWindow::trim);
+    connect(m_ui.actionToggleCalls, &QAction::triggered,
+            this, &MainWindow::toggleCalls);
+    connect(m_ui.actionEnableAllCalls, &QAction::triggered,
+            this, &MainWindow::enableAllCalls);
+    connect(m_ui.actionShowThumbnails, &QAction::triggered,
+            this, &MainWindow::showThumbnails);
+    connect(m_ui.actionOptions, &QAction::triggered,
+            this, &MainWindow::showSettings);
+    connect(m_ui.actionLeakTrace,&QAction::triggered,
+            this, &MainWindow::leakTrace);
 
-    connect(m_ui.callView->selectionModel(), SIGNAL(currentChanged(const QModelIndex &, const QModelIndex &)),
-            this, SLOT(callItemSelected(const QModelIndex &)));
-    connect(m_ui.callView, SIGNAL(doubleClicked(const QModelIndex &)),
-            this, SLOT(callItemActivated(const QModelIndex &)));
-    connect(m_ui.callView, SIGNAL(customContextMenuRequested(QPoint)),
-            this, SLOT(customContextMenuRequested(QPoint)));
+    connect(m_ui.callView->selectionModel(), &QItemSelectionModel::currentChanged,
+            this, &MainWindow::callItemSelected);
+    connect(m_ui.callView, &QAbstractItemView::doubleClicked,
+            this, &MainWindow::callItemActivated);
+    connect(m_ui.callView, &QWidget::customContextMenuRequested,
+            this, &MainWindow::customContextMenuRequested);
 
-    connect(m_ui.surfacesTreeWidget,
-            SIGNAL(customContextMenuRequested(const QPoint &)),
-            SLOT(showSurfacesMenu(const QPoint &)));
-    connect(m_ui.surfacesTreeWidget,
-            SIGNAL(itemDoubleClicked(QTreeWidgetItem *, int)),
-            SLOT(showSelectedSurface()));
+    connect(m_ui.surfacesTreeWidget, &QWidget::customContextMenuRequested,
+            this, &MainWindow::showSurfacesMenu);
+    connect(m_ui.surfacesTreeWidget, &QTreeWidget::itemDoubleClicked,
+            this, &MainWindow::showSelectedSurface);
 
-    connect(m_ui.nonDefaultsCB, SIGNAL(toggled(bool)),
-            this, SLOT(fillState(bool)));
+    connect(m_ui.nonDefaultsCB, &QAbstractButton::toggled,
+            this, &MainWindow::fillState);
 
-    connect(m_jumpWidget, SIGNAL(jumpTo(int)),
-            SLOT(slotJumpTo(int)));
+    connect(m_jumpWidget, &JumpWidget::jumpTo, this, &MainWindow::slotJumpTo);
 
-    connect(m_searchWidget,
-            SIGNAL(searchNext(const QString&, Qt::CaseSensitivity, bool)),
-            SLOT(slotSearchNext(const QString&, Qt::CaseSensitivity, bool)));
-    connect(m_searchWidget,
-            SIGNAL(searchPrev(const QString&, Qt::CaseSensitivity, bool)),
-            SLOT(slotSearchPrev(const QString&, Qt::CaseSensitivity, bool)));
+    connect(m_searchWidget, &SearchWidget::searchNext,
+            this, &MainWindow::slotSearchNext);
+    connect(m_searchWidget, &SearchWidget::searchPrev,
+            this, &MainWindow::slotSearchPrev);
 
-    connect(m_traceProcess, SIGNAL(tracedFile(const QString&)),
-            SLOT(createdTrace(const QString&)));
-    connect(m_traceProcess, SIGNAL(error(const QString&)),
-            SLOT(traceError(const QString&)));
+    connect(m_traceProcess, &TraceProcess::tracedFile,
+            this, &MainWindow::createdTrace);
+    connect(m_traceProcess, &TraceProcess::error,
+            this, &MainWindow::traceError);
 
-    connect(m_trimProcess, SIGNAL(trimmedFile(const QString&)),
-            SLOT(createdTrim(const QString&)));
-    connect(m_trimProcess, SIGNAL(error(const QString&)),
-            SLOT(trimError(const QString&)));
+    connect(m_trimProcess, &TrimProcess::trimmedFile,
+            this, &MainWindow::createdTrim);
+    connect(m_trimProcess, &TrimProcess::error,
+            this, &MainWindow::trimError);
 
-    connect(m_ui.errorsDock, SIGNAL(visibilityChanged(bool)),
-            m_ui.actionShowErrorsDock, SLOT(setChecked(bool)));
-    connect(m_ui.actionShowErrorsDock, SIGNAL(triggered(bool)),
-            m_ui.errorsDock, SLOT(setVisible(bool)));
-    connect(m_ui.errorsTreeWidget,
-            SIGNAL(itemActivated(QTreeWidgetItem*, int)),
-            this, SLOT(slotErrorSelected(QTreeWidgetItem*)));
+    connect(m_ui.errorsDock, &QDockWidget::visibilityChanged,
+            m_ui.actionShowErrorsDock, &QAction::setChecked);
+    connect(m_ui.actionShowErrorsDock, &QAction::triggered,
+            m_ui.errorsDock, &QWidget::setVisible);
+    connect(m_ui.errorsTreeWidget, &QTreeWidget::itemActivated,
+            this, &MainWindow::slotErrorSelected);
 
-    connect(m_ui.actionShowProfileDialog, SIGNAL(triggered(bool)),
-            m_profileDialog, SLOT(show()));
-    connect(m_profileDialog, SIGNAL(jumpToCall(int)),
-            this, SLOT(slotJumpTo(int)));
+    connect(m_ui.actionShowProfileDialog, &QAction::triggered,
+            m_profileDialog, &QWidget::show);
+    connect(m_profileDialog, &ProfileDialog::jumpToCall,
+            this, &MainWindow::slotJumpTo);
 
-    connect(m_ui.surfacesOpaqueCB, SIGNAL(stateChanged(int)), this,
-            SLOT(updateSurfacesView()));
-    connect(m_ui.surfacesAlphaCB, SIGNAL(stateChanged(int)), this,
-            SLOT(updateSurfacesView()));
-    connect(m_ui.surfacesResolveMSAA, SIGNAL(stateChanged(int)), this,
-            SLOT(updateSurfacesView()));
+    connect(m_ui.surfacesOpaqueCB, &QCheckBox::stateChanged, this,
+            qOverload<>(&MainWindow::updateSurfacesView));
+    connect(m_ui.surfacesAlphaCB, &QCheckBox::stateChanged, this,
+            qOverload<>(&MainWindow::updateSurfacesView));
+    connect(m_ui.surfacesResolveMSAA, &QCheckBox::stateChanged, this,
+            qOverload<>(&MainWindow::updateSurfacesView));
 }
 
 void MainWindow::updateActionsState(bool traceLoaded, bool stopped)
@@ -1500,9 +1491,9 @@ void MainWindow::customContextMenuRequested(QPoint pos)
 
     QMenu menu;
     menu.addAction(QIcon(":/resources/media-record.png"),
-                   tr("Lookup state"), this, SLOT(lookupState()));
+                   tr("Lookup state"), this, &MainWindow::lookupState);
     if (event->type() == ApiTraceEvent::Call) {
-        menu.addAction(tr("Edit"), this, SLOT(editCall()));
+        menu.addAction(tr("Edit"), this, &MainWindow::editCall);
     }
 
     menu.exec(QCursor::pos());

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -57,7 +57,8 @@ public slots:
 private slots:
     void callItemSelected(const QModelIndex &index);
     void callItemActivated(const QModelIndex &index);
-    void createTrace(const RecentLaunch* optionalLaunch = nullptr);
+    void createTrace(const RecentLaunch* optionalLaunch);
+    void createTrace() { createTrace(nullptr); }
     void openTrace();
     void saveTrace();
     void replayStart();

--- a/gui/pixelwidget.cpp
+++ b/gui/pixelwidget.cpp
@@ -283,27 +283,27 @@ void PixelWidget::contextMenuEvent(QContextMenuEvent *e)
     // Grid size options
     QAction incrGrid(QLatin1String("Increase grid size"), &menu);
     incrGrid.setShortcut(QKeySequence(Qt::Key_PageUp));
-    connect(&incrGrid, SIGNAL(triggered()), this, SLOT(increaseGridSize()));
+    connect(&incrGrid, &QAction::triggered, this, &PixelWidget::increaseGridSize);
     QAction decrGrid(QLatin1String("Decrease grid size"), &menu);
     decrGrid.setShortcut(QKeySequence(Qt::Key_PageDown));
-    connect(&decrGrid, SIGNAL(triggered()), this, SLOT(decreaseGridSize()));
+    connect(&decrGrid, &QAction::triggered, this, &PixelWidget::decreaseGridSize);
 
     // Zoom options
     QAction incrZoom(QLatin1String("Zoom in"), &menu);
     incrZoom.setShortcut(QKeySequence(Qt::Key_Plus));
-    connect(&incrZoom, SIGNAL(triggered()), this, SLOT(increaseZoom()));
+    connect(&incrZoom, &QAction::triggered, this, &PixelWidget::zoomStepUp);
     QAction decrZoom(QLatin1String("Zoom out"), &menu);
     decrZoom.setShortcut(QKeySequence(Qt::Key_Minus));
-    connect(&decrZoom, SIGNAL(triggered()), this, SLOT(decreaseZoom()));
+    connect(&decrZoom, &QAction::triggered, this, &PixelWidget::zoomStepDown);
 
     // Copy to clipboard / save
     QAction save(QLatin1String("Save as image"), &menu);
     save.setShortcut(QKeySequence(QLatin1String("Ctrl+S")));
-    connect(&save, SIGNAL(triggered()), this, SLOT(saveToFile()));
+    connect(&save, &QAction::triggered, this, &PixelWidget::saveToFile);
 #ifndef QT_NO_CLIPBOARD
     QAction copy(QLatin1String("Copy to clipboard"), &menu);
     copy.setShortcut(QKeySequence(QLatin1String("Ctrl+C")));
-    connect(&copy, SIGNAL(triggered()), this, SLOT(copyToClipboard()));
+    connect(&copy, &QAction::triggered, this, &PixelWidget::copyToClipboard);
 #endif
 
     menu.addAction(&title);

--- a/gui/pixelwidget.h
+++ b/gui/pixelwidget.h
@@ -81,7 +81,8 @@ public:
     QSize sizeHint() const override;
 
 public slots:
-    void setZoom(double zoom, bool forceGrid = true);
+    void setZoom(double zoom, bool forceGrid);
+    void setZoom(double zoom) { setZoom(zoom, true); }
     void setGridSize(int gridSize);
     void toggleGrid();
     void copyToClipboard();

--- a/gui/profiledialog.cpp
+++ b/gui/profiledialog.cpp
@@ -122,23 +122,23 @@ ProfileDialog::ProfileDialog(QWidget *parent)
 
 
     /* Synchronise selections */
-    connect(m_timeline, SIGNAL(selectionChanged(SelectionState)), m_cpuGraph, SLOT(setSelection(SelectionState)));
-    connect(m_timeline, SIGNAL(selectionChanged(SelectionState)), m_gpuGraph, SLOT(setSelection(SelectionState)));
+    connect(m_timeline, &GraphWidget::selectionChanged, m_cpuGraph, &GraphWidget::setSelection);
+    connect(m_timeline, &GraphWidget::selectionChanged, m_gpuGraph, &GraphWidget::setSelection);
 
-    connect(m_cpuGraph, SIGNAL(selectionChanged(SelectionState)), m_timeline, SLOT(setSelection(SelectionState)));
-    connect(m_cpuGraph, SIGNAL(selectionChanged(SelectionState)), m_gpuGraph, SLOT(setSelection(SelectionState)));
+    connect(m_cpuGraph, &GraphWidget::selectionChanged, m_timeline, &GraphWidget::setSelection);
+    connect(m_cpuGraph, &GraphWidget::selectionChanged, m_gpuGraph, &GraphWidget::setSelection);
 
-    connect(m_gpuGraph, SIGNAL(selectionChanged(SelectionState)), m_timeline, SLOT(setSelection(SelectionState)));
-    connect(m_gpuGraph, SIGNAL(selectionChanged(SelectionState)), m_cpuGraph, SLOT(setSelection(SelectionState)));
+    connect(m_gpuGraph, &GraphWidget::selectionChanged, m_timeline, &GraphWidget::setSelection);
+    connect(m_gpuGraph, &GraphWidget::selectionChanged, m_cpuGraph, &GraphWidget::setSelection);
 
-    connect(m_timeline, SIGNAL(selectionChanged(SelectionState)), this, SLOT(graphSelectionChanged(SelectionState)));
-    connect(m_cpuGraph, SIGNAL(selectionChanged(SelectionState)), this, SLOT(graphSelectionChanged(SelectionState)));
-    connect(m_gpuGraph, SIGNAL(selectionChanged(SelectionState)), this, SLOT(graphSelectionChanged(SelectionState)));
+    connect(m_timeline, &GraphWidget::selectionChanged, this, &ProfileDialog::graphSelectionChanged);
+    connect(m_cpuGraph, &GraphWidget::selectionChanged, this, &ProfileDialog::graphSelectionChanged);
+    connect(m_gpuGraph, &GraphWidget::selectionChanged, this, &ProfileDialog::graphSelectionChanged);
 
 
     /* Synchronise views between cpuGraph and gpuGraph */
-    connect(m_cpuGraph, SIGNAL(horizontalViewChanged(qint64,qint64)), m_gpuGraph, SLOT(setHorizontalView(qint64,qint64)));
-    connect(m_gpuGraph, SIGNAL(horizontalViewChanged(qint64,qint64)), m_cpuGraph, SLOT(setHorizontalView(qint64,qint64)));
+    connect(m_cpuGraph, &GraphWidget::horizontalViewChanged, m_gpuGraph, &GraphWidget::setHorizontalView);
+    connect(m_gpuGraph, &GraphWidget::horizontalViewChanged, m_cpuGraph, &GraphWidget::setHorizontalView);
 }
 
 

--- a/gui/searchwidget.cpp
+++ b/gui/searchwidget.cpp
@@ -12,14 +12,14 @@ SearchWidget::SearchWidget(QWidget *parent)
     m_ui.notFoundLabel->hide();
     m_origPalette = m_ui.lineEdit->palette();
 
-    connect(m_ui.nextButton, SIGNAL(clicked()),
-            SLOT(slotSearchNext()));
-    connect(m_ui.prevButton, SIGNAL(clicked()),
-            SLOT(slotSearchPrev()));
-    connect(m_ui.closeButton, SIGNAL(clicked()),
-            SLOT(slotCancel()));
-    connect(m_ui.lineEdit, SIGNAL(returnPressed()),
-            SLOT(slotSearchNext()));
+    connect(m_ui.nextButton, &QAbstractButton::clicked,
+            this, &SearchWidget::slotSearchNext);
+    connect(m_ui.prevButton, &QAbstractButton::clicked,
+            this, &SearchWidget::slotSearchPrev);
+    connect(m_ui.closeButton, &QAbstractButton::clicked,
+            this, &SearchWidget::slotCancel);
+    connect(m_ui.lineEdit, &QLineEdit::returnPressed,
+            this, &SearchWidget::slotSearchNext);
 
     m_ui.nextButton->setShortcut(
         QKeySequence::FindNext);


### PR DESCRIPTION
Use "new" Qt Signal-Slot connections, which will compile-time check the connections.

New overloads are added to work around limitations in the new-style
connections -- connecting to slots that take more arguments than the
signal, even with defaults, will not work with new-style connections.

Optimize QString concatenation by using % (removing a warning).