### PR TITLE
Some fixes related to the MRs I opened earlier

### DIFF
--- a/cli/cli_trace.cpp
+++ b/cli/cli_trace.cpp
@@ -269,7 +269,8 @@ traceProgram(trace::API api,
 
         if (output) {
             os::setEnvironment("TRACE_FILE", output);
-        } else if (timestamp) {
+        }
+        if (timestamp) {
             os::setEnvironment("TRACE_TIMESTAMP", "1");
         }
 
@@ -348,8 +349,7 @@ usage(void)
         "                        default is `gl`\n"
         "    -o, --output=TRACE  specify output trace file;\n"
         "                        default is `PROGRAM.trace`\n"
-        "    -t, --timestamp     append timestamp to output trace filename;\n"
-        "                        ignored if --output argument is specified\n"
+        "    -t, --timestamp     append timestamp to output trace filename\n"
 #ifdef TRACE_VARIABLE
         "    -d,  --debug        run inside debugger (gdb/lldb)\n"
 #endif

--- a/cli/cli_trace.cpp
+++ b/cli/cli_trace.cpp
@@ -360,7 +360,7 @@ usage(void)
 }
 
 const static char *
-shortOptions = "+hva:o:dm";
+shortOptions = "+hva:o:dmt";
 
 const static struct option
 longOptions[] = {

--- a/specs/eglapi.py
+++ b/specs/eglapi.py
@@ -490,7 +490,7 @@ eglapi.addFunctions([
     GlFunction(Void, "glEGLImageTargetRenderbufferStorageOES", [(GLenum, "target"), (EGLImageKHR, "image")]),
 
     # EGL_EXT_surface_compression
-    GlFunction(EGLBoolean, "eglQuerySupportedCompressionRatesEXT", [(EGLDisplay, "dpy"), (EGLConfig, "config"), (EGLWindowSurfaceAttribs, "attrib_list"), Out(Array(EGLint, "*num_rates"), "rates"), (EGLint, "rate_size"), Out(Pointer(EGLint), "num_rates")], sideeffects=False),
+    GlFunction(EGLBoolean, "eglQuerySupportedCompressionRatesEXT", [(EGLDisplay, "dpy"), (EGLConfig, "config"), (EGLWindowSurfaceAttribs, "attrib_list"), Out(Array(EGLSurfaceCompressionRate, "*num_rates"), "rates"), (EGLint, "rate_size"), Out(Pointer(EGLint), "num_rates")], sideeffects=False),
 
     # EGL_WL_bind_wayland_display
     GlFunction(EGLBoolean, "eglBindWaylandDisplayWL", [(EGLDisplay, "dpy"), (WlDisplay, "display")]),


### PR DESCRIPTION
- Fix "-t" short option
- Don't mutually exclude "--timestamp" and "--output" options
- Dump the enum value name for compression rates instead of the value