### PR TITLE
trace: reset locked array count when unlock.

### DIFF
--- a/wrappers/gltrace.py
+++ b/wrappers/gltrace.py
@@ -527,6 +527,12 @@ class GlTracer(Tracer):
             print('        _ctx->lockedArrayCount = first + count;')
             print('    }')
 
+        if function.name == 'glUnlockArraysEXT':
+            print('    gltrace::Context *_ctx = gltrace::getContext();')
+            print('    if (_ctx) {')
+            print('        _ctx->lockedArrayCount = 0;')
+            print('    }')
+
         # Warn if user arrays are used with glBegin/glArrayElement/glEnd.
         if function.name == 'glBegin':
             print(r'    gltrace::Context *_ctx = gltrace::getContext();')


### PR DESCRIPTION
This fixes a memory corruption that happens at `_trace_user_arrays` during subsequent draw calls after glUnlockArraysEXT called but the lockedArrayCount is not reset.