### PR TITLE
retrace: call waffle_destroy_window on drawable destructor

### DIFF
--- a/retrace/glws_waffle.cpp
+++ b/retrace/glws_waffle.cpp
@@ -69,6 +69,10 @@ public:
         window (win)
     {}
 
+    ~WaffleDrawable() {
+        waffle_window_destroy(window);
+    }
+
     void
     resize(int w, int h) {
         if (w == width && h == height) {


### PR DESCRIPTION
Without this patch, replaying an eglDestroySurface() call won't generate a eglDestroySurface() call using the waffle backend, leaving any created windows alive indefinitely.