### PR TITLE
Avoid compilation error with ambiguous `QString + QLatin1String`

### DIFF
--- a/gui/apitracecall.cpp
+++ b/gui/apitracecall.cpp
@@ -1097,7 +1097,8 @@ QString ApiTraceCall::searchText() const
         return m_searchText;
 
     QVector<QVariant> argValues = arguments();
-    m_searchText = m_signature->name() + QLatin1String("(");
+    m_searchText = m_signature->name();
+    m_searchText += QLatin1String("(");
     QStringList argNames = m_signature->argNames();
     for (int i = 0; i < argNames.count(); ++i) {
         m_searchText += argNames[i] +


### PR DESCRIPTION
Building apitrace like this on macOS causes issues:

```bash
cd apitrace

mkdir build
cd build
cmake -DENABLE_GUI=ON -DENABLE_QT6=ON ..
make
```

Eventually it ends with this error:

```
Building CXX object gui/CMakeFiles/qapitrace.dir/apitracecall.cpp.o
/Users/fox/Projects/apitrace/gui/apitracecall.cpp:1100:40: error: use of overloaded operator '+' is ambiguous (with operand types 'QString' and 'QLatin1String')
    m_searchText = m_signature->name() + QLatin1String("(");
                   ~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~
/opt/homebrew/include/QtCore/qstring.h:1524:16: note: candidate function
inline QString operator+(QString &&lhs, const QString &rhs)
               ^
/opt/homebrew/lib/QtCore.framework/Headers/qstringbuilder.h:404:1: note: candidate function [with A = QString, B = QLatin1String]
operator+(const A &a, const B &b)
^
1 error generated.
```

I'm not sure why other platforms aren't affected.