### PR TITLE
retrace: Fix GPU Duration calculation

### DIFF
--- a/retrace/metric_backend_opengl.cpp
+++ b/retrace/metric_backend_opengl.cpp
@@ -372,7 +372,7 @@ void MetricBackend_opengl::processQueries() {
                     if (!metrics[METRIC_GPU_START].profiled[i]) {
                         gpuStart = getQueryResult(query[QUERY_GPU_START]);
                     }
-                    gpuEnd = getQueryResult(query[QUERY_GPU_START]);
+                    gpuEnd = getQueryResult(query[QUERY_GPU_DURATION]);
                     if (gpuEnd < gpuStart && timestamp_bits_precision < 64) {
                         // Correct the roll-over
                         gpuEnd += (UINT64_C(2) << timestamp_bits_precision) - 1;


### PR DESCRIPTION
After the API calls refactoring, we got a typo in GPU duration, which basically made all measurements became zero-valued, since it was subtraction GPU start timestamp with itself.

Fixes: 1937ee8eb5e5ef816481b283ec9850f62132b043

---

Before

```
eglretrace --headless --benchmark --singlethread --loop=5 --pframes "opengl:GPU Duration" /tmp/replayer-db/unvanquished/unvanquished-lowest.trace 
warning: --loop blindly repeats the last frame calls, therefore frames might not necessarily render correctly (https://github.com/apitrace/apitrace/issues/800)
/app/lib/daemon
#       GPU Duration
frame   0
frame   0
frame   0
frame   0
frame   0
frame   0
frame   0
frame   0

Rendered 7 frames in 1.04942 secs, average of 6.67036 fps
```

---

After

```
$ eglretrace --headless --benchmark --singlethread --loop=5 --pframes "opengl:GPU Duration" /tmp/replayer-db/unvanquished/unvanquished-lowest.trace 
warning: --loop blindly repeats the last frame calls, therefore frames might not necessarily render correctly (https://github.com/apitrace/apitrace/issues/800)
/app/lib/daemon
#       GPU Duration
frame   113960
frame   53168350
frame   5863760
frame   6942700
frame   23366440
frame   33863450
frame   33948090
frame   173670

Rendered 7 frames in 1.25231 secs, average of 5.58969 fps
```