### PR TITLE
Allow building without GTest when BUILD_TESTING is not set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,7 +556,9 @@ if (NOT WIN32 AND NOT ENABLE_STATIC_EXE)
         pkg_check_modules (BROTLIENC IMPORTED_TARGET libbrotlienc>=1.0.7)
     endif ()
 
-    find_package (GTest)
+    if (BUILD_TESTING)
+        find_package (GTest)
+    endif ()
 endif ()
 
 add_subdirectory (thirdparty)
@@ -568,12 +570,15 @@ add_subdirectory (thirdparty)
 include_directories (BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/khronos)
 
 # Convenience macro for adding unit tests
-macro (add_gtest)
-    add_executable (${ARGV})
-    target_link_libraries (${ARGV0} GTest::GTest)
-    add_dependencies (check ${ARGV0})
-    add_test (NAME ${ARGV0} COMMAND ${ARGV0})
-endmacro ()
+# Should only be invoked when BUILD_TESTING is enabled
+if (BUILD_TESTING)
+  macro (add_gtest)
+      add_executable (${ARGV})
+      target_link_libraries (${ARGV0} GTest::GTest)
+      add_dependencies (check ${ARGV0})
+      add_test (NAME ${ARGV0} COMMAND ${ARGV0})
+  endmacro ()
+endif ()
 
 
 ##############################################################################

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -60,7 +60,7 @@ if (CMAKE_EXECUTABLE_FORMAT STREQUAL "ELF")
 endif ()
 
 # We use non-standard C++ flags, so we can't just use GTest's CMakeLists.txt
-if (NOT GTEST_FOUND)
+if (BUILD_TESTING AND NOT GTEST_FOUND)
     message (STATUS "Using bundled GTest")
     include_with_scope (gtest.cmake)
 endif ()


### PR DESCRIPTION
googletest should not be a mandatory dependency unless actually building the unit tests.