### PR TITLE
gui: fix invalid `ProgramSorter` comparators

### DIFF
--- a/gui/profiletablemodel.cpp
+++ b/gui/profiletablemodel.cpp
@@ -277,8 +277,10 @@ public:
     {
     }
 
-    bool operator()(const ProfileTableRow &p1, const ProfileTableRow &p2) const
+    bool operator()(const ProfileTableRow &lhs, const ProfileTableRow &rhs) const
     {
+        const ProfileTableRow &p1 = (mSortOrder == Qt::DescendingOrder) ? rhs : lhs;
+        const ProfileTableRow &p2 = (mSortOrder == Qt::DescendingOrder) ? lhs : rhs;
         bool result = true;
 
         switch(mSortColumn) {
@@ -308,11 +310,7 @@ public:
             break;
         }
 
-        if (mSortOrder == Qt::DescendingOrder) {
-            return !result;
-        } else {
-            return result;
-        }
+        return result;
     }
 
 private:


### PR DESCRIPTION
## What I Have Done

Fix an issue in the `ProgramSorter` where the use of taking direct negation violated the requirements of a strict weak ordering when sorting in descending order. The comparison now explicitly changes the order of `p1` and `p2` instead to restore correct comparator behavior and prevent undefined behavior during sorting.

In terms of the algorithm's contract, the comparator used by `std::sort` must induce a strict weak ordering. In particular:

- For all `a`, `comp(a, a) == false`.
- If `comp(a, b) == true` then `comp(b, a) == false`.

Directly taking negation violated these rules when two sorted keys were equal and sorting in descending order. Current fix ensures compliance with the standard and improves stability.

References:

- [C++ reference, C++ named requirements: Compare](https://en.cppreference.com/cpp/named_req/Compare)


## Real World Bug & Bug Reproduce Steps

I actually write a PoC that can let `qapitrace` Segmentation Fault, by profiling the trace of a manually crafted GL app.

- Environment: Linux
  - Any distros should be fine, I was on NixOS 25.11.
- Steps
  - Compile the manually crafted GL app [manyprogs.c](https://github.com/user-attachments/files/27125069/manyprogs.c) using `cc manyprogs.c -o manyprogs -lGLEW -lglut -lGL`.
  - Open `qapitrace` and record a trace of the app.
  - Open `Trace > Profile`, uncheck `CPU times`, and press `OK`.
  - Because we uncheck `CPU times`, so all cells in `Avg CPU Time` column should be equal (to 0). Click on that column first should sort it in ascending; click again to make it sort in descending.
  - `qapitrace` should crash now.

The reason why it causes Segmentation Fault is that the `std::sort` implementation in `libstdc++` drops some boundary check on the hot loop for speed; if the comparator violates Strict Weak Ordering, there is a **Out-Of-Bound** read/write in the current `std::sort` implementation, which causes memory corruption and the later crash. 

The manually crafted GL app is just used to create 17 rows (17 is a threshold for `libstdc++`'s `std::sort` to trigger the potential OOB path). The most important pattern to trigger this crash is the "sorting 17 equal sort-keys in descending", which I used `Avg CPU Time` in the PoC specifically.