### PR TITLE
Explicit header: stdint

### DIFF
--- a/frametrim/ft_dependecyobject.hpp
+++ b/frametrim/ft_dependecyobject.hpp
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "ft_tracecall.hpp"
+#include <stdint.h>
 
 namespace frametrim {
 

--- a/retrace/metric_writer.cpp
+++ b/retrace/metric_writer.cpp
@@ -24,6 +24,7 @@
  **************************************************************************/
 
 #include <iostream>
+#include <stdint.h>
 
 #include "metric_writer.hpp"
 


### PR DESCRIPTION
Fix building with GCC-15. It no longer includes it by default.

> apitrace-9.0/retrace/metric_writer.cpp: In static member function
> ‘static void ProfilerQuery::writeMetricEntryCallback(Metric*, int, void*, int, void*)’:
> apitrace-9.0/retrace/metric_writer.cpp:50:70: error: ‘uint64_t’ does not name a type
> 50 |         case CNT_NUM_UINT64: std::cout << "\t" <<
> *(reinterpret_cast<uint64_t*>(data)); break;
> |
> ^~~~~~~~
> apitrace-9.0/retrace/metric_writer.cpp:29:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; 
> this is probably fixable by adding ‘#include <cstdint>’
>   28 | #include "metric_writer.hpp"
>  +++ |+#include <cstdint>
>   29 |

> apitrace-12.0/frametrim/ft_dependecyobject.hpp:31:1:
> note: ‘uint32_t’ is defined in header ‘<cstdint>’; 
> this is probably fixable by adding ‘#include <cstdint>’
>   30 | #include "ft_tracecall.hpp"
>     +++ |+#include <cstdint>