### PR TITLE
d3d9retrace: Adjust presentation interval when forcing windowed mode

### DIFF
--- a/retrace/d3d9retrace.py
+++ b/retrace/d3d9retrace.py
@@ -200,6 +200,11 @@ class D3DRetracer(Retracer):
             print(r'    if (retrace::forceWindowed) {')
             print(r'        pPresentationParameters->Windowed = TRUE;')
             print(r'        pPresentationParameters->FullScreen_RefreshRateInHz = 0;')
+            if interface.name.startswith('IDirect3D9'):
+                print(r'        if (pPresentationParameters->PresentationInterval == D3DPRESENT_INTERVAL_TWO')
+                print(r'            || pPresentationParameters->PresentationInterval == D3DPRESENT_INTERVAL_THREE')
+                print(r'            || pPresentationParameters->PresentationInterval == D3DPRESENT_INTERVAL_FOUR)')
+                print(r'            pPresentationParameters->PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT;')
             if method.name == 'CreateDeviceEx':
                 print(r'   pFullscreenDisplayMode = nullptr;')
             if interface.name.startswith('IDirect3D8'):


### PR DESCRIPTION
`D3DPRESENT_INTERVAL_TWO`, `D3DPRESENT_INTERVAL_THREE`, `D3DPRESENT_INTERVAL_FOUR` are not supported in windowed mode. (See https://learn.microsoft.com/en-us/windows/win32/direct3d9/d3dpresent)

So if we force windowed mode, we also need to adjust the presentation interval otherwise the trace will just fail at device creation.