### PR TITLE
frametrim: add backend for D3D9 API

### DIFF
--- a/frametrim/CMakeLists.txt
+++ b/frametrim/CMakeLists.txt
@@ -12,13 +12,20 @@ include_directories (
     ${CMAKE_SOURCE_DIR}/thirdparty/mhook/mhook-lib
 )
 
+if (DirectX_D3D9_INCLUDE_FOUND)
+   include_directories (BEFORE SYSTEM ${DirectX_D3D9_INCLUDE_DIR})
+   add_definitions (-DHAVE_D3D9)
+   set (D3D9_SOURCES ft_d3d9.cpp)
+endif ()
+
 add_executable(gltrim
    ft_dependecyobject.cpp
    ft_frametrimmer.cpp
    ft_main.cpp
    ft_matrixstate.cpp
    ft_opengl.cpp
-   ft_tracecall.cpp)
+   ft_tracecall.cpp
+   ${D3D9_SOURCES})
 
 target_link_libraries (gltrim
     retrace_common

--- a/frametrim/ft_d3d9.cpp
+++ b/frametrim/ft_d3d9.cpp
@@ -1,0 +1,871 @@
+/*
+ * Copyright © 2024 Igalia S.L.
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "ft_d3d9.hpp"
+
+#include <algorithm>
+#include <d3d9.h>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <unordered_set>
+
+using std::bind;
+using std::placeholders::_1;
+
+namespace frametrim {
+
+struct SetState {
+    const char* method;
+    uint32_t params_to_capture;
+    int32_t resource_idx;
+};
+
+const int32_t NoResource = -1;
+
+const std::vector<SetState> state_calls = {
+    {"IDirect3DDevice9::SetClipStatus", 0, NoResource},
+    {"IDirect3DDevice9::SetDepthStencilSurface", 0, 1},
+    {"IDirect3DDevice9::SetFVF", 0, NoResource},
+    {"IDirect3DDevice9::SetIndices", 0, 1},
+    {"IDirect3DDevice9::SetMaterial", 0, NoResource},
+    {"IDirect3DDevice9::SetNPatchMode", 0, NoResource},
+    {"IDirect3DDevice9::SetPixelShader", 0, 1},
+    {"IDirect3DDevice9::SetScissorRect", 0, NoResource},
+    {"IDirect3DDevice9::SetSoftwareVertexProcessing", 0, NoResource},
+    {"IDirect3DDevice9::SetVertexDeclaration", 0, 1},
+    {"IDirect3DDevice9::SetVertexShader", 0, 1},
+    {"IDirect3DDevice9::SetViewport", 0, NoResource},
+
+    {"IDirect3DDevice9::MultiplyTransform", 1, NoResource},
+    {"IDirect3DDevice9::LightEnable", 1, NoResource},
+    {"IDirect3DDevice9::SetClipPlane", 1, NoResource},
+    {"IDirect3DDevice9::SetCurrentTexturePalette", 1, NoResource},
+    {"IDirect3DDevice9::SetGammaRamp", 1, NoResource},
+    {"IDirect3DDevice9::SetLight", 1, NoResource},
+    {"IDirect3DDevice9::SetPaletteEntries", 1, NoResource},
+    {"IDirect3DDevice9::SetRenderState", 1, NoResource},
+    {"IDirect3DDevice9::SetRenderTarget", 1, 2},
+    {"IDirect3DDevice9::SetStreamSource", 1, 2},
+    {"IDirect3DDevice9::SetStreamSourceFreq", 1, NoResource},
+    {"IDirect3DDevice9::SetTexture", 1, 2},
+    {"IDirect3DDevice9::SetTransform", 1, NoResource},
+
+    {"IDirect3DDevice9::SetSamplerState", 2, NoResource},
+    {"IDirect3DDevice9::SetTextureStageState", 2, NoResource},
+
+    // EX
+
+    {"IDirect3DDevice9Ex::SetClipStatus", 0, NoResource},
+    {"IDirect3DDevice9Ex::SetDepthStencilSurface", 0, 1},
+    {"IDirect3DDevice9Ex::SetFVF", 0, NoResource},
+    {"IDirect3DDevice9Ex::SetIndices", 0, 1},
+    {"IDirect3DDevice9Ex::SetMaterial", 0, NoResource},
+    {"IDirect3DDevice9Ex::SetNPatchMode", 0, NoResource},
+    {"IDirect3DDevice9Ex::SetPixelShader", 0, 1},
+    {"IDirect3DDevice9Ex::SetScissorRect", 0, NoResource},
+    {"IDirect3DDevice9Ex::SetSoftwareVertexProcessing", 0, NoResource},
+    {"IDirect3DDevice9Ex::SetVertexDeclaration", 0, 1},
+    {"IDirect3DDevice9Ex::SetVertexShader", 0, 1},
+    {"IDirect3DDevice9Ex::SetViewport", 0, NoResource},
+
+    {"IDirect3DDevice9Ex::MultiplyTransform", 1, NoResource},
+    {"IDirect3DDevice9Ex::LightEnable", 1, NoResource},
+    {"IDirect3DDevice9Ex::SetClipPlane", 1, NoResource},
+    {"IDirect3DDevice9Ex::SetCurrentTexturePalette", 1, NoResource},
+    {"IDirect3DDevice9Ex::SetGammaRamp", 1, NoResource},
+    {"IDirect3DDevice9Ex::SetLight", 1, NoResource},
+    {"IDirect3DDevice9Ex::SetPaletteEntries", 1, NoResource},
+    {"IDirect3DDevice9Ex::SetRenderState", 1, NoResource},
+    {"IDirect3DDevice9Ex::SetRenderTarget", 1, 2},
+    {"IDirect3DDevice9Ex::SetStreamSource", 1, 2},
+    {"IDirect3DDevice9Ex::SetStreamSourceFreq", 1, NoResource},
+    {"IDirect3DDevice9Ex::SetTexture", 1, 2},
+    {"IDirect3DDevice9Ex::SetTransform", 1, NoResource},
+
+    {"IDirect3DDevice9Ex::SetSamplerState", 2, NoResource},
+    {"IDirect3DDevice9Ex::SetTextureStageState", 2, NoResource},
+};
+
+D3D9Impl::D3D9Impl(bool keep_all_states, bool swaps_to_finish)
+    : FrameTrimmer(keep_all_states, swaps_to_finish)
+{
+    registerCalls();
+}
+
+void D3D9Impl::switch_thread(int new_thread)
+{
+}
+
+class PointerReplacer : public trace::Visitor {
+  public:
+    PointerReplacer(std::unordered_map<uintptr_t, RemapPointerInfo>& pointer_map, unsigned callno)
+        : m_callno(callno), m_pointer_map(pointer_map) {};
+
+    void visit(trace::Null*) override
+    {
+    }
+    void visit(trace::Bool*) override
+    {
+    }
+    void visit(trace::SInt*) override
+    {
+    }
+    void visit(trace::UInt*) override
+    {
+    }
+    void visit(trace::Float*) override
+    {
+    }
+    void visit(trace::Double*) override
+    {
+    }
+    void visit(trace::String*) override
+    {
+    }
+    void visit(trace::WString*) override
+    {
+    }
+    void visit(trace::Enum*) override
+    {
+    }
+    void visit(trace::Bitmask*) override
+    {
+    }
+    void visit(trace::Struct* s) override
+    {
+        for (auto memberValue : s->members) {
+            _visit(memberValue);
+        }
+    }
+    void visit(trace::Array* array) override
+    {
+        for (auto& value : array->values) {
+            _visit(value);
+        }
+    }
+    void visit(trace::Blob*) override
+    {
+    }
+    void visit(trace::Pointer* pointer) override
+    {
+        if (!pointer->value)
+            return;
+
+        auto it = m_pointer_map.find(pointer->value);
+        if (it == m_pointer_map.end())
+            return;
+
+        auto& info = it->second;
+        if (info.first_call > m_callno)
+            return;
+
+        pointer->value = info.ptr;
+    }
+    void visit(trace::Repr*) override
+    {
+    }
+
+  private:
+    unsigned m_callno;
+    std::unordered_map<uintptr_t, RemapPointerInfo>& m_pointer_map;
+};
+
+void D3D9Impl::modify_last_frame_call(trace::Call& call)
+{
+    if (m_pointer_map.empty())
+        return;
+
+    PointerReplacer replacer(m_pointer_map, call.no);
+    for (auto& arg : call.args) {
+        if (arg.value)
+            arg.value->visit(replacer);
+    }
+    if (call.ret)
+        call.ret->visit(replacer);
+}
+
+void D3D9Impl::emitState()
+{
+    assert(m_recording_frame);
+
+    auto addResource = [&](uintptr_t resource) {
+        if (resource != 0) {
+            auto it = m_active_objects.find(resource);
+
+            if (it != m_active_objects.end()) {
+                assert(it != m_active_objects.end());
+                it->second->m_used_in_recording_frame = true;
+            }
+            else {
+                std::cerr
+                    << "Resource " << std::hex << resource << std::dec
+                    << " was set in a state but was deleted without being removed from the state."
+                    << std::endl;
+            }
+        }
+    };
+
+    /* Do not drop resources which are used in frame setup */
+    for (auto&& [name, call] : m_state_calls) {
+        addResource(call.resource_used);
+    }
+    for (auto&& [addr, d3dobj] : m_active_objects) {
+        for (const auto& [key, state] : d3dobj->m_bundleState) {
+            addResource(state.resource_used);
+        }
+    }
+
+    for (auto&& [name, call] : m_state_calls)
+        m_required_calls.insert(call.call);
+
+    for (auto& stage : m_shader_constants) {
+        for (auto& c : stage) {
+            m_required_calls.insert(c);
+        }
+    }
+}
+
+void D3D9Impl::finalize()
+{
+    /* Only add calls for objects that are actually used */
+    for (auto&& [addr, d3dobj] : m_active_objects) {
+        if (d3dobj->m_used_in_recording_frame) {
+            d3dobj->addToRequiredCalls(m_required_calls);
+        }
+
+        for (auto& call : d3dobj->m_overriden_calls) {
+            m_overriden_calls.insert(std::make_pair(call->no, call));
+        }
+    }
+
+    for (auto& d3dobj : m_released_objects) {
+        for (auto& call : d3dobj->m_overriden_calls) {
+            m_overriden_calls.insert(std::make_pair(call->no, call));
+        }
+    }
+}
+
+int strendswith(const char* str, const char* suffix)
+{
+    size_t str_len = strlen(str);
+    size_t suffix_len = strlen(suffix);
+    if (suffix_len > str_len)
+        return 1;
+    return strcmp(str + str_len - suffix_len, suffix);
+}
+
+ft_callback D3D9Impl::findCallback(const char* name)
+{
+    auto it = m_call_table.find(name);
+    if (it != m_call_table.end()) {
+        return it->second;
+    }
+
+    if (strstr(name, "::Release") != nullptr) {
+        return bind(&D3D9Impl::recordResourceRelease, this, _1);
+    }
+    if (strstr(name, "::AddRef") != nullptr) {
+        return bind(&D3D9Impl::recordResourceRef, this, _1, 0);
+    }
+    if (strendswith(name, "::GetDevice") == 0) {
+        return bind(&D3D9Impl::recordResourceRef, this, _1, 1);
+    }
+    if (strendswith(name, "::QueryInterface") == 0) {
+        return bind(&D3D9Impl::recordResourceRef, this, _1, 2);
+    }
+
+    return nullptr;
+}
+
+bool D3D9Impl::skipDeleteObj(const trace::Call& call)
+{
+    /* Doesn't really skip calls in recording frame? */
+    return false;
+}
+
+#define MAP(name, call) m_call_table.insert(std::make_pair(#name, bind(&D3D9Impl::call, this, _1)))
+
+#define MAP_V(name, call, param1)                                                                  \
+    m_call_table.insert(std::make_pair(#name, bind(&D3D9Impl::call, this, _1, param1)))
+
+#define MAP_VV(name, call, param1, param2)                                                         \
+    m_call_table.insert(std::make_pair(#name, bind(&D3D9Impl::call, this, _1, param1, param2)))
+
+#define MAP_VVV(name, call, param1, param2, param3)                                                \
+    m_call_table.insert(                                                                           \
+        std::make_pair(#name, bind(&D3D9Impl::call, this, _1, param1, param2, param3)))
+
+#define MAP_VVVV(name, call, param1, param2, param3, param4)                                       \
+    m_call_table.insert(                                                                           \
+        std::make_pair(#name, bind(&D3D9Impl::call, this, _1, param1, param2, param3, param4)))
+
+#define MAP_EX(ifc, method, call)                                                                  \
+    MAP(ifc::method, call);                                                                        \
+    MAP(ifc##Ex::method, call)
+
+#define MAP_EX_V(ifc, method, call, param1)                                                        \
+    MAP_V(ifc::method, call, param1);                                                              \
+    MAP_V(ifc##Ex::method, call, param1)
+
+#define MAP_EX_VV(ifc, method, call, param1, param2)                                               \
+    MAP_VV(ifc::method, call, param1, param2);                                                     \
+    MAP_VV(ifc##Ex::method, call, param1, param2)
+
+void D3D9Impl::registerCalls()
+{
+    for (auto& state : state_calls)
+        m_call_table.insert(
+            std::make_pair(state.method, bind(&D3D9Impl::recordStateCall, this, _1,
+                                              state.params_to_capture, state.resource_idx)));
+
+    MAP_EX(IDirect3DDevice9, BeginStateBlock, recordBeginStateBlock);
+    MAP_EX(IDirect3DDevice9, EndStateBlock, recordEndStateBlock);
+
+    MAP(IDirect3DStateBlock9::Apply, recordStateBlockApply);
+    MAP(IDirect3DStateBlock9::Capture, recordStateBlockCapture);
+
+    MAP_EX_V(IDirect3DDevice9, SetVertexShaderConstantF, recordShaderSetConstant, ss_vertex);
+    MAP_EX_V(IDirect3DDevice9, SetVertexShaderConstantI, recordShaderSetConstant, ss_vertex);
+    MAP_EX_V(IDirect3DDevice9, SetVertexShaderConstantB, recordShaderSetConstant, ss_vertex);
+    MAP_EX_V(IDirect3DDevice9, SetPixelShaderConstantF, recordShaderSetConstant, ss_pixel);
+    MAP_EX_V(IDirect3DDevice9, SetPixelShaderConstantI, recordShaderSetConstant, ss_pixel);
+    MAP_EX_V(IDirect3DDevice9, SetPixelShaderConstantB, recordShaderSetConstant, ss_pixel);
+
+    MAP(memcpy, recordMemcpy);
+    MAP_EX(IDirect3DDevice9, Reset, recordReset);
+    MAP(IDirect3DDevice9Ex::ResetEx, recordReset);
+    MAP_EX_VV(IDirect3DDevice9, UpdateSurface, recordResourceDep, 1, 3);
+    MAP_EX_VV(IDirect3DDevice9, StretchRect, recordResourceDep, 1, 3);
+    MAP_EX_VV(IDirect3DDevice9, UpdateTexture, recordResourceDep, 1, 2);
+
+    MAP_EX_V(IDirect3DDevice9, GetPixelShader, recordResourceRef, 1);
+    MAP_EX_V(IDirect3DDevice9, GetVertexShader, recordResourceRef, 1);
+    MAP_EX_V(IDirect3DDevice9, GetVertexDeclaration, recordResourceRef, 1);
+    MAP_EX_V(IDirect3DDevice9, GetIndices, recordResourceRef, 1);
+    MAP_EX_V(IDirect3DDevice9, GetTexture, recordResourceRef, 2);
+    MAP_EX_V(IDirect3DDevice9, GetStreamSource, recordResourceRef, 2);
+
+    MAP_VV(Direct3DCreate9, recordResourceCreation, -1, false);
+    MAP_VV(Direct3DCreate9Ex, recordResourceCreation, 1, false);
+    MAP_EX_VV(IDirect3D9, CreateDevice, recordResourceCreation, 6, false);
+    MAP_EX_VV(IDirect3DDevice9, GetDirect3D, recordResourceCreation, 1, false);
+
+    MAP_EX_VV(IDirect3DDevice9, CreateVertexDeclaration, recordResourceCreation, 2, true);
+    MAP_EX_VV(IDirect3DDevice9, CreateVertexBuffer, recordResourceCreation, 5, true);
+    MAP_EX_VV(IDirect3DDevice9, CreateIndexBuffer, recordResourceCreation, 5, true);
+    MAP_EX_VV(IDirect3DDevice9, CreatePixelShader, recordResourceCreation, 2, true);
+    MAP_EX_VV(IDirect3DDevice9, CreateVertexShader, recordResourceCreation, 2, true);
+    MAP_EX_VV(IDirect3DDevice9, CreateTexture, recordResourceCreation, 7, true);
+    MAP_EX_VV(IDirect3DDevice9, CreateCubeTexture, recordResourceCreation, 6, true);
+    MAP_EX_VV(IDirect3DDevice9, CreateVolumeTexture, recordResourceCreation, 8, true);
+    MAP_EX_VV(IDirect3DDevice9, CreateOffscreenPlainSurface, recordResourceCreation, 5, true);
+    MAP_EX_VV(IDirect3DDevice9, CreateRenderTarget, recordResourceCreation, 7, true);
+    MAP_EX_VV(IDirect3DDevice9, CreateDepthStencilSurface, recordResourceCreation, 7, true);
+    MAP_EX_VV(IDirect3DDevice9, CreateAdditionalSwapChain, recordResourceCreation, 2, true);
+    MAP_EX_VV(IDirect3DDevice9, CreateQuery, recordResourceCreation, 2, true);
+    MAP_VV(IDirect3DDevice9Ex::CreateRenderTargetEx, recordResourceCreation, 7, true);
+    MAP_VV(IDirect3DDevice9Ex::CreateOffscreenPlainSurfaceEx, recordResourceCreation, 7, true);
+    MAP_VV(IDirect3DDevice9Ex::CreateDepthStencilSurfaceEx, recordResourceCreation, 7, true);
+
+    MAP_EX_V(IDirect3DDevice9, GetBackBuffer, recordResourceInternalCreateOrGet, 4);
+    MAP_EX_V(IDirect3DDevice9, GetRenderTarget, recordResourceInternalCreateOrGet, 2);
+    MAP_EX_V(IDirect3DDevice9, GetDepthStencilSurface, recordResourceInternalCreateOrGet, 1);
+    MAP_EX_V(IDirect3DDevice9, GetSwapChain, recordResourceInternalCreateOrGet, 2);
+
+    MAP_EX_VV(IDirect3DSwapChain9, GetBackBuffer, recordResourceCreation, 3, true);
+    MAP_EX(IDirect3DSwapChain9, Present, recordPresent);
+
+    MAP_VV(IDirect3DQuery9::Issue, recordResourceUsage, 0, eCallType::unknown);
+
+    MAP_VVV(IDirect3DTexture9::GetSurfaceLevel, recordResourceSubresource, 0, 1, 2);
+    MAP_VVV(IDirect3DCubeTexture9::GetCubeMapSurface, recordResourceSubresource, 0, 2, 3);
+    MAP_VVV(IDirect3DVolumeTexture9::GetVolumeLevel, recordResourceSubresource, 0, 1, 2);
+
+    MAP_VVVV(IDirect3DIndexBuffer9::Lock, recordResourceLock, 0, -1, -1, 3);
+    MAP_VVV(IDirect3DIndexBuffer9::Unlock, recordResourceUnlock, 0, -1, -1);
+    MAP_VVVV(IDirect3DVertexBuffer9::Lock, recordResourceLock, 0, -1, -1, 3);
+    MAP_VVV(IDirect3DVertexBuffer9::Unlock, recordResourceUnlock, 0, -1, -1);
+
+    MAP_VVVV(IDirect3DTexture9::LockRect, recordResourceLock, 0, 1, -1, 2);
+    MAP_VVV(IDirect3DTexture9::UnlockRect, recordResourceUnlock, 0, 1, -1);
+    MAP_VVVV(IDirect3DCubeTexture9::LockRect, recordResourceLock, 0, 2, 1, 3);
+    MAP_VVV(IDirect3DCubeTexture9::UnlockRect, recordResourceUnlock, 0, 2, 1);
+    MAP_VVVV(IDirect3DVolume9::LockBox, recordResourceLock, 0, -1, -1, 1);
+    MAP_VVV(IDirect3DVolume9::UnlockBox, recordResourceUnlock, 0, -1, -1);
+    MAP_VVVV(IDirect3DVolumeTexture9::LockBox, recordResourceLock, 0, 1, -1, 2);
+    MAP_VVV(IDirect3DVolumeTexture9::UnlockBox, recordResourceUnlock, 0, 1, -1);
+    MAP_VVVV(IDirect3DSurface9::LockRect, recordResourceLock, 0, -1, -1, 1);
+    MAP_VVV(IDirect3DSurface9::UnlockRect, recordResourceUnlock, 0, -1, -1);
+}
+
+void D3D9Impl::recordBeginStateBlock(const trace::Call& call)
+{
+    /* E.g. Command and Conquer 3 does this */
+    if (m_currentStateBlock)
+        return;
+
+    m_currentStateBlock = std::make_unique<D3D9Object>();
+    m_currentStateBlock->m_calls.push_back(trace2call(call));
+}
+
+void D3D9Impl::recordEndStateBlock(const trace::Call& call)
+{
+    if (!m_currentStateBlock)
+        return;
+
+    /* We get block's pointer only at ::EndStateBlock */
+
+    auto begin_block_call = m_currentStateBlock->m_calls[0];
+    m_currentStateBlock->create(call, m_recording_frame, true);
+    m_currentStateBlock->m_calls.push_back(begin_block_call);
+
+    auto block_ptr = call.arg(1).toArray()->values[0]->toUIntPtr();
+
+    remapPointer(m_currentStateBlock.get(), block_ptr, call.no);
+
+    m_active_objects.insert_or_assign(block_ptr,
+                                      std::shared_ptr<D3D9Object>(m_currentStateBlock.release()));
+    m_currentStateBlock.reset();
+}
+
+void D3D9Impl::recordStateBlockApply(const trace::Call& call)
+{
+    /* TODO: Handle ShaderConstant calls */
+    auto block_ptr = call.arg(0).toUIntPtr();
+    auto& d3dobj = m_active_objects[block_ptr];
+    for (const auto& [key, value] : d3dobj->m_bundleState) {
+        m_state_calls[key] = value;
+    }
+
+    d3dobj->access(call, m_recording_frame);
+}
+
+void D3D9Impl::recordStateBlockCapture(const trace::Call& call)
+{
+    auto block_ptr = call.arg(0).toUIntPtr();
+    auto& d3dobj = m_active_objects[block_ptr];
+
+    d3dobj->m_calls.push_back(trace2call(call));
+
+    for (const auto& [key, value] : d3dobj->m_bundleState) {
+        const auto&& it = m_state_calls.find(key);
+        if (it != m_state_calls.end()) {
+            (d3dobj->m_bundleState)[key] = it->second;
+            d3dobj->m_calls.push_back(value.call);
+        }
+    }
+
+    d3dobj->access(call, m_recording_frame);
+
+    if (d3dobj->m_state_block_has_set_constant && !m_recording_frame) {
+        std::cerr
+            << call.no << " " << call.name()
+            << " captures shader constants outside of recording frame, this may lead to issues!"
+            << std::endl;
+    }
+}
+
+void D3D9Impl::recordReset(const trace::Call& call)
+{
+    std::cerr << call.no << " " << call.name() << " may not be perfectly handled." << std::endl;
+    m_currentStateBlock.reset();
+    m_state_calls.clear();
+    this->recordRequiredCall(call);
+}
+
+static const unsigned long long getResourcePtrFromCall(const trace::Call& call, int32_t param_idx)
+{
+    if (param_idx == -1)
+        return call.ret->toUIntPtr();
+
+    if (!call.args[param_idx].value)
+        return 0;
+
+    auto& arg = call.arg(param_idx);
+    if (arg.toArray() == nullptr)
+        return call.arg(param_idx).toUIntPtr();
+    else
+        return call.arg(param_idx).toArray()->values[0]->toUIntPtr();
+}
+
+void D3D9Impl::recordStateCall(const trace::Call& call, uint32_t params_to_capture,
+                               int32_t resource_idx)
+{
+    uintptr_t resource_ptr = 0;
+    if (resource_idx != NoResource) {
+        resource_ptr = getResourcePtrFromCall(call, resource_idx);
+    }
+
+    if (m_recording_frame && resource_ptr > 0) {
+        auto it = m_active_objects.find(resource_ptr);
+        if (it != m_active_objects.end()) {
+            it->second->access(call, true);
+        }
+
+        return;
+    }
+
+    std::array<uint32_t, 4> key = {0, 0, 0, 0};
+    key[0] = call.sig->id;
+    for (unsigned i = 0; i < params_to_capture; ++i)
+        key[i + 1] = call.arg(i + 1).toUInt();
+
+    auto c = std::make_shared<TraceCall>(call, call.name());
+
+    if (m_currentStateBlock) {
+        (m_currentStateBlock->m_bundleState)[key] = {c, resource_ptr};
+        return;
+    }
+
+    m_state_calls[key] = {c, resource_ptr};
+}
+
+void D3D9Impl::recordResourceCreation(const trace::Call& call, int32_t resource_idx, bool removable)
+{
+    auto resource_ptr = getResourcePtrFromCall(call, resource_idx);
+    if (resource_ptr == 0)
+        return;
+
+    m_active_objects[resource_ptr] = std::make_shared<D3D9Object>();
+    auto& d3dobj = m_active_objects[resource_ptr];
+    d3dobj->create(call, m_recording_frame, removable);
+
+    if (!d3dobj->m_calls_removable && !m_recording_frame)
+        this->recordRequiredCall(call);
+
+    remapPointer(d3dobj.get(), resource_ptr, call.no);
+}
+
+void D3D9Impl::recordResourceSubresource(const trace::Call& call, int32_t parent_idx,
+                                         int32_t level_idx, int32_t subresource_idx)
+{
+    auto parent_ptr = getResourcePtrFromCall(call, parent_idx);
+    auto subresource_ptr = getResourcePtrFromCall(call, subresource_idx);
+    uint32_t level = call.arg(level_idx).toUInt();
+
+    if (subresource_ptr == 0)
+        return;
+
+    auto& parent = m_active_objects[parent_ptr];
+
+    auto subresource_parent = SubResourceParent{parent, level};
+
+    auto sub_it = m_active_objects.find(subresource_ptr);
+    bool old_subresource =
+        sub_it != m_active_objects.end() &&
+        sub_it->second->m_subresource_parent.parent == subresource_parent.parent &&
+        sub_it->second->m_subresource_parent.level == subresource_parent.level;
+    if (!old_subresource) {
+        if (sub_it != m_active_objects.end()) {
+            m_released_objects.push_back(sub_it->second);
+            m_active_objects.erase(sub_it);
+        }
+        recordResourceCreation(call, subresource_idx, parent->m_calls_removable);
+    }
+
+    auto& subresource = m_active_objects[subresource_ptr];
+    subresource->m_subresource_parent = subresource_parent;
+
+    parent->m_dependencies.push_back(subresource);
+    subresource->m_dependencies.push_back(parent);
+
+    subresource->reference(call, m_recording_frame);
+}
+
+void D3D9Impl::recordResourceInternalCreateOrGet(const trace::Call& call, int32_t resource_idx)
+{
+    auto resource_ptr = getResourcePtrFromCall(call, resource_idx);
+    if (resource_ptr == 0)
+        return;
+
+    auto it = m_active_objects.find(resource_ptr);
+    if (it != m_active_objects.end()) {
+        it->second->reference(call, m_recording_frame);
+    }
+    else {
+        recordResourceCreation(call, resource_idx, false);
+    }
+}
+
+void D3D9Impl::recordResourceRef(const trace::Call& call, int32_t resource_idx)
+{
+    auto resource_ptr = getResourcePtrFromCall(call, resource_idx);
+    if (resource_ptr == 0)
+        return;
+
+    assert(m_active_objects.find(resource_ptr) != m_active_objects.end());
+
+    auto it = m_active_objects.find(resource_ptr);
+    if (it == m_active_objects.end()) {
+        std::cerr << call.no << " " << call.name() << " references unknown object " << std::endl;
+        this->recordRequiredCall(call);
+        return;
+    }
+
+    auto& d3dobj = it->second;
+    d3dobj->reference(call, m_recording_frame);
+}
+
+void D3D9Impl::recordResourceRelease(const trace::Call& call)
+{
+    auto resource_ptr = call.arg(0).toUIntPtr();
+
+    auto it = m_active_objects.find(resource_ptr);
+    if (it == m_active_objects.end()) {
+        std::cerr << call.no << " " << call.name() << " releases unknown object " << std::endl;
+        this->recordRequiredCall(call);
+        return;
+    }
+
+    uint32_t references_left = call.ret->toUInt();
+
+    auto& d3dobj = it->second;
+    d3dobj->release(call, references_left, m_recording_frame);
+
+    if (references_left == 0) {
+        m_released_objects.push_back(d3dobj);
+        m_active_objects.erase(it);
+
+        if (!d3dobj->m_calls_removable) {
+            m_required_calls.insert(trace2call(call));
+        }
+    }
+}
+
+void D3D9Impl::recordResourceUsage(const trace::Call& call, int32_t resource_idx, eCallType type)
+{
+    auto resource_ptr = getResourcePtrFromCall(call, resource_idx);
+    if (resource_ptr == 0)
+        return;
+
+    auto it = m_active_objects.find(resource_ptr);
+    if (it == m_active_objects.end()) {
+        std::cerr << call.no << " " << call.name() << " uses unknown object " << std::endl;
+        this->recordRequiredCall(call);
+        return;
+    }
+
+    auto& d3dobj = it->second;
+    d3dobj->access(call, m_recording_frame, type);
+
+    if (!d3dobj->m_calls_removable && !m_recording_frame)
+        this->recordRequiredCall(call);
+}
+
+void D3D9Impl::recordResourceLock(const trace::Call& call, int32_t resource_idx, int32_t level_idx,
+                                  int32_t face_idx, int32_t mem_map_idx)
+{
+    auto resource_ptr = getResourcePtrFromCall(call, resource_idx);
+
+    /* It's invalid to map different parts of the same level+face,
+     * but different level+face are ok to map simultaneously,
+     * so we have to track what exactly is locked.
+     */
+    uint32_t level = 0;
+    uint32_t face = 0;
+    if (level_idx != -1)
+        level = call.arg(level_idx).toUInt();
+    if (face_idx != -1)
+        face = call.arg(face_idx).toUInt();
+    auto& d3dobj = m_active_objects[resource_ptr];
+
+    uint64_t map = 0;
+
+    auto mem_map_arg = call.arg(mem_map_idx).toArray()->values[0];
+    auto struct_arg = mem_map_arg->toStruct();
+    if (struct_arg) {
+        map = struct_arg->members.back()->toUIntPtr();
+    }
+    else {
+        map = mem_map_arg->toUIntPtr();
+    }
+
+    if (strncmp("IDirect3DIndex", call.name(), strlen("IDirect3DIndex")) == 0 ||
+        strncmp("IDirect3DVertex", call.name(), strlen("IDirect3DVertex")) == 0) {
+        uint32_t flags = call.arg(call.args.size() - 1).toUInt();
+        /* For vertex and index buffers, the entire buffer will be discarded,
+         * so we could just remove all preceding calls writing into the memory.
+         * This should eliminate a LOT of dead weight from the trace.
+         */
+        if (flags & D3DLOCK_DISCARD) {
+            d3dobj->m_calls.erase(std::remove_if(d3dobj->m_calls.begin(), d3dobj->m_calls.end(),
+                                                 [](const D3D9Call& call) {
+                                                     return call.type == eCallType::mem_access;
+                                                 }),
+                                  d3dobj->m_calls.end());
+        }
+    }
+
+    m_mem_mapping.mapObject(map, {d3dobj, level, face});
+
+    recordResourceUsage(call, resource_idx, eCallType::mem_access);
+}
+
+void D3D9Impl::recordResourceUnlock(const trace::Call& call, int32_t resource_idx,
+                                    int32_t level_idx, int32_t face_idx)
+{
+    auto resource_ptr = getResourcePtrFromCall(call, resource_idx);
+    uint32_t level = 0;
+    uint32_t face = 0;
+    if (level_idx != -1)
+        level = call.arg(level_idx).toUInt();
+    if (face_idx != -1)
+        face = call.arg(face_idx).toUInt();
+    auto& d3dobj = m_active_objects[resource_ptr];
+    m_mem_mapping.removeMapping({d3dobj, level, face});
+
+    recordResourceUsage(call, resource_idx, eCallType::mem_access);
+}
+
+void D3D9Impl::recordMemcpy(const trace::Call& call)
+{
+    auto map = call.arg(0).toUIntPtr();
+    auto obj = m_mem_mapping.findObject(map);
+    assert(obj);
+    obj->object->access(call, m_recording_frame, eCallType::mem_access);
+}
+
+void D3D9Impl::recordResourceDep(const trace::Call& call, int32_t resource_src_idx,
+                                 int32_t resource_dst_idx)
+{
+    auto src_ptr = getResourcePtrFromCall(call, resource_src_idx);
+    auto dst_ptr = getResourcePtrFromCall(call, resource_dst_idx);
+
+    auto& src = m_active_objects[src_ptr];
+    auto& dst = m_active_objects[dst_ptr];
+
+    dst->m_dependencies.push_back(src);
+
+    dst->access(call, m_recording_frame);
+}
+
+void D3D9Impl::recordPresent(const trace::Call& call)
+{
+    if (!m_recording_frame)
+        return;
+    recordResourceUsage(call, 0);
+}
+
+void D3D9Impl::remapPointer(D3D9Object* obj, uintptr_t resource_ptr, unsigned callno)
+{
+    /* In recording frame we remove ::Release of old objects for them to be present
+     * during frame looping. However new objects may use the same address as old object,
+     * so we have to change addresses for new objects.
+     */
+    if (m_recording_frame && !obj->m_created_before_recording_frame) {
+        auto it = m_pointer_map.find(resource_ptr);
+        if (it == m_pointer_map.end()) {
+            auto remapped_ptr = m_new_pointers++;
+            m_pointer_map[resource_ptr] = RemapPointerInfo{remapped_ptr, callno};
+        }
+    }
+}
+
+void D3D9Impl::updateCallTable(const std::vector<const char*>& names, ft_callback cb)
+{
+    for (auto& i : names)
+        m_call_table.insert(std::make_pair(i, cb));
+}
+
+void D3D9Impl::recordShaderSetConstant(const trace::Call& call, eShaderStage stage)
+{
+    if (m_currentStateBlock) {
+        m_currentStateBlock->m_calls.push_back(trace2call(call));
+        m_currentStateBlock->m_state_block_has_set_constant = true;
+    }
+    else {
+        /* Constants are unlikely to be preserved across frames,
+         * but could be the majority of calls when targetting
+         * far enough frame.
+         */
+        // m_required_calls.insert(trace2call(call));
+        auto pcall = trace2call(call);
+        auto start_reg = call.arg(1).toUInt();
+        auto count = call.arg(3).toUInt();
+        for (unsigned i = start_reg; i < (start_reg + count); i++) {
+            m_shader_constants[stage][i] = pcall;
+        }
+    }
+}
+
+void D3D9Impl::recordRequiredCall(const trace::Call& call)
+{
+    m_required_calls.insert(trace2call(call));
+}
+
+void D3D9Object::reference(const trace::Call& call, bool recording_frame)
+{
+    m_used_in_recording_frame |= recording_frame;
+    m_explicit_refs++;
+}
+
+void D3D9Object::create(const trace::Call& call, bool recording_frame, bool calls_removable)
+{
+    if (m_created_before_recording_frame && m_used_in_recording_frame) {
+        std::cerr << call.no << " " << call.name()
+                  << " creates object with the same pointer as another object which is not freed "
+                     "in recording frame! "
+                  << std::endl;
+    }
+
+    m_calls_removable = calls_removable;
+    m_created_before_recording_frame = !recording_frame;
+
+    access(call, recording_frame);
+}
+
+void D3D9Object::access(const trace::Call& call, bool recording_frame, eCallType type)
+{
+    if (!recording_frame)
+        m_calls.push_back(D3D9Call(trace2call(call), type));
+    m_used_in_recording_frame |= recording_frame;
+}
+
+void D3D9Object::release(const trace::Call& call, int references_left, bool recording_frame)
+{
+    m_used_in_recording_frame |= recording_frame;
+    m_explicit_refs--;
+
+    if (!recording_frame) {
+        /* We track explicit references to drop matching releases,
+         * the last ::Release isn't counted and "hidden" references are ignored.
+         */
+        if (m_explicit_refs < 0) {
+            m_calls.push_back(trace2call(call));
+        }
+        return;
+    }
+
+    if (m_created_before_recording_frame) {
+        /* Recording frame should not release resources created in the setup. */
+        static const char* args[] = {"col", "wszName"};
+        static const trace::FunctionSig sig = {10, "D3DPERF_SetMarker", 2, args};
+        auto new_call = new trace::Call(&sig, 0, call.thread_id);
+        new_call->args[0].value = new trace::UInt(0);
+        char* str = new char[strlen(call.sig->name) + 1];
+        strcpy(str, call.sig->name);
+        new_call->args[1].value = new trace::String(str);
+        new_call->no = call.no;
+
+        m_overriden_calls.emplace_back(new_call);
+    }
+}
+
+void D3D9Object::addToRequiredCalls(CallSet& required_calls)
+{
+    if (m_emitted)
+        return;
+    m_emitted = true;
+
+    for (auto& d3d9call : m_calls)
+        required_calls.insert(d3d9call.call);
+    for (auto& dep : m_dependencies)
+        dep->addToRequiredCalls(required_calls);
+}
+
+} // namespace frametrim

--- a/frametrim/ft_d3d9.hpp
+++ b/frametrim/ft_d3d9.hpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2024 Igalia S.L.
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "ft_frametrimmer.hpp"
+#include <array>
+#include <optional>
+
+namespace frametrim {
+
+template <typename T>
+struct MappedObj {
+    T object;
+    uint32_t level;
+    uint32_t face;
+
+    bool operator==(const MappedObj<T>& rhs) const
+    {
+        return (object == rhs.object) && (level == rhs.level) && (face == rhs.face);
+    }
+};
+
+/* Mapped addresses are continious chunks of memory and we expect
+ * all memcpy's to access existing mapped memory. With that, we could
+ * just store the start address of a mapping, and map given address
+ * back to object by finding the closest less-equal mapping.
+ */
+template <typename T>
+class MemoryMapper {
+  private:
+    struct MappingInfo {
+        MappedObj<T> obj;
+        uint32_t refs;
+    };
+    std::map<uintptr_t, MappingInfo> mappings;
+
+  public:
+    void mapObject(uintptr_t start, const MappedObj<T>& obj)
+    {
+        auto it = mappings.find(start);
+        if (it != mappings.end())
+            it->second.refs++;
+        else
+            mappings[start] = {obj, 1};
+    }
+
+    MappedObj<T>* findObject(uintptr_t address)
+    {
+        auto it = mappings.upper_bound(address);
+        if (it == mappings.begin()) {
+            return nullptr;
+        }
+        --it;
+        return &it->second.obj;
+    }
+
+    bool removeMapping(const MappedObj<T>& obj)
+    {
+        for (auto it = mappings.rbegin(); it != mappings.rend(); ++it) {
+            if (it->second.obj == obj) {
+                if (--it->second.refs == 0)
+                    mappings.erase(std::next(it).base());
+                return true;
+            }
+        }
+
+        return false;
+    }
+};
+
+struct ArrayHasher {
+    std::size_t operator()(const std::array<uint32_t, 4>& a) const
+    {
+        std::size_t h = 0;
+
+        for (auto e : a) {
+            h ^= std::hash<int>{}(e) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        }
+        return h;
+    }
+};
+
+enum eShaderStage {
+    ss_vertex = 0,
+    ss_pixel = 1,
+};
+
+struct StateCall {
+    PTraceCall call;
+    uintptr_t resource_used;
+};
+
+using StateMap = std::unordered_map<std::array<uint32_t, 4>, StateCall, ArrayHasher>;
+
+class D3D9Object;
+struct SubResourceParent {
+    std::shared_ptr<D3D9Object> parent;
+    uint32_t level;
+};
+
+enum class eCallType {
+    unknown,
+    mem_access,
+};
+
+struct D3D9Call {
+    eCallType type;
+    PTraceCall call;
+
+    D3D9Call(PTraceCall call, eCallType type = eCallType::unknown) : type(type), call(call)
+    {
+    }
+};
+
+class D3D9Object {
+  public:
+    void reference(const trace::Call& call, bool recording_frame);
+    void create(const trace::Call& call, bool recording_frame, bool calls_removable);
+    void access(const trace::Call& call, bool recording_frame, eCallType type = eCallType::unknown);
+    void release(const trace::Call& call, int references_left, bool recording_frame);
+
+    void addToRequiredCalls(CallSet& required_calls);
+
+    int32_t m_explicit_refs;
+
+    /* While we track most of created resource, we don't track
+     * direc3d object or devices, it's much easier to never remove them.
+     */
+    bool m_calls_removable{false};
+    /* All calls that use this object. */
+    std::vector<D3D9Call> m_calls;
+    /* These calls will replace the corresponding ones in rendering frame. */
+    std::vector<trace::Call*> m_overriden_calls;
+
+    bool m_used_in_recording_frame{false};
+    bool m_created_before_recording_frame{false};
+    uintptr_t m_new_pointer;
+
+    /* Subresources may be created from a parent resource, or
+     * one resource could be copied into another. In such cases
+     * both objects would have a dependency on each other and
+     * one won't be eliminated without the other.
+     */
+    std::vector<std::shared_ptr<D3D9Object>> m_dependencies;
+    SubResourceParent m_subresource_parent;
+    /* Break circular dependencies. */
+    bool m_emitted;
+
+    /* Captured state of IDirect3DStateBlock9. */
+    StateMap m_bundleState;
+    bool m_state_block_has_set_constant{false};
+};
+
+struct RemapPointerInfo {
+    uintptr_t ptr;
+    unsigned first_call;
+};
+
+class D3D9Impl : public FrameTrimmer {
+  public:
+    D3D9Impl(bool keep_all_states, bool swaps_to_finish);
+
+    void switch_thread(int new_thread) override;
+    void modify_last_frame_call(trace::Call& call) override;
+
+  protected:
+    void emitState() override;
+    void finalize() override;
+    ft_callback findCallback(const char* name) override;
+    bool skipDeleteObj(const trace::Call& call) override;
+
+  private:
+    void recordStateCall(const trace::Call& call, uint32_t params_to_capture, int32_t resource_idx);
+
+    void registerCalls();
+
+    void recordRequiredCall(const trace::Call& call);
+
+    void updateCallTable(const std::vector<const char*>& names, ft_callback cb);
+
+    void recordShaderSetConstant(const trace::Call& call, eShaderStage stage);
+
+    void recordBeginStateBlock(const trace::Call& call);
+    void recordEndStateBlock(const trace::Call& call);
+    void recordStateBlockApply(const trace::Call& call);
+    void recordStateBlockCapture(const trace::Call& call);
+
+    void recordReset(const trace::Call& call);
+
+    void recordResourceCreation(const trace::Call& call, int32_t resource_idx, bool removable);
+    void recordResourceSubresource(const trace::Call& call, int32_t parent_idx, int32_t level_idx,
+                                   int32_t subresource_idx);
+    void recordResourceInternalCreateOrGet(const trace::Call& call, int32_t resource_idx);
+    void recordResourceRef(const trace::Call& call, int32_t resource_idx);
+    void recordResourceRelease(const trace::Call& call);
+    void recordResourceUsage(const trace::Call& call, int32_t resource_idx,
+                             eCallType type = eCallType::unknown);
+    void recordResourceLock(const trace::Call& call, int32_t resource_idx, int32_t level_idx,
+                            int32_t face_idx, int32_t mem_map_idx);
+    void recordResourceUnlock(const trace::Call& call, int32_t resource_idx, int32_t level_idx,
+                              int32_t face_idx);
+
+    void recordResourceDep(const trace::Call& call, int32_t resource_src_idx,
+                           int32_t resource_dst_idx);
+
+    void recordMemcpy(const trace::Call& call);
+    void recordPresent(const trace::Call& call);
+
+    void remapPointer(D3D9Object* obj, uintptr_t resource_ptr, unsigned callno);
+
+    std::unordered_map<std::string, ft_callback> m_call_table;
+
+    MemoryMapper<std::shared_ptr<D3D9Object>> m_mem_mapping;
+
+    StateMap m_state_calls;
+    std::array<std::array<PTraceCall, 256>, 2> m_shader_constants;
+
+    std::unordered_map<uintptr_t, std::shared_ptr<D3D9Object>> m_active_objects;
+    std::vector<std::shared_ptr<D3D9Object>> m_released_objects;
+
+    std::unique_ptr<D3D9Object> m_currentStateBlock{nullptr};
+
+    uintptr_t m_new_pointers{1};
+    std::unordered_map<uintptr_t, RemapPointerInfo> m_pointer_map;
+};
+} // namespace frametrim

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -159,6 +159,12 @@ FrameTrimmer::get_swap_to_finish_calls()
     return m_swap_calls;
 }
 
+std::unordered_map<unsigned, std::unique_ptr<trace::Call>>&
+FrameTrimmer::get_overriden_calls()
+{
+    return m_overriden_calls;
+}
+
 std::vector<unsigned>
 FrameTrimmer::getSortedCallIds()
 {

--- a/frametrim/ft_frametrimmer.cpp
+++ b/frametrim/ft_frametrimmer.cpp
@@ -27,6 +27,9 @@
 
 #include "ft_frametrimmer.hpp"
 #include "ft_opengl.hpp"
+#ifdef HAVE_D3D9
+#include "ft_d3d9.hpp"
+#endif
 
 #include <algorithm>
 
@@ -44,7 +47,7 @@ FrameTrimmer::FrameTrimmer(bool keep_all_states, bool swap_to_finish):
 bool
 FrameTrimmer::isSupported(trace::API api)
 {
-    return (api == trace::API_GL || api == trace::API_EGL);
+    return (api == trace::API_GL || api == trace::API_EGL || api == trace::API_DX);
 }
 
 std::shared_ptr<FrameTrimmer>
@@ -53,6 +56,11 @@ FrameTrimmer::create(trace::API api, bool keep_all_states, bool swap_to_finish)
     if (api == trace::API_GL || api == trace::API_EGL) {
         std::cerr << "Creating OpenGL trimmer" << std::endl;
         return std::make_shared<OpenGLImpl>(keep_all_states, swap_to_finish);
+#ifdef HAVE_D3D9
+    } else if (api == trace::API_DX) {
+        std::cerr << "Creating D3D9 trimmer" << std::endl;
+        return std::make_shared<D3D9Impl>(keep_all_states, swap_to_finish);
+#endif
     } else {
         assert(0);
     }

--- a/frametrim/ft_frametrimmer.hpp
+++ b/frametrim/ft_frametrimmer.hpp
@@ -67,6 +67,7 @@ public:
 
     std::unordered_set<unsigned> get_skip_loop_calls();
     std::unordered_set<unsigned> get_swap_to_finish_calls();
+    std::unordered_map<unsigned, std::unique_ptr<trace::Call>>& get_overriden_calls();
 
     std::vector<unsigned> getSortedCallIds();
     std::unordered_set<unsigned> getUniqueCallIds();
@@ -93,6 +94,7 @@ protected:
     std::set<std::string> m_unhandled_calls;
     std::unordered_set<unsigned> m_swap_calls;
     std::unordered_set<unsigned> m_skip_loop_calls;
+    std::unordered_map<unsigned, std::unique_ptr<trace::Call>> m_overriden_calls;
 };
 
 }

--- a/frametrim/ft_frametrimmer.hpp
+++ b/frametrim/ft_frametrimmer.hpp
@@ -74,6 +74,8 @@ public:
 
     virtual void switch_thread(int new_thread) {}
 
+    virtual void modify_last_frame_call(trace::Call& call) {}
+
 protected:
     virtual void emitState() {};
     virtual void finalize() {};

--- a/frametrim/ft_main.cpp
+++ b/frametrim/ft_main.cpp
@@ -269,6 +269,7 @@ static int trim_to_frame(const char *filename,
         }
 
         if (skip_loop_calls.find(call->no) == skip_loop_calls.end()) {
+            trimmer->modify_last_frame_call(*call.get());
             call->no = call_id++;
             writer.writeCall(call.get());
         }

--- a/frametrim/ft_main.cpp
+++ b/frametrim/ft_main.cpp
@@ -195,6 +195,7 @@ static int trim_to_frame(const char *filename,
     trimmer->end_last_frame();
     auto skip_loop_calls = trimmer->get_skip_loop_calls();
     auto swap_calls = trimmer->get_swap_to_finish_calls();
+    auto& overriden_calls = trimmer->get_overriden_calls();
 
     std::cerr << "\nDone scanning frames\n";
 
@@ -233,6 +234,11 @@ static int trim_to_frame(const char *filename,
                 call.reset(new trace::Call(&glFinishSig, 0, call->thread_id));
             }
 
+            auto override_call = overriden_calls.find(call->no);
+            if (override_call != overriden_calls.end()) {
+                call = std::move(override_call->second);
+            }
+
             call->no = call_id++;
             writer.writeCall(call.get());
         }
@@ -253,6 +259,11 @@ static int trim_to_frame(const char *filename,
 
         if (!call)
             break;
+
+        auto override_call = overriden_calls.find(call->no);
+        if (override_call != overriden_calls.end()) {
+            call = std::move(override_call->second);
+        }
 
         if (skip_loop_calls.find(call->no) == skip_loop_calls.end()) {
             call->no = call_id++;

--- a/frametrim/ft_main.cpp
+++ b/frametrim/ft_main.cpp
@@ -153,6 +153,7 @@ static int trim_to_frame(const char *filename,
 
     unsigned calls_in_this_frame = 0;
     uint32_t last_frame_start = 0;
+    uint32_t last_frame_end = 0;
 
     while (call) {
         /* There's no use doing any work past the last call and frame
@@ -192,6 +193,8 @@ static int trim_to_frame(const char *filename,
         ++calls_in_this_frame;
     }
 
+    last_frame_end = call->no - 1;
+
     trimmer->end_last_frame();
     auto skip_loop_calls = trimmer->get_skip_loop_calls();
     auto swap_calls = trimmer->get_swap_to_finish_calls();
@@ -219,10 +222,10 @@ static int trim_to_frame(const char *filename,
     const trace::FunctionSig glFinishSig = {0, "glFinish", 0, NULL};
 
     while (1) {
-        while (call && call_ids.find(call->no) == call_ids.end())
+        while (call && call_ids.find(call->no) == call_ids.end() && call->no < last_frame_end)
             call.reset(p.parse_call());
 
-        if (!call)
+        if (!call || call->no > last_frame_end)
             break;
 
         // Write setup calls in last frame  before last frame starts
@@ -254,10 +257,10 @@ static int trim_to_frame(const char *filename,
     while (1) {
         while (call &&
                (call->no < last_frame_start ||
-                call_ids.find(call->no) == call_ids.end()))
+                call_ids.find(call->no) == call_ids.end()) && call->no < last_frame_end)
             call.reset(p.parse_call());
 
-        if (!call)
+        if (!call || call->no > last_frame_end)
             break;
 
         auto override_call = overriden_calls.find(call->no);

--- a/frametrim/ft_tracecall.cpp
+++ b/frametrim/ft_tracecall.cpp
@@ -69,15 +69,6 @@ TraceCall::TraceCall(const trace::Call& call, const std::string& name):
     m_trace_call_no(call.no),
     m_name(name)
 {
-    std::stringstream s;
-    s << call.name();
-
-    trace::StreamVisitor sv(s);
-    for(auto&& a: call.args) {
-        s << "_";  a.value->visit(sv);
-    }
-
-    m_name_with_params = s.str();
 }
 
 TraceCall::TraceCall(const trace::Call& call, unsigned nsel):

--- a/frametrim/ft_tracecall.hpp
+++ b/frametrim/ft_tracecall.hpp
@@ -58,14 +58,12 @@ public:
 
     unsigned callNo() const { return m_trace_call_no;};
     const std::string& name() const { return m_name;}
-    const std::string& nameWithParams() const { return m_name_with_params;}
 private:
 
     static std::string nameWithParamsel(const trace::Call& call, unsigned nsel);
 
     unsigned m_trace_call_no;
     std::string m_name;
-    std::string m_name_with_params;
 };
 using PTraceCall = TraceCall::Pointer;
 

--- a/lib/trace/trace_parser.cpp
+++ b/lib/trace/trace_parser.cpp
@@ -279,11 +279,11 @@ Parser::parse_function_sig(void) {
                 api = trace::API_GL;
             } else if (n[0] == 'e' && n[1] == 'g' && n[2] == 'l' && n[3] >= 'A' && n[3] <= 'Z') { // egl[A-Z]*
                 api = trace::API_EGL;
-            } else if ((n[0] == 'D' &&
-                        ((n[1] == 'i' && n[2] == 'r' && n[3] == 'e' && n[4] == 'c' && n[5] == 't') || // Direct*
-                         (n[1] == '3' && n[2] == 'D'))) || // D3D*
+            } else if ((n[0] == 'D' && n[1] == 'i' && n[2] == 'r' && n[3] == 'e' && n[4] == 'c' && n[5] == 't') || // Direct*
                        (n[0] == 'C' && n[1] == 'r' && n[2] == 'e' && n[3] == 'a' && n[4] == 't' && n[5] == 'e')) { // Create*
                 api = trace::API_DX;
+            } else if (n[0] == 'D' && n[1] == '3' && n[2] == 'D' && n[3] == '1' && (n[4] == '0' || n[4] == '1')) { // D3D1{0,1}*
+                api = trace::API_DXGI;
             } else {
                 /* TODO */
             }


### PR DESCRIPTION
Limitations, by importance:
- Resource `::Lock`/`::Unlock` should match in the rendering frame,
  otherwise unmatched function would be called several times
  during looping.
- State block doesn't capture shaders constants in setup frames.
- Not all useless memory writes are eliminated, only discards of
  vertex and index buffers, so in some cases the trimmed result
  may have a large size.

Misc:
- keep_all_states option isn't implemented.

Tested on:

| Game | Replay | Loop | Comment |
|--------|--------|--------|--------|
| Dead Space 3 | :white_check_mark: | :white_check_mark: |  takes a bit more space than it could have |
| A Hat in Time | :white_check_mark: | :white_check_mark: |  |
| Resident Evil 6 | :white_check_mark: | :white_check_mark: |  |
| Timeshift | :white_check_mark: | :white_check_mark: | |
| The Last Remnant | :white_check_mark: | :white_check_mark: |  | 
| Call of Duty 4 | :white_check_mark: | :white_check_mark: |  | 
| Call of Duty 2 | :white_check_mark: | :x:  | Mismatch in `::Lock`/`::Unlock` in the rendering frame |
| Far Cry 2 | :white_check_mark: | :white_check_mark: |  | 
| War of The Ring | :white_check_mark: | :white_check_mark: | takes a bit more space than it could have  |
| KoA Reckoning | :white_check_mark: | :white_check_mark: | |
|Super Meat Boy| :white_check_mark: | :white_check_mark: | |
| Guild 2 | :white_check_mark: | :white_check_mark: | |
| C&C 3 Kanes Wrath | :yellow_circle: | :white_check_mark: | minor corruption in some icons due to offscreen render in prev frames |
| Oblivion | :yellow_circle: | :white_check_mark: | part of water is missing due to some offscreen setup |
| Brawlhalla | :white_check_mark: | :white_check_mark: | trace is much larger than expected |
| The Slormancer| :yellow_circle: | :white_check_mark: | some UI is missing due to prev frame offscreen setup |

