### PR TITLE
fix qt-6.9

### DIFF
--- a/gui/qubjson.cpp
+++ b/gui/qubjson.cpp
@@ -148,7 +148,7 @@ readChar(QDataStream &stream)
     qint8 c;
     stream >> c;
     Q_ASSERT(c >= 0);
-    return QChar(c);
+    return QChar(static_cast<char>(c));
 }
 
 


### PR DESCRIPTION
> gui/qubjson.cpp: In function QString readChar(QDataStream&):
> gui/qubjson.cpp:151:19: error: no matching function for call to QChar::QChar(qint8&)
>  151 |     return QChar(c);

implicit conversions are disabled for QChar::QChar with [qt-6.9](https://doc.qt.io/qt-6.9/qchar.html#QChar-3)