### PR TITLE
Fix tracing and replaying of Dying Light

### DIFF
--- a/lib/os/os_posix.cpp
+++ b/lib/os/os_posix.cpp
@@ -146,11 +146,13 @@ getProcessCommandLine(void)
             size_t start = strlen(buf) + 1;
             size_t cmdlineLen = len - start;
 
-            char *pathBuf = path.buf(cmdlineLen);
-            for (size_t i = 0; i < cmdlineLen - 1; i++) {
-                char character = buf[start + i];
-                if (character == '\0') character = ' ';
-                pathBuf[i] = character;
+            if (cmdlineLen > 0) {
+                char *pathBuf = path.buf(cmdlineLen);
+                for (size_t i = 0; i < cmdlineLen - 1; i++) {
+                    char character = buf[start + i];
+                    if (character == '\0') character = ' ';
+                    pathBuf[i] = character;
+                }
             }
         }
     }

--- a/wrappers/gltrace.hpp
+++ b/wrappers/gltrace.hpp
@@ -130,7 +130,7 @@ is_coherent_write_map(GLbitfield access)
     }
 #endif
 
-    return true;
+    return false;
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/apitrace/apitrace/issues/493

The fixes are in the recent code, so the issue is probably not the exact same as the original reporter had. But tracing and replaying the Dying Light was broken in 11.1 and current master too.

With these patches, I can confirm that both tracing and replaying actually works.