### PR TITLE
Re-enable and fix GL window system cleanup

### DIFF
--- a/retrace/glws_egl_xlib.cpp
+++ b/retrace/glws_egl_xlib.cpp
@@ -307,6 +307,7 @@ init(void) {
 void
 cleanup(void) {
     if (eglDisplay != EGL_NO_DISPLAY) {
+        eglMakeCurrent(eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
         eglTerminate(eglDisplay);
     }
 

--- a/retrace/retrace_main.cpp
+++ b/retrace/retrace_main.cpp
@@ -1475,8 +1475,7 @@ int main(int argc, char **argv)
 
     delete snapshotter;
 
-    // XXX: X often hangs on XCloseDisplay
-    //retrace::cleanUp();
+    retrace::cleanUp();
 
 #ifdef _WIN32
     if (mmRes == MMSYSERR_NOERROR) {


### PR DESCRIPTION
We have a number of apitraces that we'd like to use for driver performance work with perfetto or MESA_GPU_TRACES=print_*, but we can't because a lack of cleanup of the window system means that the output gets arbitrarily truncated.

I've now confirmed that my screen gets destroyed on an EGL and a GLX trace from traces-db, with and without waffle.  TBD: d3d.