### PR TITLE
Fake command line arguments during replay, so they match traced program's arguments

### DIFF
--- a/lib/os/os_posix.cpp
+++ b/lib/os/os_posix.cpp
@@ -130,6 +130,35 @@ getProcessName(void)
 }
 
 String
+getProcessCommandLine(void)
+{
+    String path;
+
+    size_t size = PATH_MAX;
+    char buf[size];
+
+    int fd = open("/proc/self/cmdline", O_RDONLY);
+    if (fd >= 0) {
+        size_t len = read(fd, buf, size);
+        close(fd);
+
+        if (len > 0) {
+            size_t start = strlen(buf) + 1;
+            size_t cmdlineLen = len - start;
+
+            char *pathBuf = path.buf(cmdlineLen);
+            for (size_t i = 0; i < cmdlineLen - 1; i++) {
+                char character = buf[start + i];
+                if (character == '\0') character = ' ';
+                pathBuf[i] = character;
+            }
+        }
+    }
+
+    return path;
+}
+
+String
 getCurrentDir(void)
 {
     String path;

--- a/lib/os/os_string.hpp
+++ b/lib/os/os_string.hpp
@@ -423,6 +423,7 @@ public:
 
 
 String getProcessName();
+String getProcessCommandLine(void);
 String getCurrentDir();
 
 String getConfigDir();

--- a/lib/os/os_win32.cpp
+++ b/lib/os/os_win32.cpp
@@ -57,6 +57,15 @@ getProcessName(void)
 }
 
 String
+getProcessCommandLine(void)
+{
+    LPSTR commandLineRaw = GetCommandLineA();
+    String commandLine(commandLineRaw);
+
+    return commandLine;
+}
+
+String
 getCurrentDir(void)
 {
     String path;

--- a/lib/trace/trace_writer_local.cpp
+++ b/lib/trace/trace_writer_local.cpp
@@ -154,6 +154,8 @@ LocalWriter::open(void) {
     Properties properties;
     os::String processName = os::getProcessName();
     properties["process.name"] = processName;
+    os::String processCommandLine = os::getProcessCommandLine();
+    properties["process.commandLine"] = processCommandLine;
 
     if (!Writer::open(lpFileName, TRACE_VERSION, properties)) {
         os::log("apitrace: error: failed to open %s\n", lpFileName);

--- a/retrace/process_name.hpp
+++ b/retrace/process_name.hpp
@@ -29,3 +29,6 @@
 
 void
 setProcessName(const char *processName);
+
+void
+setProcessCommandLine(const char* processCommandLine);

--- a/retrace/retrace_main.cpp
+++ b/retrace/retrace_main.cpp
@@ -1456,6 +1456,10 @@ int main(int argc, char **argv)
             if (processNameIt != properties.end()) {
                 adjustProcessName(processNameIt->second);
             }
+            auto processCommandLineIt = properties.find("process.commandLine");
+            if (processCommandLineIt != properties.end()) {
+                setProcessCommandLine(processCommandLineIt->second.c_str());
+            }
 
             retrace::mainLoop();
 


### PR DESCRIPTION
Some middleware libraries and/or drivers may detect applications based on executable name and command line. Apitrace currently saves executable name in the trace and then injects its own implementation of some syscalls during replay to return this name.

This PR adds this functionality to command line to further enhance the illusion of replayed app being the real app. Currently only fully implemented on Windows.