### PR TITLE
retrace: Use right API calls when using EXT_disjoint_timer_query

### DIFF
--- a/retrace/metric_backend_opengl.hpp
+++ b/retrace/metric_backend_opengl.hpp
@@ -198,6 +198,10 @@ private:
 
     int64_t getTimeFrequency(void);
 
+    void queryTimestamp(GLuint query);
+
+    int64_t getQueryResult(GLuint query);
+
     void processQueries();
 };
 


### PR DESCRIPTION
Even though the Mesa drivers are aliasing the EXT API calls with the unsuffixed versions, it doesn't work with all drivers (e.g. libmali). Selecting the right call to use depending on the supported extensions makes it work universally.